### PR TITLE
CurveMapper -> VRMCurveMapper

### DIFF
--- a/src/vrm/lookat/VRMCurveMapper.ts
+++ b/src/vrm/lookat/VRMCurveMapper.ts
@@ -68,7 +68,7 @@ const evaluateCurve = (arr: number[], x: number): number => {
  *
  * See: https://github.com/vrm-c/UniVRM/blob/master/Assets/VRM/UniVRM/Scripts/LookAt/CurveMapper.cs
  */
-export class CurveMapper {
+export class VRMCurveMapper {
   /**
    * An array represents the curve. See AnimationCurve class of Unity for its details.
    *
@@ -77,17 +77,17 @@ export class CurveMapper {
   public curve: number[] = [0.0, 0.0, 0.0, 1.0, 1.0, 1.0, 1.0, 0.0];
 
   /**
-   * The maximum input range of the [[CurveMapper]].
+   * The maximum input range of the [[VRMCurveMapper]].
    */
   public curveXRangeDegree = 90.0;
 
   /**
-   * The maximum output value of the [[CurveMapper]].
+   * The maximum output value of the [[VRMCurveMapper]].
    */
   public curveYRangeDegree = 10.0;
 
   /**
-   * Create a new [[CurveMapper]].
+   * Create a new [[VRMCurveMapper]].
    *
    * @param xRange The maximum input range
    * @param yRange The maximum output value

--- a/src/vrm/lookat/VRMLookAtBlendShapeApplyer.ts
+++ b/src/vrm/lookat/VRMLookAtBlendShapeApplyer.ts
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 import { VRMBlendShapeProxy } from '../blendshape';
 import { VRMSchema } from '../types';
-import { CurveMapper } from './CurveMapper';
+import { VRMCurveMapper } from './VRMCurveMapper';
 import { VRMLookAtApplyer } from './VRMLookAtApplyer';
 
 /**
@@ -10,9 +10,9 @@ import { VRMLookAtApplyer } from './VRMLookAtApplyer';
 export class VRMLookAtBlendShapeApplyer extends VRMLookAtApplyer {
   public readonly type = VRMSchema.FirstPersonLookAtTypeName.BlendShape;
 
-  private readonly _curveHorizontal: CurveMapper;
-  private readonly _curveVerticalDown: CurveMapper;
-  private readonly _curveVerticalUp: CurveMapper;
+  private readonly _curveHorizontal: VRMCurveMapper;
+  private readonly _curveVerticalDown: VRMCurveMapper;
+  private readonly _curveVerticalUp: VRMCurveMapper;
 
   private readonly _blendShapeProxy: VRMBlendShapeProxy;
 
@@ -20,15 +20,15 @@ export class VRMLookAtBlendShapeApplyer extends VRMLookAtApplyer {
    * Create a new VRMLookAtBlendShapeApplyer.
    *
    * @param blendShapeProxy A [[VRMBlendShapeProxy]] used by this applier
-   * @param curveHorizontal A [[CurveMapper]] used for transverse direction
-   * @param curveVerticalDown A [[CurveMapper]] used for down direction
-   * @param curveVerticalUp A [[CurveMapper]] used for up direction
+   * @param curveHorizontal A [[VRMCurveMapper]] used for transverse direction
+   * @param curveVerticalDown A [[VRMCurveMapper]] used for down direction
+   * @param curveVerticalUp A [[VRMCurveMapper]] used for up direction
    */
   constructor(
     blendShapeProxy: VRMBlendShapeProxy,
-    curveHorizontal: CurveMapper,
-    curveVerticalDown: CurveMapper,
-    curveVerticalUp: CurveMapper,
+    curveHorizontal: VRMCurveMapper,
+    curveVerticalDown: VRMCurveMapper,
+    curveVerticalUp: VRMCurveMapper,
   ) {
     super();
 

--- a/src/vrm/lookat/VRMLookAtBoneApplyer.ts
+++ b/src/vrm/lookat/VRMLookAtBoneApplyer.ts
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 import { VRMHumanoid } from '../humanoid';
 import { GLTFNode, VRMSchema } from '../types';
-import { CurveMapper } from './CurveMapper';
+import { VRMCurveMapper } from './VRMCurveMapper';
 import { VRMLookAtApplyer } from './VRMLookAtApplyer';
 import { VRMLookAtHead } from './VRMLookAtHead';
 
@@ -13,10 +13,10 @@ const _euler = new THREE.Euler(0.0, 0.0, 0.0, VRMLookAtHead.EULER_ORDER);
 export class VRMLookAtBoneApplyer extends VRMLookAtApplyer {
   public readonly type = VRMSchema.FirstPersonLookAtTypeName.Bone;
 
-  private readonly _curveHorizontalInner: CurveMapper;
-  private readonly _curveHorizontalOuter: CurveMapper;
-  private readonly _curveVerticalDown: CurveMapper;
-  private readonly _curveVerticalUp: CurveMapper;
+  private readonly _curveHorizontalInner: VRMCurveMapper;
+  private readonly _curveHorizontalOuter: VRMCurveMapper;
+  private readonly _curveVerticalDown: VRMCurveMapper;
+  private readonly _curveVerticalUp: VRMCurveMapper;
 
   private readonly _leftEye: GLTFNode | null;
   private readonly _rightEye: GLTFNode | null;
@@ -25,17 +25,17 @@ export class VRMLookAtBoneApplyer extends VRMLookAtApplyer {
    * Create a new VRMLookAtBoneApplyer.
    *
    * @param humanoid A [[VRMHumanoid]] used by this applier
-   * @param curveHorizontalInner A [[CurveMapper]] used for inner transverse direction
-   * @param curveHorizontalOuter A [[CurveMapper]] used for outer transverse direction
-   * @param curveVerticalDown A [[CurveMapper]] used for down direction
-   * @param curveVerticalUp A [[CurveMapper]] used for up direction
+   * @param curveHorizontalInner A [[VRMCurveMapper]] used for inner transverse direction
+   * @param curveHorizontalOuter A [[VRMCurveMapper]] used for outer transverse direction
+   * @param curveVerticalDown A [[VRMCurveMapper]] used for down direction
+   * @param curveVerticalUp A [[VRMCurveMapper]] used for up direction
    */
   constructor(
     humanoid: VRMHumanoid,
-    curveHorizontalInner: CurveMapper,
-    curveHorizontalOuter: CurveMapper,
-    curveVerticalDown: CurveMapper,
-    curveVerticalUp: CurveMapper,
+    curveHorizontalInner: VRMCurveMapper,
+    curveHorizontalOuter: VRMCurveMapper,
+    curveVerticalDown: VRMCurveMapper,
+    curveVerticalUp: VRMCurveMapper,
   ) {
     super();
 

--- a/src/vrm/lookat/VRMLookAtImporter.ts
+++ b/src/vrm/lookat/VRMLookAtImporter.ts
@@ -3,7 +3,7 @@ import { VRMBlendShapeProxy } from '../blendshape';
 import { VRMFirstPerson } from '../firstperson';
 import { VRMHumanoid } from '../humanoid';
 import { VRMSchema } from '../types';
-import { CurveMapper } from './CurveMapper';
+import { VRMCurveMapper } from './VRMCurveMapper';
 import { VRMLookAtApplyer } from './VRMLookAtApplyer';
 import { VRMLookAtBlendShapeApplyer } from './VRMLookAtBlendShapeApplyer';
 import { VRMLookAtBoneApplyer } from './VRMLookAtBoneApplyer';
@@ -87,16 +87,16 @@ export class VRMLookAtImporter {
     }
   }
 
-  private _importCurveMapperBone(map: VRMSchema.FirstPersonDegreeMap): CurveMapper {
-    return new CurveMapper(
+  private _importCurveMapperBone(map: VRMSchema.FirstPersonDegreeMap): VRMCurveMapper {
+    return new VRMCurveMapper(
       typeof map.xRange === 'number' ? THREE.Math.DEG2RAD * map.xRange : undefined,
       typeof map.yRange === 'number' ? THREE.Math.DEG2RAD * map.yRange : undefined,
       map.curve,
     );
   }
 
-  private _importCurveMapperBlendShape(map: VRMSchema.FirstPersonDegreeMap): CurveMapper {
-    return new CurveMapper(
+  private _importCurveMapperBlendShape(map: VRMSchema.FirstPersonDegreeMap): VRMCurveMapper {
+    return new VRMCurveMapper(
       typeof map.xRange === 'number' ? THREE.Math.DEG2RAD * map.xRange : undefined,
       map.yRange,
       map.curve,

--- a/src/vrm/lookat/index.ts
+++ b/src/vrm/lookat/index.ts
@@ -1,4 +1,4 @@
-export * from './CurveMapper';
+export * from './VRMCurveMapper';
 export * from './VRMLookAtApplyer';
 export * from './VRMLookAtBlendShapeApplyer';
 export * from './VRMLookAtBoneApplyer';


### PR DESCRIPTION
Will close #294 

To prevent undesired potential name conflict
Since `CurveMapper` is already exposed to end developers, this is a breaking change

---

### Breaking Change

`CurveMapper` -> `VRMCurveMapper`