### PR TITLE
fix some colorspace issues

### DIFF
--- a/src/vrm/material/MToonMaterial.ts
+++ b/src/vrm/material/MToonMaterial.ts
@@ -554,6 +554,9 @@ export class MToonMaterial extends THREE.ShaderMaterial {
         : '') +
       (this.sphereAdd !== null
         ? getTexelDecodingFunction('sphereAddTexelToLinear', this.sphereAdd.encoding) + '\n'
+        : '') +
+      (this.rimTexture !== null
+        ? getTexelDecodingFunction('rimTextureTexelToLinear', this.rimTexture.encoding) + '\n'
         : '');
 
     // == generate shader code =================================================

--- a/src/vrm/material/VRMMaterialImporter.ts
+++ b/src/vrm/material/VRMMaterialImporter.ts
@@ -160,7 +160,7 @@ export class VRMMaterialImporter {
       });
 
       // these textures must be sRGB Encoding, depends on current colorspace
-      ['mainTex', 'shadeTexture', 'emission', 'sphereAdd'].forEach((name) => {
+      ['mainTex', 'shadeTexture', 'emissionMap', 'sphereAdd', 'rimTexture'].forEach((name) => {
         if (params[name] !== undefined) {
           params[name].encoding = this._encoding;
         }

--- a/src/vrm/material/shaders/mtoon.frag
+++ b/src/vrm/material/shaders/mtoon.frag
@@ -470,7 +470,7 @@ void main() {
   vec3 rimMix = mix(vec3(1.0), lighting + indirectLightIntensity * irradiance, rimLightingMix);
   vec3 rim = rimColor * pow( saturate( 1.0 - dot( viewDir, normal ) + rimLift ), rimFresnelPower );
   #ifdef USE_RIMTEXTURE
-    rim *= texture2D( rimTexture, uv ).rgb;
+    rim *= rimTextureTexelToLinear( texture2D( rimTexture, uv ) ).rgb;
   #endif
   col += rim;
 


### PR DESCRIPTION
- `emissionMap` property in MToon has miswritten as `emission` in code, fixed this
- `rimTexture` should be converted into appropriate color space since it's a color texture