### PR TITLE
Bump three to r116

### DIFF
--- a/examples/animations.html
+++ b/examples/animations.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.114.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.114.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.114.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.116.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.116.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.116.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/examples/basic.html
+++ b/examples/basic.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.114.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.114.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.114.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.116.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.116.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.116.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/examples/blendshapes.html
+++ b/examples/blendshapes.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.114.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.114.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.114.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.116.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.116.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.116.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/examples/bones.html
+++ b/examples/bones.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.114.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.114.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.114.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.116.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.116.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.116.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/examples/debug.html
+++ b/examples/debug.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.114.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.114.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.114.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.116.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.116.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.116.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/examples/dnd.html
+++ b/examples/dnd.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.114.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.114.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.114.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.116.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.116.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.116.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/examples/encoding.html
+++ b/examples/encoding.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.114.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.114.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.114.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.116.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.116.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.116.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/examples/envmap.html
+++ b/examples/envmap.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.114.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.114.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.114.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.116.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.116.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.116.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/examples/firstperson.html
+++ b/examples/firstperson.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.114.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.114.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.114.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.116.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.116.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.116.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/examples/lookat-advanced.html
+++ b/examples/lookat-advanced.html
@@ -21,9 +21,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.114.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.114.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.114.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.116.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.116.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.116.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			const _v3A = new THREE.Vector3();

--- a/examples/lookat.html
+++ b/examples/lookat.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.114.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.114.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.114.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.116.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.116.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.116.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/examples/materials-debug.html
+++ b/examples/materials-debug.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.114.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.114.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.114.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.116.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.116.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.116.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/examples/meta.html
+++ b/examples/meta.html
@@ -24,9 +24,9 @@
 
 	<body>
 		<span id="meta"></span>
-		<script src="https://unpkg.com/three@0.114.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.114.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.114.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.116.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.116.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.116.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/examples/mouse.html
+++ b/examples/mouse.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.114.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.114.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.114.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.116.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.116.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.116.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "quicktype": "^15.0.199",
     "raw-loader": "^4.0.1",
     "rimraf": "^3.0.0",
-    "three": "^0.114.0",
+    "three": "^0.116.0",
     "ts-loader": "^6.1.0",
     "ts-node": "^8.4.1",
     "typedoc": "^0.17.7",
@@ -88,6 +88,6 @@
     "worker-loader": "^2.0.0"
   },
   "peerDependencies": {
-    "three": "^0.114.0"
+    "three": "^0.116.0"
   }
 }

--- a/src/vrm/springbone/VRMSpringBone.ts
+++ b/src/vrm/springbone/VRMSpringBone.ts
@@ -282,7 +282,7 @@ export class VRMSpringBone {
   private _collision(tail: THREE.Vector3): void {
     this.colliders.forEach((collider) => {
       const colliderWorldPosition = _v3A.setFromMatrixPosition(collider.matrixWorld);
-      const colliderRadius = collider.geometry.boundingSphere!.radius;
+      const colliderRadius = collider.geometry.boundingSphere!.radius; // the bounding sphere is guaranteed to be exist by VRMSpringBoneImporter._createColliderMesh
       const r = this.radius + colliderRadius;
 
       if (tail.distanceToSquared(colliderWorldPosition) <= r * r) {

--- a/src/vrm/springbone/VRMSpringBone.ts
+++ b/src/vrm/springbone/VRMSpringBone.ts
@@ -282,7 +282,7 @@ export class VRMSpringBone {
   private _collision(tail: THREE.Vector3): void {
     this.colliders.forEach((collider) => {
       const colliderWorldPosition = _v3A.setFromMatrixPosition(collider.matrixWorld);
-      const colliderRadius = collider.geometry.boundingSphere.radius;
+      const colliderRadius = collider.geometry.boundingSphere!.radius;
       const r = this.radius + colliderRadius;
 
       if (tail.distanceToSquared(colliderWorldPosition) <= r * r) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5531,10 +5531,10 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
-three@^0.114.0:
-  version "0.114.0"
-  resolved "https://registry.yarnpkg.com/three/-/three-0.114.0.tgz#754d08467a950ddeef06a0c645a1302b130e455a"
-  integrity sha512-3av45FxJeqYm7Rl02dfGBoqTaf2a934oUB4zMNrN8xjmASoSGeeykYoAr35+UntTdJDY/STw6CY3KuXFBWETig==
+three@^0.116.0:
+  version "0.116.1"
+  resolved "https://registry.yarnpkg.com/three/-/three-0.116.1.tgz#a393f7a81fdc3e2fbf57ded5ba47dc5bd3678ce0"
+  integrity sha512-l2JCMiA/lVZAuSrLWRYMalvpR+0j8hbIhCpfs4V6JFnw2+JQEQJ5HltNpfFr+9TDpQts1BhtcISehWf/xBGPvQ==
 
 through2@^2.0.0, through2@~2.0.3:
   version "2.0.5"


### PR DESCRIPTION
- `three` is now `0.116.0`
- Fix a type error that caused by the update of three.js