### PR TITLE
feat(examples): set the pixel ratio

### DIFF
--- a/examples/animations.html
+++ b/examples/animations.html
@@ -27,6 +27,7 @@
 			// renderer
 			const renderer = new THREE.WebGLRenderer();
 			renderer.setSize( window.innerWidth, window.innerHeight );
+			renderer.setPixelRatio( window.devicePixelRatio );
 			document.body.appendChild( renderer.domElement );
 
 			// camera

--- a/examples/basic.html
+++ b/examples/basic.html
@@ -27,6 +27,7 @@
 			// renderer
 			const renderer = new THREE.WebGLRenderer();
 			renderer.setSize( window.innerWidth, window.innerHeight );
+			renderer.setPixelRatio( window.devicePixelRatio );
 			document.body.appendChild( renderer.domElement );
 
 			// camera

--- a/examples/blendshapes.html
+++ b/examples/blendshapes.html
@@ -27,6 +27,7 @@
 			// renderer
 			const renderer = new THREE.WebGLRenderer();
 			renderer.setSize( window.innerWidth, window.innerHeight );
+			renderer.setPixelRatio( window.devicePixelRatio );
 			document.body.appendChild( renderer.domElement );
 
 			// camera

--- a/examples/bones.html
+++ b/examples/bones.html
@@ -27,6 +27,7 @@
 			// renderer
 			const renderer = new THREE.WebGLRenderer();
 			renderer.setSize( window.innerWidth, window.innerHeight );
+			renderer.setPixelRatio( window.devicePixelRatio );
 			document.body.appendChild( renderer.domElement );
 
 			// camera

--- a/examples/dnd.html
+++ b/examples/dnd.html
@@ -27,6 +27,7 @@
 			// renderer
 			const renderer = new THREE.WebGLRenderer();
 			renderer.setSize( window.innerWidth, window.innerHeight );
+			renderer.setPixelRatio( window.devicePixelRatio );
 			document.body.appendChild( renderer.domElement );
 
 			// camera

--- a/examples/firstperson.html
+++ b/examples/firstperson.html
@@ -27,6 +27,7 @@
 			// renderer
 			const renderer = new THREE.WebGLRenderer();
 			renderer.setSize( window.innerWidth, window.innerHeight );
+			renderer.setPixelRatio( window.devicePixelRatio );
 			document.body.appendChild( renderer.domElement );
 
 			// camera

--- a/examples/lookat.html
+++ b/examples/lookat.html
@@ -27,6 +27,7 @@
 			// renderer
 			const renderer = new THREE.WebGLRenderer();
 			renderer.setSize( window.innerWidth, window.innerHeight );
+			renderer.setPixelRatio( window.devicePixelRatio );
 			document.body.appendChild( renderer.domElement );
 
 			// camera

--- a/examples/materials-debug.html
+++ b/examples/materials-debug.html
@@ -27,6 +27,7 @@
 			// renderer
 			const renderer = new THREE.WebGLRenderer();
 			renderer.setSize( window.innerWidth, window.innerHeight );
+			renderer.setPixelRatio( window.devicePixelRatio );
 			document.body.appendChild( renderer.domElement );
 
 			// camera

--- a/examples/meta.html
+++ b/examples/meta.html
@@ -32,6 +32,7 @@
 			// renderer
 			const renderer = new THREE.WebGLRenderer();
 			renderer.setSize( window.innerWidth, window.innerHeight );
+			renderer.setPixelRatio( window.devicePixelRatio );
 			document.body.appendChild( renderer.domElement );
 
 			// camera

--- a/examples/mouse.html
+++ b/examples/mouse.html
@@ -27,6 +27,7 @@
 			// renderer
 			const renderer = new THREE.WebGLRenderer();
 			renderer.setSize( window.innerWidth, window.innerHeight );
+			renderer.setPixelRatio( window.devicePixelRatio );
 			document.body.appendChild( renderer.domElement );
 
 			// camera


### PR DESCRIPTION
次の動機から、`examples`の各コードに、dpiが通常と異なるモニタに対応するための`renderer.setPixelRatio( window.devicePixelRatio );`を加えました。

- より綺麗なサンプルを見せたい。
- 開発時の動作確認を見やすくしたい。

しかし、`@pixiv/three-vrm`の動作とは無関係な行が増えるデメリットも考えられますのでcontributorの方々のご意見を伺いたいです。
