### PR TITLE
tidy up importers

### DIFF
--- a/src/vrm/VRM.ts
+++ b/src/vrm/VRM.ts
@@ -83,6 +83,11 @@ export class VRM {
    * You might want to use [[VRMLookAtHead.setTarget]] to control the eye direction of your VRMs.
    */
   public readonly lookAt?: VRMLookAtHead;
+
+  /**
+   * Contains materials of the VRM.
+   * `updateVRMMaterials` method of these materials will be called via its [[VRM.update]] method.
+   */
   public readonly materials?: THREE.Material[];
 
   /**

--- a/src/vrm/VRMImporter.ts
+++ b/src/vrm/VRMImporter.ts
@@ -68,24 +68,17 @@ export class VRMImporter {
 
     reduceBones(scene);
 
-    const materials = await this._materialImporter.convertGLTFMaterials(gltf);
+    const materials = (await this._materialImporter.convertGLTFMaterials(gltf)) || undefined;
 
-    const humanoid = vrmExt.humanoid
-      ? (await this._humanoidImporter.import(gltf, vrmExt.humanoid)) || undefined
-      : undefined;
+    const humanoid = (await this._humanoidImporter.import(gltf)) || undefined;
 
-    const firstPerson =
-      vrmExt.firstPerson && humanoid
-        ? (await this._firstPersonImporter.import(gltf, humanoid, vrmExt.firstPerson)) || undefined
-        : undefined;
+    const firstPerson = humanoid ? (await this._firstPersonImporter.import(gltf, humanoid)) || undefined : undefined;
 
-    const blendShapeProxy = vrmExt.blendShapeMaster
-      ? (await this._blendShapeImporter.import(gltf, vrmExt.blendShapeMaster)) || undefined
-      : undefined;
+    const blendShapeProxy = (await this._blendShapeImporter.import(gltf)) || undefined;
 
     const lookAt =
-      vrmExt.firstPerson && blendShapeProxy && humanoid
-        ? await this._lookAtImporter.import(vrmExt.firstPerson, blendShapeProxy, humanoid)
+      blendShapeProxy && humanoid
+        ? (await this._lookAtImporter.import(gltf, blendShapeProxy, humanoid)) || undefined
         : undefined;
 
     const springBoneManager = (await this._springBoneImporter.import(gltf)) || undefined;

--- a/src/vrm/blendshape/VRMBlendShapeImporter.ts
+++ b/src/vrm/blendshape/VRMBlendShapeImporter.ts
@@ -12,9 +12,18 @@ export class VRMBlendShapeImporter {
    * Import a [[VRMBlendShape]] from a VRM.
    *
    * @param gltf A parsed result of GLTF taken from GLTFLoader
-   * @param schemaBlendShape A raw `blendShapeMaster` field taken from the VRM extension of the GLTF
    */
-  public async import(gltf: THREE.GLTF, schemaBlendShape: VRMSchema.BlendShape): Promise<VRMBlendShapeProxy | null> {
+  public async import(gltf: THREE.GLTF): Promise<VRMBlendShapeProxy | null> {
+    const vrmExt: VRMSchema.VRM | undefined = gltf.parser.json.extensions && gltf.parser.json.extensions.VRM;
+    if (!vrmExt) {
+      return null;
+    }
+
+    const schemaBlendShape: VRMSchema.BlendShape | undefined = vrmExt.blendShapeMaster;
+    if (!schemaBlendShape) {
+      return null;
+    }
+
     const blendShape = new VRMBlendShapeProxy();
 
     const blendShapeGroups: VRMSchema.BlendShapeGroup[] | undefined = schemaBlendShape.blendShapeGroups;

--- a/src/vrm/debug/VRMImporterDebug.ts
+++ b/src/vrm/debug/VRMImporterDebug.ts
@@ -37,22 +37,17 @@ export class VRMImporterDebug extends VRMImporter {
 
     reduceBones(scene);
 
-    const materials = await this._materialImporter.convertGLTFMaterials(gltf);
+    const materials = (await this._materialImporter.convertGLTFMaterials(gltf)) || undefined;
 
-    const humanoid = (await this._humanoidImporter.import(gltf, vrmExt.humanoid)) || undefined;
+    const humanoid = (await this._humanoidImporter.import(gltf)) || undefined;
 
-    const firstPerson =
-      vrmExt.firstPerson && humanoid
-        ? (await this._firstPersonImporter.import(gltf, humanoid, vrmExt.firstPerson)) || undefined
-        : undefined;
+    const firstPerson = humanoid ? (await this._firstPersonImporter.import(gltf, humanoid)) || undefined : undefined;
 
-    const blendShapeProxy = vrmExt.blendShapeMaster
-      ? (await this._blendShapeImporter.import(gltf, vrmExt.blendShapeMaster)) || undefined
-      : undefined;
+    const blendShapeProxy = (await this._blendShapeImporter.import(gltf)) || undefined;
 
     const lookAt =
       blendShapeProxy && humanoid
-        ? await this._lookAtImporter.import(vrmExt.firstPerson, blendShapeProxy, humanoid)
+        ? (await this._lookAtImporter.import(gltf, blendShapeProxy, humanoid)) || undefined
         : undefined;
     if ((lookAt as any).setupHelper) {
       (lookAt as VRMLookAtHeadDebug).setupHelper(scene, debugOptions);

--- a/src/vrm/debug/VRMLookAtImporterDebug.ts
+++ b/src/vrm/debug/VRMLookAtImporterDebug.ts
@@ -1,3 +1,4 @@
+import * as THREE from 'three';
 import { VRMBlendShapeProxy } from '../blendshape';
 import { VRMHumanoid } from '../humanoid';
 import { VRMLookAtHead } from '../lookat/VRMLookAtHead';
@@ -6,12 +7,18 @@ import { VRMSchema } from '../types';
 import { VRMLookAtHeadDebug } from './VRMLookAtHeadDebug';
 
 export class VRMLookAtImporterDebug extends VRMLookAtImporter {
-  public import(
-    firstPerson: VRMSchema.FirstPerson,
-    blendShapeProxy: VRMBlendShapeProxy,
-    humanoid: VRMHumanoid,
-  ): VRMLookAtHead {
-    const applyer = this._importApplyer(firstPerson, blendShapeProxy, humanoid);
+  public import(gltf: THREE.GLTF, blendShapeProxy: VRMBlendShapeProxy, humanoid: VRMHumanoid): VRMLookAtHead | null {
+    const vrmExt: VRMSchema.VRM | undefined = gltf.parser.json.extensions && gltf.parser.json.extensions.VRM;
+    if (!vrmExt) {
+      return null;
+    }
+
+    const schemaFirstPerson: VRMSchema.FirstPerson | undefined = vrmExt.firstPerson;
+    if (!schemaFirstPerson) {
+      return null;
+    }
+
+    const applyer = this._importApplyer(schemaFirstPerson, blendShapeProxy, humanoid);
     return new VRMLookAtHeadDebug(humanoid, applyer || undefined);
   }
 }

--- a/src/vrm/firstperson/VRMFirstPersonImporter.ts
+++ b/src/vrm/firstperson/VRMFirstPersonImporter.ts
@@ -12,13 +12,18 @@ export class VRMFirstPersonImporter {
    *
    * @param gltf A parsed result of GLTF taken from GLTFLoader
    * @param humanoid A [[VRMHumanoid]] instance that represents the VRM
-   * @param schemaFirstPerson A raw `firstPerson` field taken from the VRM extension of the GLTF
    */
-  public async import(
-    gltf: THREE.GLTF,
-    humanoid: VRMHumanoid,
-    schemaFirstPerson: VRMSchema.FirstPerson,
-  ): Promise<VRMFirstPerson | null> {
+  public async import(gltf: THREE.GLTF, humanoid: VRMHumanoid): Promise<VRMFirstPerson | null> {
+    const vrmExt: VRMSchema.VRM | undefined = gltf.parser.json.extensions && gltf.parser.json.extensions.VRM;
+    if (!vrmExt) {
+      return null;
+    }
+
+    const schemaFirstPerson: VRMSchema.FirstPerson | undefined = vrmExt.firstPerson;
+    if (!schemaFirstPerson) {
+      return null;
+    }
+
     const firstPersonBoneIndex = schemaFirstPerson.firstPersonBone;
 
     let firstPersonBone: GLTFNode | null;

--- a/src/vrm/humanoid/VRMHumanoidImporter.ts
+++ b/src/vrm/humanoid/VRMHumanoidImporter.ts
@@ -13,9 +13,18 @@ export class VRMHumanoidImporter {
    * Import a [[VRMHumanoid]] from a VRM.
    *
    * @param gltf A parsed result of GLTF taken from GLTFLoader
-   * @param schemaHumanoid A raw `humanoid` field taken from the VRM extension of the GLTF
    */
-  public async import(gltf: THREE.GLTF, schemaHumanoid: VRMSchema.Humanoid): Promise<VRMHumanoid | null> {
+  public async import(gltf: THREE.GLTF): Promise<VRMHumanoid | null> {
+    const vrmExt: VRMSchema.VRM | undefined = gltf.parser.json.extensions && gltf.parser.json.extensions.VRM;
+    if (!vrmExt) {
+      return null;
+    }
+
+    const schemaHumanoid: VRMSchema.Humanoid | undefined = vrmExt.humanoid;
+    if (!schemaHumanoid) {
+      return null;
+    }
+
     const humanBoneArray: VRMHumanBoneArray = [];
     if (schemaHumanoid.humanBones) {
       await Promise.all(

--- a/src/vrm/lookat/VRMLookAtImporter.ts
+++ b/src/vrm/lookat/VRMLookAtImporter.ts
@@ -1,3 +1,4 @@
+import * as THREE from 'three';
 import { VRMBlendShapeProxy } from '../blendshape';
 import { VRMHumanoid } from '../humanoid';
 import { VRMSchema } from '../types';
@@ -13,30 +14,36 @@ export class VRMLookAtImporter {
   /**
    * Import a [[VRMLookAtHead]] from a VRM.
    *
-   * @param firstPerson A raw `firstPerson` field taken from the VRM extension of the GLTF
+   * @param gltf A parsed result of GLTF taken from GLTFLoader
    * @param blendShapeProxy A [[VRMBlendShapeProxy]] instance that represents the VRM
    * @param humanoid A [[VRMHumanoid]] instance that represents the VRM
    */
-  public import(
-    firstPerson: VRMSchema.FirstPerson,
-    blendShapeProxy: VRMBlendShapeProxy,
-    humanoid: VRMHumanoid,
-  ): VRMLookAtHead {
-    const applyer = this._importApplyer(firstPerson, blendShapeProxy, humanoid);
+  public import(gltf: THREE.GLTF, blendShapeProxy: VRMBlendShapeProxy, humanoid: VRMHumanoid): VRMLookAtHead | null {
+    const vrmExt: VRMSchema.VRM | undefined = gltf.parser.json.extensions && gltf.parser.json.extensions.VRM;
+    if (!vrmExt) {
+      return null;
+    }
+
+    const schemaFirstPerson: VRMSchema.FirstPerson | undefined = vrmExt.firstPerson;
+    if (!schemaFirstPerson) {
+      return null;
+    }
+
+    const applyer = this._importApplyer(schemaFirstPerson, blendShapeProxy, humanoid);
     return new VRMLookAtHead(humanoid, applyer || undefined);
   }
 
   protected _importApplyer(
-    firstPerson: VRMSchema.FirstPerson,
+    schemaFirstPerson: VRMSchema.FirstPerson,
     blendShapeProxy: VRMBlendShapeProxy,
     humanoid: VRMHumanoid,
   ): VRMLookAtApplyer | null {
-    const lookAtHorizontalInner = firstPerson.lookAtHorizontalInner;
-    const lookAtHorizontalOuter = firstPerson.lookAtHorizontalOuter;
-    const lookAtVerticalDown = firstPerson.lookAtVerticalDown;
-    const lookAtVerticalUp = firstPerson.lookAtVerticalUp;
+    const lookAtHorizontalInner = schemaFirstPerson.lookAtHorizontalInner;
+    const lookAtHorizontalOuter = schemaFirstPerson.lookAtHorizontalOuter;
+    const lookAtVerticalDown = schemaFirstPerson.lookAtVerticalDown;
+    const lookAtVerticalUp = schemaFirstPerson.lookAtVerticalUp;
 
-    switch (firstPerson.lookAtTypeName) {
+    switch (schemaFirstPerson.lookAtTypeName) {
       case VRMSchema.FirstPersonLookAtTypeName.Bone: {
         if (
           lookAtHorizontalInner === undefined ||

--- a/src/vrm/material/VRMMaterialImporter.ts
+++ b/src/vrm/material/VRMMaterialImporter.ts
@@ -43,7 +43,17 @@ export class VRMMaterialImporter {
    *
    * @param gltf A parsed result of GLTF taken from GLTFLoader
    */
-  public async convertGLTFMaterials(gltf: THREE.GLTF): Promise<THREE.Material[]> {
+  public async convertGLTFMaterials(gltf: THREE.GLTF): Promise<THREE.Material[] | null> {
+    const vrmExt: VRMSchema.VRM | undefined = gltf.parser.json.extensions && gltf.parser.json.extensions.VRM;
+    if (!vrmExt) {
+      return null;
+    }
+
+    const materialProperties: VRMSchema.Material[] | undefined = vrmExt.materialProperties;
+    if (!materialProperties) {
+      return null;
+    }
+
     const meshesMap: GLTFMesh[] = await gltf.parser.getDependencies('mesh');
     const materialList: { [vrmMaterialIndex: number]: { surface: THREE.Material; outline?: THREE.Material } } = {};
     const materials: THREE.Material[] = []; // result
@@ -67,7 +77,7 @@ export class VRMMaterialImporter {
             // create / push to cache (or pop from cache) vrm materials
             const vrmMaterialIndex = gltf.parser.json.meshes![meshIndex].primitives[primitiveIndex].material!;
 
-            let props = (gltf.parser.json.extensions!.VRM as VRMSchema.VRM).materialProperties![vrmMaterialIndex];
+            let props = materialProperties[vrmMaterialIndex];
             if (!props) {
               console.warn(
                 `VRMMaterialImporter: There are no material definition for material #${vrmMaterialIndex} on VRM extension.`,


### PR DESCRIPTION
各コンポーネントのimporter実装について、gltfを受け取るかvrm拡張を受け取るかがバラバラだったため、統一してgltfを受け取る形としました。