### PR TITLE
Better gltf import

### DIFF
--- a/src/vrm/VRM.ts
+++ b/src/vrm/VRM.ts
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import { GLTF } from 'three/examples/jsm/loaders/GLTFLoader';
 import { VRMBlendShapeProxy } from './blendshape';
 import { VRMFirstPerson } from './firstperson';
 import { VRMHumanoid } from './humanoid';
@@ -49,7 +50,7 @@ export class VRM {
    * @param gltf A parsed GLTF object taken from GLTFLoader
    * @param options Options that will be used in importer
    */
-  public static async from(gltf: THREE.GLTF, options: VRMImporterOptions = {}): Promise<VRM> {
+  public static async from(gltf: GLTF, options: VRMImporterOptions = {}): Promise<VRM> {
     const importer = new VRMImporter(options);
     return await importer.import(gltf);
   }

--- a/src/vrm/VRMImporter.ts
+++ b/src/vrm/VRMImporter.ts
@@ -1,4 +1,3 @@
-import * as THREE from 'three';
 import { GLTF } from 'three/examples/jsm/loaders/GLTFLoader';
 import { VRMBlendShapeImporter } from './blendshape';
 import { VRMFirstPersonImporter } from './firstperson';

--- a/src/vrm/VRMImporter.ts
+++ b/src/vrm/VRMImporter.ts
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import { GLTF } from 'three/examples/jsm/loaders/GLTFLoader';
 import { VRMBlendShapeImporter } from './blendshape';
 import { VRMFirstPersonImporter } from './firstperson';
 import { VRMHumanoidImporter } from './humanoid/VRMHumanoidImporter';
@@ -47,7 +48,7 @@ export class VRMImporter {
    *
    * @param gltf A parsed result of GLTF taken from GLTFLoader
    */
-  public async import(gltf: THREE.GLTF): Promise<VRM> {
+  public async import(gltf: GLTF): Promise<VRM> {
     if (gltf.parser.json.extensions === undefined || gltf.parser.json.extensions.VRM === undefined) {
       throw new Error('Could not find VRM extension on the GLTF');
     }

--- a/src/vrm/blendshape/VRMBlendShapeImporter.ts
+++ b/src/vrm/blendshape/VRMBlendShapeImporter.ts
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import { GLTF } from 'three/examples/jsm/loaders/GLTFLoader';
 import { GLTFMesh, GLTFPrimitive, VRMSchema } from '../types';
 import { renameMaterialProperty } from '../utils/renameMaterialProperty';
 import { VRMBlendShapeGroup } from './VRMBlendShapeGroup';
@@ -13,7 +14,7 @@ export class VRMBlendShapeImporter {
    *
    * @param gltf A parsed result of GLTF taken from GLTFLoader
    */
-  public async import(gltf: THREE.GLTF): Promise<VRMBlendShapeProxy | null> {
+  public async import(gltf: GLTF): Promise<VRMBlendShapeProxy | null> {
     const vrmExt: VRMSchema.VRM | undefined = gltf.parser.json.extensions && gltf.parser.json.extensions.VRM;
     if (!vrmExt) {
       return null;

--- a/src/vrm/debug/VRMDebug.ts
+++ b/src/vrm/debug/VRMDebug.ts
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import { GLTF } from 'three/examples/jsm/loaders/GLTFLoader';
 import { VRM, VRMParameters } from '../VRM';
 import { VRMImporterOptions } from '../VRMImporter';
 import { VRMDebugOptions } from './VRMDebugOptions';
@@ -18,7 +19,7 @@ export class VRMDebug extends VRM {
    * @param debugOption Options for VRMDebug features
    */
   public static async from(
-    gltf: THREE.GLTF,
+    gltf: GLTF,
     options: VRMImporterOptions = {},
     debugOption: VRMDebugOptions = {},
   ): Promise<VRM> {

--- a/src/vrm/debug/VRMImporterDebug.ts
+++ b/src/vrm/debug/VRMImporterDebug.ts
@@ -1,4 +1,3 @@
-import * as THREE from 'three';
 import { GLTF } from 'three/examples/jsm/loaders/GLTFLoader';
 import { VRMImporter, VRMImporterOptions } from '../VRMImporter';
 import { VRMDebug } from './VRMDebug';

--- a/src/vrm/debug/VRMImporterDebug.ts
+++ b/src/vrm/debug/VRMImporterDebug.ts
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import { GLTF } from 'three/examples/jsm/loaders/GLTFLoader';
 import { VRMImporter, VRMImporterOptions } from '../VRMImporter';
 import { VRMDebug } from './VRMDebug';
 import { VRMDebugOptions } from './VRMDebugOptions';
@@ -16,7 +17,7 @@ export class VRMImporterDebug extends VRMImporter {
     super(options);
   }
 
-  public async import(gltf: THREE.GLTF, debugOptions: VRMDebugOptions = {}): Promise<VRMDebug> {
+  public async import(gltf: GLTF, debugOptions: VRMDebugOptions = {}): Promise<VRMDebug> {
     if (gltf.parser.json.extensions === undefined || gltf.parser.json.extensions.VRM === undefined) {
       throw new Error('Could not find VRM extension on the GLTF');
     }

--- a/src/vrm/debug/VRMLookAtImporterDebug.ts
+++ b/src/vrm/debug/VRMLookAtImporterDebug.ts
@@ -1,4 +1,3 @@
-import * as THREE from 'three';
 import { GLTF } from 'three/examples/jsm/loaders/GLTFLoader';
 import { VRMBlendShapeProxy } from '../blendshape';
 import { VRMFirstPerson } from '../firstperson';

--- a/src/vrm/debug/VRMLookAtImporterDebug.ts
+++ b/src/vrm/debug/VRMLookAtImporterDebug.ts
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import { GLTF } from 'three/examples/jsm/loaders/GLTFLoader';
 import { VRMBlendShapeProxy } from '../blendshape';
 import { VRMFirstPerson } from '../firstperson';
 import { VRMHumanoid } from '../humanoid';
@@ -9,7 +10,7 @@ import { VRMLookAtHeadDebug } from './VRMLookAtHeadDebug';
 
 export class VRMLookAtImporterDebug extends VRMLookAtImporter {
   public import(
-    gltf: THREE.GLTF,
+    gltf: GLTF,
     firstPerson: VRMFirstPerson,
     blendShapeProxy: VRMBlendShapeProxy,
     humanoid: VRMHumanoid,

--- a/src/vrm/debug/VRMSpringBoneImporterDebug.ts
+++ b/src/vrm/debug/VRMSpringBoneImporterDebug.ts
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import { GLTF } from 'three/examples/jsm/loaders/GLTFLoader';
 import { VRMSpringBone } from '../springbone/VRMSpringBone';
 import { VRMSpringBoneImporter } from '../springbone/VRMSpringBoneImporter';
 import { VRMSpringBoneDebug } from './VRMSpringBoneDebug';
@@ -9,7 +10,7 @@ export class VRMSpringBoneImporterDebug extends VRMSpringBoneImporter {
   }
 
   protected _createSpringBone(
-    gltf: THREE.GLTF,
+    gltf: GLTF,
     bone: THREE.Object3D,
     hitRadius: number,
     stiffiness: number,

--- a/src/vrm/firstperson/VRMFirstPersonImporter.ts
+++ b/src/vrm/firstperson/VRMFirstPersonImporter.ts
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import { GLTF } from 'three/examples/jsm/loaders/GLTFLoader';
 import { VRMHumanoid } from '../humanoid';
 import { GLTFMesh, GLTFNode, VRMSchema } from '../types';
 import { VRMFirstPerson, VRMRendererFirstPersonFlags } from './VRMFirstPerson';
@@ -13,7 +14,7 @@ export class VRMFirstPersonImporter {
    * @param gltf A parsed result of GLTF taken from GLTFLoader
    * @param humanoid A [[VRMHumanoid]] instance that represents the VRM
    */
-  public async import(gltf: THREE.GLTF, humanoid: VRMHumanoid): Promise<VRMFirstPerson | null> {
+  public async import(gltf: GLTF, humanoid: VRMHumanoid): Promise<VRMFirstPerson | null> {
     const vrmExt: VRMSchema.VRM | undefined = gltf.parser.json.extensions && gltf.parser.json.extensions.VRM;
     if (!vrmExt) {
       return null;

--- a/src/vrm/humanoid/VRMHumanoidImporter.ts
+++ b/src/vrm/humanoid/VRMHumanoidImporter.ts
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import { GLTF } from 'three/examples/jsm/loaders/GLTFLoader';
 import { VRMSchema } from '../types';
 import { VRMHumanBone } from './VRMHumanBone';
 import { VRMHumanBoneArray } from './VRMHumanBoneArray';
@@ -14,7 +15,7 @@ export class VRMHumanoidImporter {
    *
    * @param gltf A parsed result of GLTF taken from GLTFLoader
    */
-  public async import(gltf: THREE.GLTF): Promise<VRMHumanoid | null> {
+  public async import(gltf: GLTF): Promise<VRMHumanoid | null> {
     const vrmExt: VRMSchema.VRM | undefined = gltf.parser.json.extensions && gltf.parser.json.extensions.VRM;
     if (!vrmExt) {
       return null;

--- a/src/vrm/lookat/VRMLookAtImporter.ts
+++ b/src/vrm/lookat/VRMLookAtImporter.ts
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import { GLTF } from 'three/examples/jsm/loaders/GLTFLoader';
 import { VRMBlendShapeProxy } from '../blendshape';
 import { VRMFirstPerson } from '../firstperson';
 import { VRMHumanoid } from '../humanoid';
@@ -21,7 +22,7 @@ export class VRMLookAtImporter {
    * @param humanoid A [[VRMHumanoid]] instance that represents the VRM
    */
   public import(
-    gltf: THREE.GLTF,
+    gltf: GLTF,
     firstPerson: VRMFirstPerson,
     blendShapeProxy: VRMBlendShapeProxy,
     humanoid: VRMHumanoid,

--- a/src/vrm/material/VRMMaterialImporter.ts
+++ b/src/vrm/material/VRMMaterialImporter.ts
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import { GLTF } from 'three/examples/jsm/loaders/GLTFLoader';
 import { GLTFMesh, GLTFPrimitive, VRMSchema } from '../types';
 import { MToonMaterial, MToonMaterialOutlineWidthMode, MToonMaterialRenderMode } from './MToonMaterial';
 import { VRMUnlitMaterial, VRMUnlitMaterialRenderType } from './VRMUnlitMaterial';
@@ -43,7 +44,7 @@ export class VRMMaterialImporter {
    *
    * @param gltf A parsed result of GLTF taken from GLTFLoader
    */
-  public async convertGLTFMaterials(gltf: THREE.GLTF): Promise<THREE.Material[] | null> {
+  public async convertGLTFMaterials(gltf: GLTF): Promise<THREE.Material[] | null> {
     const vrmExt: VRMSchema.VRM | undefined = gltf.parser.json.extensions && gltf.parser.json.extensions.VRM;
     if (!vrmExt) {
       return null;
@@ -132,7 +133,7 @@ export class VRMMaterialImporter {
   public async createVRMMaterials(
     originalMaterial: THREE.Material,
     vrmProps: VRMSchema.Material,
-    gltf: THREE.GLTF,
+    gltf: GLTF,
   ): Promise<{
     surface: THREE.Material;
     outline?: THREE.Material;
@@ -259,7 +260,7 @@ export class VRMMaterialImporter {
   private _extractMaterialProperties(
     originalMaterial: THREE.Material,
     vrmProps: VRMSchema.Material,
-    gltf: THREE.GLTF,
+    gltf: GLTF,
   ): Promise<any> {
     const taskList: Array<Promise<any>> = [];
     const params: any = {};

--- a/src/vrm/springbone/VRMSpringBoneImporter.ts
+++ b/src/vrm/springbone/VRMSpringBoneImporter.ts
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import { GLTF } from 'three/examples/jsm/loaders/GLTFLoader';
 import { GLTFNode, VRMSchema } from '../types';
 import { GIZMO_RENDER_ORDER, VRMSpringBone } from './VRMSpringBone';
 import { VRMSpringBoneColliderGroup, VRMSpringBoneColliderMesh } from './VRMSpringBoneColliderGroup';
@@ -13,7 +14,7 @@ export class VRMSpringBoneImporter {
    *
    * @param gltf A parsed result of GLTF taken from GLTFLoader
    */
-  public async import(gltf: THREE.GLTF): Promise<VRMSpringBoneManager | null> {
+  public async import(gltf: GLTF): Promise<VRMSpringBoneManager | null> {
     if (
       !gltf.parser.json.extensions ||
       !gltf.parser.json.extensions.VRM ||
@@ -38,7 +39,7 @@ export class VRMSpringBoneImporter {
   }
 
   protected _createSpringBone(
-    gltf: THREE.GLTF,
+    gltf: GLTF,
     bone: THREE.Object3D,
     hitRadius: number,
     stiffiness: number,
@@ -51,7 +52,7 @@ export class VRMSpringBoneImporter {
   }
 
   private async _getSpringBoneGroupList(
-    gltf: THREE.GLTF,
+    gltf: GLTF,
     colliderGroups: VRMSpringBoneColliderGroup[],
   ): Promise<VRMSpringBoneGroup[]> {
     const springBoneGroups: VRMSchema.SecondaryAnimationSpring[] = gltf.parser.json.extensions!.VRM!.secondaryAnimation!
@@ -124,7 +125,7 @@ export class VRMSpringBoneImporter {
   /**
    * Create an array of [[VRMSpringBoneColliderGroup]].
    */
-  private async _getColliderMeshGroups(gltf: THREE.GLTF): Promise<VRMSpringBoneColliderGroup[]> {
+  private async _getColliderMeshGroups(gltf: GLTF): Promise<VRMSpringBoneColliderGroup[]> {
     const vrmExt: VRMSchema.VRM | undefined = gltf.parser.json.extensions && gltf.parser.json.extensions.VRM;
     if (vrmExt === undefined) {
       return [];

--- a/src/vrm/types/three.d.ts
+++ b/src/vrm/types/three.d.ts
@@ -1,19 +1,12 @@
 import { GLTFSchema } from '.';
 
-declare module 'three' {
+declare module 'three/examples/jsm/loaders/GLTFLoader' {
   export class GLTF {
     public scene: THREE.Scene;
     public scenes: THREE.Scene[];
     public cameras: THREE.Camera[];
     public animations: THREE.AnimationClip[];
-    public asset: {
-      copyright?: string;
-      generator?: string;
-      version: string;
-      minVersion?: string;
-      extensions?: object;
-      extras?: any;
-    };
+    public asset: object;
     public parser: {
       json: GLTFSchema.GLTF;
       getDependency: (type: string, index: number) => Promise<any>;


### PR DESCRIPTION
branched from #267 

- it now imports `GLTF` from `three/examples/jsm/loaders/GLTFLoader`
