### PR TITLE
editorconfig on examples

### DIFF
--- a/examples/html/.editorconfig
+++ b/examples/html/.editorconfig
@@ -1,0 +1,2 @@
+[*]
+indent_style = tab


### PR DESCRIPTION
`/examples` にsoft tabを入れるミスを頻発していたので、 `.editorconfig` を `/examples` に追加しました。