### PR TITLE
Fix lint script

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "build-types": "tsc --emitDeclarationOnly",
     "docs": "typedoc --out docs --mode file --excludeNotExported",
     "gh-pages": "node ./bin/gh-pages.js",
-    "lint": "eslint 'src/**/*.{ts,tsx}'",
+    "lint": "eslint \"src/**/*.{ts,tsx}\"",
     "typedefgen": "node ./bin/typedefgen.js"
   },
   "husky": {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "build-types": "tsc --emitDeclarationOnly",
     "docs": "typedoc --out docs --mode file --excludeNotExported",
     "gh-pages": "node ./bin/gh-pages.js",
-    "lint": "eslint src/**/*.{ts,tsx}",
+    "lint": "eslint 'src/**/*.{ts,tsx}'",
     "typedefgen": "node ./bin/typedefgen.js"
   },
   "husky": {


### PR DESCRIPTION
開発中に `yarn lint` を叩いたらエラーが出たので修正しました。
興味のあるプロジェクトなので応援しています 🙌 

Before:

```bash
$ yarn lint
yarn run v1.17.3
$ eslint src/**/*.{ts,tsx}

Oops! Something went wrong! :(

ESLint: 6.3.0.

No files matching the pattern "src/**/*.tsx" were found.
Please check for typing mistakes in the pattern.

error Command failed with exit code 2.
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command.
```

After:

```bash
$ yarn lint
yarn run v1.17.3
$ eslint 'src/**/*.{ts,tsx}'
✨  Done in 4.03s.
```