### PR TITLE
Fix some z-axis that was inverted

### DIFF
--- a/src/vrm/firstperson/VRMFirstPersonImporter.ts
+++ b/src/vrm/firstperson/VRMFirstPersonImporter.ts
@@ -43,7 +43,7 @@ export class VRMFirstPersonImporter {
       ? new THREE.Vector3(
           schemaFirstPerson.firstPersonBoneOffset.x,
           schemaFirstPerson.firstPersonBoneOffset.y,
-          -schemaFirstPerson.firstPersonBoneOffset.z!,
+          -schemaFirstPerson.firstPersonBoneOffset.z!, // VRM 0.0 uses left-handed y-up
         )
       : new THREE.Vector3(0.0, 0.06, 0.0); // fallback, taken from UniVRM implementation
 

--- a/src/vrm/firstperson/VRMFirstPersonImporter.ts
+++ b/src/vrm/firstperson/VRMFirstPersonImporter.ts
@@ -43,7 +43,7 @@ export class VRMFirstPersonImporter {
       ? new THREE.Vector3(
           schemaFirstPerson.firstPersonBoneOffset.x,
           schemaFirstPerson.firstPersonBoneOffset.y,
-          schemaFirstPerson.firstPersonBoneOffset.z,
+          -schemaFirstPerson.firstPersonBoneOffset.z!,
         )
       : new THREE.Vector3(0.0, 0.06, 0.0); // fallback, taken from UniVRM implementation
 

--- a/src/vrm/springbone/VRMSpringBoneImporter.ts
+++ b/src/vrm/springbone/VRMSpringBoneImporter.ts
@@ -149,7 +149,7 @@ export class VRMSpringBoneImporter {
           return;
         }
 
-        const offset = _v3A.set(collider.offset.x, collider.offset.y, collider.offset.z);
+        const offset = _v3A.set(collider.offset.x, collider.offset.y, -collider.offset.z);
         const colliderMesh = this._createColliderMesh(collider.radius, offset);
 
         bone.add(colliderMesh);

--- a/src/vrm/springbone/VRMSpringBoneImporter.ts
+++ b/src/vrm/springbone/VRMSpringBoneImporter.ts
@@ -149,7 +149,11 @@ export class VRMSpringBoneImporter {
           return;
         }
 
-        const offset = _v3A.set(collider.offset.x, collider.offset.y, -collider.offset.z);
+        const offset = _v3A.set(
+          collider.offset.x,
+          collider.offset.y,
+          -collider.offset.z, // VRM 0.0 uses left-handed y-up
+        );
         const colliderMesh = this._createColliderMesh(collider.radius, offset);
 
         bone.add(colliderMesh);

--- a/src/vrm/springbone/VRMSpringBoneImporter.ts
+++ b/src/vrm/springbone/VRMSpringBoneImporter.ts
@@ -74,7 +74,11 @@ export class VRMSpringBoneImporter {
         }
 
         const stiffiness = vrmBoneGroup.stiffiness;
-        const gravityDir = _v3A.set(vrmBoneGroup.gravityDir.x, vrmBoneGroup.gravityDir.y, vrmBoneGroup.gravityDir.z);
+        const gravityDir = new THREE.Vector3(
+          vrmBoneGroup.gravityDir.x,
+          vrmBoneGroup.gravityDir.y,
+          -vrmBoneGroup.gravityDir.z, // VRM 0.0 uses left-handed y-up
+        );
         const gravityPower = vrmBoneGroup.gravityPower;
         const dragForce = vrmBoneGroup.dragForce;
         const hitRadius = vrmBoneGroup.hitRadius;


### PR DESCRIPTION
Sequel of #91 

- Fix some z-axes that was inverted since vrm uses left-handed y-up for vectors
  - `gravityDir` of spring bones
  - `offset` of spring bone corriders
  - `firstPersonBoneOffset` of first person
- gravityDir is now working properly
  - It was not working properly because of an async operation
