### PR TITLE
GLTF.scene is now okay to be a THREE.Group instead of THREE.Scene

### DIFF
--- a/src/vrm/VRM.ts
+++ b/src/vrm/VRM.ts
@@ -13,7 +13,7 @@ import { VRMImporter, VRMImporterOptions } from './VRMImporter';
  * Parameters for a [[VRM]] class.
  */
 export interface VRMParameters {
-  scene: THREE.Scene;
+  scene: THREE.Scene | THREE.Group; // COMPAT: `GLTF.scene` is going to be `THREE.Group` in r114
   humanoid?: VRMHumanoid;
   blendShapeProxy?: VRMBlendShapeProxy;
   firstPerson?: VRMFirstPerson;
@@ -55,9 +55,9 @@ export class VRM {
     return await importer.import(gltf);
   }
   /**
-   * `THREE.Scene` that contains the entire VRM.
+   * `THREE.Scene` or `THREE.Group` (depends on your three.js revision) that contains the entire VRM.
    */
-  public readonly scene: THREE.Scene;
+  public readonly scene: THREE.Scene | THREE.Group; // COMPAT: `GLTF.scene` is going to be `THREE.Group` in r114
 
   /**
    * Contains [[VRMHumanoid]] of the VRM.
@@ -155,7 +155,6 @@ export class VRM {
     const scene = this.scene;
     if (scene) {
       deepDispose(scene);
-      scene.dispose();
     }
   }
 }

--- a/src/vrm/debug/VRMLookAtHeadDebug.ts
+++ b/src/vrm/debug/VRMLookAtHeadDebug.ts
@@ -7,7 +7,7 @@ const _v3 = new THREE.Vector3();
 export class VRMLookAtHeadDebug extends VRMLookAtHead {
   private _faceDirectionHelper?: THREE.ArrowHelper;
 
-  public setupHelper(scene: THREE.Scene, debugOption: VRMDebugOptions): void {
+  public setupHelper(scene: THREE.Object3D, debugOption: VRMDebugOptions): void {
     if (!debugOption.disableFaceDirectionHelper) {
       this._faceDirectionHelper = new THREE.ArrowHelper(
         new THREE.Vector3(0, 0, -1),

--- a/src/vrm/debug/VRMSpringBoneManagerDebug.ts
+++ b/src/vrm/debug/VRMSpringBoneManagerDebug.ts
@@ -17,7 +17,7 @@ const _colliderGizmoMaterial = new THREE.MeshBasicMaterial({
 export type VRMSpringBoneGroupDebug = VRMSpringBoneDebug[];
 
 export class VRMSpringBoneManagerDebug extends VRMSpringBoneManager {
-  public setupHelper(scene: THREE.Scene, debugOption: VRMDebugOptions): void {
+  public setupHelper(scene: THREE.Object3D, debugOption: VRMDebugOptions): void {
     if (debugOption.disableSpringBoneHelper) return;
 
     this.springBoneGroupList.forEach((springBoneGroup) => {


### PR DESCRIPTION
`GLTF.scene` is going to be `THREE.Group` in r114
This PR make it tolerable to be used in r114.

See: https://github.com/mrdoob/three.js/pull/18601
