### PR TITLE
these "as any" are no longer needed

### DIFF
--- a/src/vrm/material/VRMMaterialImporter.ts
+++ b/src/vrm/material/VRMMaterialImporter.ts
@@ -236,8 +236,8 @@ export class VRMMaterialImporter {
           mtl.emissiveMap.encoding = THREE.LinearEncoding;
         }
       } else {
-        (mtl as any).color.convertSRGBToLinear(); // TODO: `as any` is temporal, since there are no declaration in @types/three
-        (mtl as any).emissive.convertSRGBToLinear(); // TODO: `as any` is temporal, since there are no declaration in @types/three
+        mtl.color.convertSRGBToLinear();
+        mtl.emissive.convertSRGBToLinear();
       }
     }
 
@@ -249,7 +249,7 @@ export class VRMMaterialImporter {
           mtl.map.encoding = THREE.LinearEncoding;
         }
       } else {
-        (mtl as any).color.convertSRGBToLinear(); // TODO: `as any` is temporal, since there are no declaration in @types/three
+        mtl.color.convertSRGBToLinear();
       }
     }
 


### PR DESCRIPTION
`Color.convertSRGBToLinear` がthreeの型定義に入ったようなので、該当箇所の `as any` を消しました。

https://github.com/mrdoob/three.js/blob/7a6d8dd4afcaf396ce61386822896d71977fb9ea/src/math/Color.d.ts#L126