### PR TITLE
We don't have to export IDENTITY_MATRIX4

### DIFF
--- a/src/vrm/springbone/VRMSpringBone.ts
+++ b/src/vrm/springbone/VRMSpringBone.ts
@@ -5,7 +5,7 @@ import { getWorldQuaternionLite } from '../utils/math';
 // https://github.com/dwango/UniVRM/blob/master/Scripts/SpringBone/VRMSpringBone.cs
 
 export const GIZMO_RENDER_ORDER = 10000;
-export const IDENTITY_MATRIX4 = Object.freeze(new THREE.Matrix4());
+const IDENTITY_MATRIX4 = Object.freeze(new THREE.Matrix4());
 const IDENTITY_QUATERNION = Object.freeze(new THREE.Quaternion());
 
 // 計算中の一時保存用変数（一度インスタンスを作ったらあとは使い回す）


### PR DESCRIPTION
`IDENTITY_MATRIX4` は、本ライブラリのどこでも使われてそうにないし、簡単に作れるので、特にexportされていなくても良いと思います。