### PR TITLE
[WIP] fix outlineWidthWorld

### DIFF
--- a/src/vrm/material/shaders/mtoon.vert
+++ b/src/vrm/material/shaders/mtoon.vert
@@ -71,8 +71,9 @@ void main() {
     #endif
 
     #ifdef OUTLINE_WIDTH_WORLD
-      vec3 outlineOffset = 0.01 * outlineWidth * outlineTex * normalize( objectNormal );
-      gl_Position += projectionMatrix * modelViewMatrix * vec4( outlineOffset, 0.0 );
+      float worldNormalLength = length( transformedNormal );
+      vec3 outlineOffset = 0.01 * outlineWidth * outlineTex * worldNormalLength * normalize( objectNormal );
+      gl_Position = projectionMatrix * modelViewMatrix * vec4( outlineOffset + transformed, 1.0 );
     #endif
 
     #ifdef OUTLINE_WIDTH_SCREEN

--- a/src/vrm/material/shaders/mtoon.vert
+++ b/src/vrm/material/shaders/mtoon.vert
@@ -46,6 +46,10 @@ void main() {
   #include <morphnormal_vertex>
   #include <skinbase_vertex>
   #include <skinnormal_vertex>
+
+  // we need this to compute the outline properly
+  objectNormal = normalize( objectNormal );
+
   #include <defaultnormal_vertex>
 
   #ifndef FLAT_SHADED // Normal computed with derivatives when FLAT_SHADED
@@ -71,13 +75,13 @@ void main() {
     #endif
 
     #ifdef OUTLINE_WIDTH_WORLD
-      float worldNormalLength = length( normalMatrix * normalize( objectNormal ) );
-      vec3 outlineOffset = 0.01 * outlineWidth * outlineTex * worldNormalLength * normalize( objectNormal );
+      float worldNormalLength = length( transformedNormal );
+      vec3 outlineOffset = 0.01 * outlineWidth * outlineTex * worldNormalLength * objectNormal;
       gl_Position = projectionMatrix * modelViewMatrix * vec4( outlineOffset + transformed, 1.0 );
     #endif
 
     #ifdef OUTLINE_WIDTH_SCREEN
-      vec3 clipNormal = ( projectionMatrix * modelViewMatrix * vec4( normalize( objectNormal ), 0.0 ) ).xyz;
+      vec3 clipNormal = ( projectionMatrix * modelViewMatrix * vec4( objectNormal, 0.0 ) ).xyz;
       vec2 projectedNormal = normalize( clipNormal.xy );
       projectedNormal *= min( gl_Position.w, outlineScaledMaxDistance );
       projectedNormal.x *= projectionMatrix[ 0 ].x / projectionMatrix[ 1 ].y;

--- a/src/vrm/material/shaders/mtoon.vert
+++ b/src/vrm/material/shaders/mtoon.vert
@@ -71,7 +71,7 @@ void main() {
     #endif
 
     #ifdef OUTLINE_WIDTH_WORLD
-      float worldNormalLength = length( transformedNormal );
+      float worldNormalLength = length( normalMatrix * normalize( objectNormal ) );
       vec3 outlineOffset = 0.01 * outlineWidth * outlineTex * worldNormalLength * normalize( objectNormal );
       gl_Position = projectionMatrix * modelViewMatrix * vec4( outlineOffset + transformed, 1.0 );
     #endif


### PR DESCRIPTION
outline width under `outlineWidthMode === WorldCoordinates` seems to be different a bit in three-vrm, being affected by its object scale.
This PR fixes this. Now the code is almost identical to the one in the original MToon code.

See: https://github.com/Santarh/MToon/blob/43b8a33053d59aba7efa44efd3214ba741d0d871/MToon/Resources/Shaders/MToonCore.cginc#L87-L89