### PR TITLE
MToon: fix rimTexture and uvAnimMaskTexture

### DIFF
--- a/src/vrm/material/MToonMaterial.ts
+++ b/src/vrm/material/MToonMaterial.ts
@@ -210,9 +210,11 @@ export class MToonMaterial extends THREE.ShaderMaterial {
       'bumpMap_ST',
       'receiveShadowTexture_ST',
       'shadingGradeTexture_ST',
+      'rimTexture_ST',
       'sphereAdd_ST',
       'emissionMap_ST',
       'outlineWidthTexture_ST',
+      'uvAnimMaskTexture_ST',
       'srcBlend',
       'dstBlend',
     ].forEach((key) => {

--- a/src/vrm/material/VRMMaterialImporter.ts
+++ b/src/vrm/material/VRMMaterialImporter.ts
@@ -317,16 +317,17 @@ export class VRMMaterialImporter {
         let newName = this._renameMaterialProperty(name);
 
         // if this is textureST (same name as texture name itself), add '_ST'
-        // this is my most favorite MToon feature tbh
         const isTextureST = [
           '_MainTex',
           '_ShadeTexture',
           '_BumpMap',
           '_ReceiveShadowTexture',
           '_ShadingGradeTexture',
+          '_RimTexture',
           '_SphereAdd',
           '_EmissionMap',
           '_OutlineWidthTexture',
+          '_UvAnimMaskTexture',
         ].some((textureName) => name === textureName);
         if (isTextureST) {
           newName += '_ST';


### PR DESCRIPTION
rimTexture and uvAnimMaskTexture has malfunctioned because of ST values in vectorProperties.
This PR will fix this.
