### PR TITLE
Materials: better uniform management

### DIFF
--- a/src/vrm/material/Unlit.ts
+++ b/src/vrm/material/Unlit.ts
@@ -27,13 +27,15 @@ export class Unlit extends THREE.ShaderMaterial {
     parameters.morphTargets = parameters.morphTargets || false;
     parameters.morphNormals = parameters.morphNormals || false;
 
-    // == set shader-related parameters ========================================
-    parameters.uniforms = {
-      // == VRM variables (don't worry, I'll set actual value later) ===========
-      cutoff: { type: 'f' },
-      map: { type: 't' },
-      mainTex_ST: { type: 'v4', value: new THREE.Vector4() },
-    };
+    // == uniforms =============================================================
+    parameters.uniforms = THREE.UniformsUtils.merge([
+      THREE.UniformsLib.common, // map
+      THREE.UniformsLib.fog,
+      {
+        cutoff: { value: 0.5 },
+        mainTex_ST: { value: new THREE.Vector4(0.0, 0.0, 1.0, 1.0) },
+      },
+    ]);
 
     // == finally compile the shader program ===================================
     this.setValues(parameters);
@@ -100,6 +102,9 @@ export class Unlit extends THREE.ShaderMaterial {
 
     this.vertexShader = require('./shaders/unlit.vert');
     this.fragmentShader = require('./shaders/unlit.frag');
+
+    // == set needsUpdate flag =================================================
+    this.needsUpdate = true;
   }
 }
 

--- a/src/vrm/material/shaders/mtoon.vert
+++ b/src/vrm/material/shaders/mtoon.vert
@@ -1,9 +1,5 @@
 // #define PHONG
 
-#define OUTLINEWIDTHMODE_NONE 0
-#define OUTLINEWIDTHMODE_WORLDCOORDINATES 1
-#define OUTLINEWIDTHMODE_SCREENCOORDINATES 2
-
 varying vec3 vViewPosition;
 
 #ifndef FLAT_SHADED
@@ -35,7 +31,6 @@ varying vec3 vViewPosition;
 
 uniform float outlineWidth;
 uniform float outlineScaledMaxDistance;
-uniform int outlineWidthMode;
 
 void main() {
 
@@ -69,21 +64,25 @@ void main() {
   vViewPosition = - mvPosition.xyz;
 
   float outlineTex = 1.0;
-  #if defined( OUTLINE ) && defined( USE_OUTLINEWIDTHTEXTURE )
-    outlineTex = texture2D( outlineWidthTexture, vUv ).r;
-  #endif
 
   #ifdef OUTLINE
-    if ( outlineWidthMode == OUTLINEWIDTHMODE_WORLDCOORDINATES ) {
+    #ifdef USE_OUTLINEWIDTHTEXTURE
+      outlineTex = texture2D( outlineWidthTexture, vUv ).r;
+    #endif
+
+    #ifdef OUTLINE_WIDTH_WORLD
       vec3 outlineOffset = 0.01 * outlineWidth * outlineTex * normalize( objectNormal );
       gl_Position += projectionMatrix * modelViewMatrix * vec4( outlineOffset, 0.0 );
-    } else if ( outlineWidthMode == OUTLINEWIDTHMODE_SCREENCOORDINATES ) {
+    #endif
+
+    #ifdef OUTLINE_WIDTH_SCREEN
       vec3 clipNormal = ( projectionMatrix * modelViewMatrix * vec4( normalize( objectNormal ), 0.0 ) ).xyz;
       vec2 projectedNormal = normalize( clipNormal.xy );
       projectedNormal *= min( gl_Position.w, outlineScaledMaxDistance );
       projectedNormal.x *= projectionMatrix[ 0 ].x / projectionMatrix[ 1 ].y;
       gl_Position.xy += 0.01 * outlineWidth * projectedNormal.xy;
-    }
+    #endif
+
     gl_Position.z += 1E-6 * gl_Position.w; // anti-artifact magic
   #endif
 


### PR DESCRIPTION
will resolve #9 

これまで、自前でlights関連のuniformをMToonにアサインしていましたが、
`UniformsUtils` を使うとより簡単にできる事がわかったので、これを使う形へと変更しました。

また、uniformとして渡していた `debugMode` 、 `outlineWidthMode` 、 `outlineColorMode` を
プリプロセッサでの管理に変更しました。