### PR TITLE
make reduceBones (renamed to removeUnnecessaryJoints) optional

### DIFF
--- a/src/vrm/VRMImporter.ts
+++ b/src/vrm/VRMImporter.ts
@@ -4,7 +4,6 @@ import { VRMFirstPersonImporter } from './firstperson';
 import { VRMHumanoidImporter } from './humanoid/VRMHumanoidImporter';
 import { VRMLookAtImporter } from './lookat/VRMLookAtImporter';
 import { VRMMaterialImporter } from './material';
-import { reduceBones } from './reduceBones';
 import { VRMSpringBoneImporter } from './springbone/VRMSpringBoneImporter';
 import { VRMSchema } from './types';
 import { VRM } from './VRM';
@@ -65,8 +64,6 @@ export class VRMImporter {
         object3d.frustumCulled = false;
       }
     });
-
-    reduceBones(scene);
 
     const materials = (await this._materialImporter.convertGLTFMaterials(gltf)) || undefined;
 

--- a/src/vrm/debug/VRMImporterDebug.ts
+++ b/src/vrm/debug/VRMImporterDebug.ts
@@ -1,5 +1,4 @@
 import * as THREE from 'three';
-import { reduceBones } from '../reduceBones';
 import { VRMImporter, VRMImporterOptions } from '../VRMImporter';
 import { VRMDebug } from './VRMDebug';
 import { VRMDebugOptions } from './VRMDebugOptions';
@@ -34,8 +33,6 @@ export class VRMImporterDebug extends VRMImporter {
         object3d.frustumCulled = false;
       }
     });
-
-    reduceBones(scene);
 
     const materials = (await this._materialImporter.convertGLTFMaterials(gltf)) || undefined;
 

--- a/src/vrm/index.ts
+++ b/src/vrm/index.ts
@@ -1,6 +1,6 @@
 export * from './VRM';
 export * from './VRMImporter';
-export * from './reduceBones';
+export * from './removeUnnecessaryJoints';
 export * from './blendshape';
 export * from './debug';
 export * from './firstperson';

--- a/src/vrm/removeUnnecessaryJoints.ts
+++ b/src/vrm/removeUnnecessaryJoints.ts
@@ -1,6 +1,13 @@
 import * as THREE from 'three';
 
-export function reduceBones(root: THREE.Object3D): void {
+/**
+ * Traverse given object and remove unnecessarily bound joints from every `THREE.SkinnedMesh`.
+ * Some environments like mobile devices have a lower limit of bones and might be unable to perform mesh skinning, this function might resolve such an issue.
+ * Also this function might greatly improve the performance of mesh skinning.
+ *
+ * @param root Root object that will be traversed
+ */
+export function removeUnnecessaryJoints(root: THREE.Object3D): void {
   // Traverse an entire tree
   root.traverse((obj) => {
     if (obj.type !== 'SkinnedMesh') {


### PR DESCRIPTION
`reduceBones` （ `removeUnnecessaryJoints` と名前を変更しました）の実行を任意としました。
つかいたい場合は、自分で `gltf.scene` を `removeUnnecessaryJoints` に入れる形となります。

VRM読み込み時のオプションで指定させても良かったかもしれませんが、どこにオプションを渡すべきかで悩みました……

### API Breaking

`reduceBones` -> `removeUnnecessaryJoints`