### PR TITLE
MToon: fix a GPU specific issue that is caused by shadeToony = 1.0

### DIFF
--- a/src/vrm/material/shaders/mtoon.frag
+++ b/src/vrm/material/shaders/mtoon.frag
@@ -168,7 +168,9 @@ float getLightIntensity(
   lightIntensity = lightIntensity * shadow;
   lightIntensity = lightIntensity * shadingGrade;
   lightIntensity = lightIntensity * 2.0 - 1.0;
-  return smoothstep( shadeShift, shadeShift + ( 1.0 - shadeToony ), lightIntensity );
+  return shadeToony == 1.0
+    ? step( shadeShift, lightIntensity )
+    : smoothstep( shadeShift, shadeShift + ( 1.0 - shadeToony ), lightIntensity );
 }
 
 vec3 getLighting( const in vec3 lightColor ) {


### PR DESCRIPTION
There is an issue on MToon that occurs when shadeToony is 1.0, in some specific GPU (tested @ GTX1080).
It seems that is caused by `smoothstep( 1.0, 1.0, x )` .
This PR will fix this.


