### PR TITLE
MToon: Fix DebugLitShadeRate behavior

### DIFF
--- a/src/vrm/material/shaders/mtoon.frag
+++ b/src/vrm/material/shaders/mtoon.frag
@@ -403,11 +403,17 @@ void main() {
 
   vec3 col = reflectedLight.directDiffuse + reflectedLight.indirectDiffuse;
 
-  #if defined( OUTLINE ) && defined( OUTLINE_COLOR_MIXED ) // omitting DebugMode
+  #if defined( OUTLINE ) && defined( OUTLINE_COLOR_MIXED )
     gl_FragColor = vec4(
       outlineColor.rgb * mix( vec3( 1.0 ), col, outlineLightingMix ),
       diffuseColor.a
     );
+    postCorrection();
+    return;
+  #endif
+
+  #ifdef DEBUG_LITSHADERATE
+    gl_FragColor = vec4( col, diffuseColor.a );
     postCorrection();
     return;
   #endif


### PR DESCRIPTION
MToonのLitShadeRate DebugModeにおいて、MatCapやEmissiveなどの値が加算されていたため、これを修正しました。

![image](https://user-images.githubusercontent.com/7824814/66626913-e7079880-ec34-11e9-8136-0a23364622e1.png)
