### PR TITLE
Narrow range of dependabot updates

### DIFF
--- a/.dependabot/config.yml
+++ b/.dependabot/config.yml
@@ -8,8 +8,11 @@ update_configs:
 
     update_schedule: "weekly"
 
-    default_assignees:
-      - FMS-Cat
+    allowed_updates:
+      - match:
+          dependency_type: "direct"
+      - match:
+          update_type: "security"
 
     version_requirement_updates: "auto"
 
@@ -19,7 +22,10 @@ update_configs:
 
     update_schedule: "weekly"
 
-    default_assignees:
-      - FMS-Cat
+    allowed_updates:
+      - match:
+          dependency_type: "direct"
+      - match:
+          update_type: "security"
 
     version_requirement_updates: "auto"


### PR DESCRIPTION
- dependabotの範囲を狭めました。
- Default assigneesからFMS_Catを外しました。