### PR TITLE
VRMSpringBone: introducing center

### DIFF
--- a/src/vrm/debug/VRMSpringBoneDebug.ts
+++ b/src/vrm/debug/VRMSpringBoneDebug.ts
@@ -15,8 +15,9 @@ export class VRMSpringBoneDebug extends VRMSpringBone {
     gravityPower: number,
     dragForce: number,
     colliders: THREE.Mesh[] = [],
+    center?: THREE.Object3D | null, // TODO: make it sane in next breaking update
   ) {
-    super(bone, radius, stiffiness, gravityDir, gravityPower, dragForce, colliders);
+    super(bone, radius, stiffiness, gravityDir, gravityPower, dragForce, colliders, center);
   }
 
   /**

--- a/src/vrm/debug/VRMSpringBoneDebug.ts
+++ b/src/vrm/debug/VRMSpringBoneDebug.ts
@@ -29,12 +29,12 @@ export class VRMSpringBoneDebug extends VRMSpringBone {
       return this._gizmo;
     }
 
-    const nextTailRelative = _v3A.copy(this._nextTail).sub(this._worldPosition);
+    const nextTailRelative = _v3A.copy(this._nextTail).sub(this._relativePosition);
     const nextTailRelativeLength = nextTailRelative.length();
 
     this._gizmo = new THREE.ArrowHelper(
       nextTailRelative.normalize(),
-      this._worldPosition,
+      this._relativePosition,
       nextTailRelativeLength,
       0xffff00,
       this.radius,
@@ -63,11 +63,11 @@ export class VRMSpringBoneDebug extends VRMSpringBone {
       return;
     }
 
-    const nextTailRelative = _v3A.copy(this._currentTail).sub(this._worldPosition);
+    const nextTailRelative = _v3A.copy(this._currentTail).sub(this._relativePosition);
     const nextTailRelativeLength = nextTailRelative.length();
 
     this._gizmo.setDirection(nextTailRelative.normalize());
     this._gizmo.setLength(nextTailRelativeLength, this.radius, this.radius);
-    this._gizmo.position.copy(this._worldPosition);
+    this._gizmo.position.copy(this._relativePosition);
   }
 }

--- a/src/vrm/debug/VRMSpringBoneDebug.ts
+++ b/src/vrm/debug/VRMSpringBoneDebug.ts
@@ -29,12 +29,12 @@ export class VRMSpringBoneDebug extends VRMSpringBone {
       return this._gizmo;
     }
 
-    const nextTailRelative = _v3A.copy(this._nextTail).sub(this._relativePosition);
+    const nextTailRelative = _v3A.copy(this._nextTail).sub(this._centerSpacePosition);
     const nextTailRelativeLength = nextTailRelative.length();
 
     this._gizmo = new THREE.ArrowHelper(
       nextTailRelative.normalize(),
-      this._relativePosition,
+      this._centerSpacePosition,
       nextTailRelativeLength,
       0xffff00,
       this.radius,
@@ -63,11 +63,11 @@ export class VRMSpringBoneDebug extends VRMSpringBone {
       return;
     }
 
-    const nextTailRelative = _v3A.copy(this._currentTail).sub(this._relativePosition);
+    const nextTailRelative = _v3A.copy(this._currentTail).sub(this._centerSpacePosition);
     const nextTailRelativeLength = nextTailRelative.length();
 
     this._gizmo.setDirection(nextTailRelative.normalize());
     this._gizmo.setLength(nextTailRelativeLength, this.radius, this.radius);
-    this._gizmo.position.copy(this._relativePosition);
+    this._gizmo.position.copy(this._centerSpacePosition);
   }
 }

--- a/src/vrm/debug/VRMSpringBoneImporterDebug.ts
+++ b/src/vrm/debug/VRMSpringBoneImporterDebug.ts
@@ -31,7 +31,8 @@ export class VRMSpringBoneImporterDebug extends VRMSpringBoneImporter {
     gravityPower: number,
     dragForce: number,
     colliders: THREE.Mesh[] = [],
+    center?: THREE.Object3D | null, // TODO: make it sane in next breaking update
   ): VRMSpringBoneDebug {
-    return new VRMSpringBoneDebug(bone, hitRadius, stiffiness, gravityDir, gravityPower, dragForce, colliders);
+    return new VRMSpringBoneDebug(bone, hitRadius, stiffiness, gravityDir, gravityPower, dragForce, colliders, center);
   }
 }

--- a/src/vrm/springbone/VRMSpringBone.ts
+++ b/src/vrm/springbone/VRMSpringBone.ts
@@ -185,6 +185,7 @@ export class VRMSpringBone {
     gravityPower: number,
     dragForce: number,
     colliders: THREE.Mesh[] = [],
+    center?: THREE.Object3D | null, // TODO: make it sane in next breaking update
   ) {
     this.bone = bone; // uniVRMでの parent
     this.bone.matrixAutoUpdate = false; // updateにより計算されるのでthree.js内での自動処理は不要
@@ -223,6 +224,8 @@ export class VRMSpringBone {
       .applyMatrix4(this.bone.matrixWorld)
       .sub(this._centerSpacePosition)
       .length();
+
+    this.center = center ?? null;
   }
 
   /**

--- a/src/vrm/springbone/VRMSpringBoneImporter.ts
+++ b/src/vrm/springbone/VRMSpringBoneImporter.ts
@@ -43,8 +43,9 @@ export class VRMSpringBoneImporter {
     gravityPower: number,
     dragForce: number,
     colliders: THREE.Mesh[] = [],
+    center?: THREE.Object3D | null, // TODO: make it sane in next breaking update
   ): VRMSpringBone {
-    return new VRMSpringBone(bone, hitRadius, stiffiness, gravityDir, gravityPower, dragForce, colliders);
+    return new VRMSpringBone(bone, hitRadius, stiffiness, gravityDir, gravityPower, dragForce, colliders, center);
   }
 
   protected async _importSpringBoneGroupList(
@@ -94,6 +95,9 @@ export class VRMSpringBoneImporter {
             // VRMの情報から「揺れモノ」ボーンのルートが取れる
             const springRootBone: GLTFNode = await gltf.parser.getDependency('node', nodeIndex);
 
+            const center: GLTFNode =
+              vrmBoneGroup.center != null ? await gltf.parser.getDependency('node', vrmBoneGroup.center) : null;
+
             // it's weird but there might be cases we can't find the root bone
             if (!springRootBone) {
               return;
@@ -108,6 +112,7 @@ export class VRMSpringBoneImporter {
                 gravityPower,
                 dragForce,
                 colliders,
+                center,
               );
               springBoneGroup.push(springBone);
             });

--- a/src/vrm/springbone/VRMSpringBoneManager.ts
+++ b/src/vrm/springbone/VRMSpringBoneManager.ts
@@ -24,6 +24,19 @@ export class VRMSpringBoneManager {
   }
 
   /**
+   * Set all bones be calculated based on the space relative from this object.
+   * If `null` is given, springbone will be calculated in world space.
+   * @param root Root object, or `null`
+   */
+  public setRelativeRoot(root: THREE.Object3D | null): void {
+    this.springBoneGroupList.forEach((springBoneGroup) => {
+      springBoneGroup.forEach((springBone) => {
+        springBone.relativeRoot = root;
+      });
+    });
+  }
+
+  /**
    * Update every spring bone attached to this manager.
    *
    * @param delta deltaTime

--- a/src/vrm/springbone/VRMSpringBoneManager.ts
+++ b/src/vrm/springbone/VRMSpringBoneManager.ts
@@ -28,10 +28,10 @@ export class VRMSpringBoneManager {
    * If `null` is given, springbone will be calculated in world space.
    * @param root Root object, or `null`
    */
-  public setRelativeRoot(root: THREE.Object3D | null): void {
+  public setCenter(root: THREE.Object3D | null): void {
     this.springBoneGroupList.forEach((springBoneGroup) => {
       springBoneGroup.forEach((springBone) => {
-        springBone.relativeRoot = root;
+        springBone.center = root;
       });
     });
   }

--- a/src/vrm/utils/Matrix4WithInverseCache.ts
+++ b/src/vrm/utils/Matrix4WithInverseCache.ts
@@ -1,0 +1,188 @@
+import * as THREE from 'three';
+
+export class Matrix4WithInverseCache extends THREE.Matrix4 {
+  public constructor() {
+    super();
+  }
+
+  /**
+   * Inverse of this matrix.
+   * Note that it will return its internal private instance.
+   * Make sure copying this before mutate this.
+   */
+  public get inverse(): THREE.Matrix4 {
+    if (this._shouldUpdateInverse) {
+      this._inverseCache.getInverse(this);
+      this._shouldUpdateInverse = false;
+    }
+
+    return this._inverseCache;
+  }
+
+  /**
+   * A cache of inverse of current matrix.
+   */
+  private _inverseCache = new THREE.Matrix4();
+
+  /**
+   * A flag that makes it want to recalculate its {@link _inverseCache}.
+   * Will be set `true` when `elements` are mutated and be used in `getInverse`.
+   */
+  private _shouldUpdateInverse = false;
+
+  set(
+    n11: number,
+    n12: number,
+    n13: number,
+    n14: number,
+    n21: number,
+    n22: number,
+    n23: number,
+    n24: number,
+    n31: number,
+    n32: number,
+    n33: number,
+    n34: number,
+    n41: number,
+    n42: number,
+    n43: number,
+    n44: number,
+  ): this {
+    super.set(n11, n12, n13, n14, n21, n22, n23, n24, n31, n32, n33, n34, n41, n42, n43, n44);
+
+    this._shouldUpdateInverse = true;
+
+    return this;
+  }
+
+  /**
+   * Resets this matrix to identity.
+   */
+  identity(): this {
+    super.identity();
+
+    this._shouldUpdateInverse = true;
+
+    return this;
+  }
+
+  copy(m: THREE.Matrix4): this {
+    super.copy(m);
+
+    this._shouldUpdateInverse = true;
+
+    return this;
+  }
+
+  copyPosition(m: THREE.Matrix4): this {
+    super.copyPosition(m);
+
+    this._shouldUpdateInverse = true;
+
+    return this;
+  }
+
+  extractRotation(m: THREE.Matrix4): this {
+    super.extractRotation(m);
+
+    this._shouldUpdateInverse = true;
+
+    return this;
+  }
+
+  makeRotationFromEuler(euler: THREE.Euler): this {
+    super.makeRotationFromEuler(euler);
+
+    this._shouldUpdateInverse = true;
+
+    return this;
+  }
+
+  lookAt(eye: THREE.Vector3, target: THREE.Vector3, up: THREE.Vector3): this {
+    super.lookAt(eye, target, up);
+
+    this._shouldUpdateInverse = true;
+
+    return this;
+  }
+
+  multiplyMatrices(a: THREE.Matrix4, b: THREE.Matrix4): this {
+    super.multiplyMatrices(a, b);
+
+    this._shouldUpdateInverse = true;
+
+    return this;
+  }
+
+  multiplyScalar(s: number): this {
+    super.multiplyScalar(s);
+
+    this._shouldUpdateInverse = true;
+
+    return this;
+  }
+
+  transpose(): this {
+    super.transpose();
+
+    this._shouldUpdateInverse = true;
+
+    return this;
+  }
+
+  setPosition(v: THREE.Vector3 | number, y?: number, z?: number): this {
+    super.setPosition(v, y, z);
+
+    this._shouldUpdateInverse = true;
+
+    return this;
+  }
+
+  getInverse(m: THREE.Matrix4): this {
+    super.getInverse(m);
+
+    this._shouldUpdateInverse = true;
+
+    return this;
+  }
+
+  scale(v: THREE.Vector3): this {
+    super.scale(v);
+
+    this._shouldUpdateInverse = true;
+
+    return this;
+  }
+
+  compose(translation: THREE.Vector3, rotation: THREE.Quaternion, scale: THREE.Vector3): this {
+    super.compose(translation, rotation, scale);
+
+    this._shouldUpdateInverse = true;
+
+    return this;
+  }
+
+  makePerspective(fov: number, aspect: number, near: number, far: number): this {
+    super.makePerspective(fov, aspect, near, far);
+
+    this._shouldUpdateInverse = true;
+
+    return this;
+  }
+
+  makeOrthographic(left: number, right: number, top: number, bottom: number, near: number, far: number): this {
+    super.makeOrthographic(left, right, top, bottom, near, far);
+
+    this._shouldUpdateInverse = true;
+
+    return this;
+  }
+
+  fromArray(array: number[], offset?: number): this {
+    super.fromArray(array, offset);
+
+    this._shouldUpdateInverse = true;
+
+    return this;
+  }
+}


### PR DESCRIPTION
- "Center" feature is now functional as UniVRM
    - `center` is set for each spring bones, defines a space for the calculation of spring bones
- 🚨 It now deserializes `center` of spring bones
    - If you need the previous behavior, call `vrm.springBoneManager.setCenter(null)` after you import VRMs
