### PR TITLE
We can use THREE.Math.DEG2RAD instead of our own one

### DIFF
--- a/src/vrm/lookat/CurveMapper.ts
+++ b/src/vrm/lookat/CurveMapper.ts
@@ -1,7 +1,5 @@
 import { VRMSchema } from '../types';
 
-export const DEG2RAD = Math.PI / 180.0;
-
 const hermiteSpline = (y0: number, y1: number, t0: number, t1: number, x: number): number => {
   const xc = x * x * x;
   const xs = x * x;

--- a/src/vrm/lookat/VRMLookAtBlendShapeApplyer.ts
+++ b/src/vrm/lookat/VRMLookAtBlendShapeApplyer.ts
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 import { VRMBlendShapeProxy } from '../blendshape';
 import { VRMSchema } from '../types';
-import { CurveMapper, DEG2RAD } from './CurveMapper';
+import { CurveMapper } from './CurveMapper';
 import { VRMLookAtApplyer } from './VRMLookAtApplyer';
 
 export class VRMLookAtBlendShapeApplyer extends VRMLookAtApplyer {
@@ -48,7 +48,7 @@ export class VRMLookAtBlendShapeApplyer extends VRMLookAtApplyer {
 
 function deg2rad(map: VRMSchema.FirstPersonDegreeMap): VRMSchema.FirstPersonDegreeMap {
   return {
-    xRange: typeof map.xRange === 'number' ? DEG2RAD * map.xRange : undefined,
+    xRange: typeof map.xRange === 'number' ? THREE.Math.DEG2RAD * map.xRange : undefined,
     yRange: map.yRange, // yRange means weight not radian
     curve: map.curve,
   };

--- a/src/vrm/lookat/VRMLookAtBoneApplyer.ts
+++ b/src/vrm/lookat/VRMLookAtBoneApplyer.ts
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 import { VRMHumanoid } from '../humanoid';
 import { GLTFNode, VRMSchema } from '../types';
-import { CurveMapper, DEG2RAD } from './CurveMapper';
+import { CurveMapper } from './CurveMapper';
 import { VRMLookAtApplyer } from './VRMLookAtApplyer';
 
 export class VRMLookAtBoneApplyer extends VRMLookAtApplyer {
@@ -70,8 +70,8 @@ export class VRMLookAtBoneApplyer extends VRMLookAtApplyer {
 
 function deg2rad(map: VRMSchema.FirstPersonDegreeMap): VRMSchema.FirstPersonDegreeMap {
   return {
-    xRange: typeof map.xRange === 'number' ? DEG2RAD * map.xRange : undefined,
-    yRange: typeof map.yRange === 'number' ? DEG2RAD * map.yRange : undefined,
+    xRange: typeof map.xRange === 'number' ? THREE.Math.DEG2RAD * map.xRange : undefined,
+    yRange: typeof map.yRange === 'number' ? THREE.Math.DEG2RAD * map.yRange : undefined,
     curve: map.curve,
   };
 }


### PR DESCRIPTION
これまで、 `DEG2RAD` が自前で定義されていたようですが、これは `THREE.Math.DEG2RAD` を使えば十分ではないかと思います。