### PR TITLE
refactor (VRMSpringBone): Make most of constructor parameters an interface / make readonly parameters mutable

### DIFF
--- a/src/vrm/debug/VRMSpringBoneDebug.ts
+++ b/src/vrm/debug/VRMSpringBoneDebug.ts
@@ -1,23 +1,15 @@
 import * as THREE from 'three';
 import { VRMSpringBone } from '../springbone';
 import { VRM_GIZMO_RENDER_ORDER } from './VRMDebug';
+import { VRMSpringBoneParameters } from '../springbone/VRMSpringBoneParameters';
 
 const _v3A = new THREE.Vector3();
 
 export class VRMSpringBoneDebug extends VRMSpringBone {
   private _gizmo?: THREE.ArrowHelper;
 
-  constructor(
-    bone: THREE.Object3D,
-    radius: number,
-    stiffiness: number,
-    gravityDir: THREE.Vector3,
-    gravityPower: number,
-    dragForce: number,
-    colliders: THREE.Mesh[] = [],
-    center?: THREE.Object3D | null, // TODO: make it sane in next breaking update
-  ) {
-    super(bone, radius, stiffiness, gravityDir, gravityPower, dragForce, colliders, center);
+  constructor(bone: THREE.Object3D, params: VRMSpringBoneParameters) {
+    super(bone, params);
   }
 
   /**

--- a/src/vrm/debug/VRMSpringBoneImporterDebug.ts
+++ b/src/vrm/debug/VRMSpringBoneImporterDebug.ts
@@ -4,6 +4,7 @@ import { VRMSpringBoneImporter } from '../springbone/VRMSpringBoneImporter';
 import { VRMSpringBoneManagerDebug } from './VRMSpringBoneManagerDebug';
 import { VRMSchema } from '../types';
 import { VRMSpringBoneDebug } from './VRMSpringBoneDebug';
+import { VRMSpringBoneParameters } from '../springbone/VRMSpringBoneParameters';
 
 export class VRMSpringBoneImporterDebug extends VRMSpringBoneImporter {
   public async import(gltf: GLTF): Promise<VRMSpringBoneManagerDebug | null> {
@@ -23,16 +24,7 @@ export class VRMSpringBoneImporterDebug extends VRMSpringBoneImporter {
     return new VRMSpringBoneManagerDebug(colliderGroups, springBoneGroupList);
   }
 
-  protected _createSpringBone(
-    bone: THREE.Object3D,
-    hitRadius: number,
-    stiffiness: number,
-    gravityDir: THREE.Vector3,
-    gravityPower: number,
-    dragForce: number,
-    colliders: THREE.Mesh[] = [],
-    center?: THREE.Object3D | null, // TODO: make it sane in next breaking update
-  ): VRMSpringBoneDebug {
-    return new VRMSpringBoneDebug(bone, hitRadius, stiffiness, gravityDir, gravityPower, dragForce, colliders, center);
+  protected _createSpringBone(bone: THREE.Object3D, params: VRMSpringBoneParameters): VRMSpringBoneDebug {
+    return new VRMSpringBoneDebug(bone, params);
   }
 }

--- a/src/vrm/springbone/VRMSpringBoneImporter.ts
+++ b/src/vrm/springbone/VRMSpringBoneImporter.ts
@@ -4,6 +4,7 @@ import { GLTFNode, VRMSchema } from '../types';
 import { VRMSpringBone } from './VRMSpringBone';
 import { VRMSpringBoneColliderGroup, VRMSpringBoneColliderMesh } from './VRMSpringBoneColliderGroup';
 import { VRMSpringBoneGroup, VRMSpringBoneManager } from './VRMSpringBoneManager';
+import { VRMSpringBoneParameters } from './VRMSpringBoneParameters';
 
 const _v3A = new THREE.Vector3();
 
@@ -35,17 +36,8 @@ export class VRMSpringBoneImporter {
     return new VRMSpringBoneManager(colliderGroups, springBoneGroupList);
   }
 
-  protected _createSpringBone(
-    bone: THREE.Object3D,
-    hitRadius: number,
-    stiffiness: number,
-    gravityDir: THREE.Vector3,
-    gravityPower: number,
-    dragForce: number,
-    colliders: THREE.Mesh[] = [],
-    center?: THREE.Object3D | null, // TODO: make it sane in next breaking update
-  ): VRMSpringBone {
-    return new VRMSpringBone(bone, hitRadius, stiffiness, gravityDir, gravityPower, dragForce, colliders, center);
+  protected _createSpringBone(bone: THREE.Object3D, params: VRMSpringBoneParameters = {}): VRMSpringBone {
+    return new VRMSpringBone(bone, params);
   }
 
   protected async _importSpringBoneGroupList(
@@ -69,12 +61,13 @@ export class VRMSpringBoneImporter {
           vrmBoneGroup.dragForce === undefined ||
           vrmBoneGroup.hitRadius === undefined ||
           vrmBoneGroup.colliderGroups === undefined ||
-          vrmBoneGroup.bones === undefined
+          vrmBoneGroup.bones === undefined ||
+          vrmBoneGroup.center === undefined
         ) {
           return;
         }
 
-        const stiffiness = vrmBoneGroup.stiffiness;
+        const stiffnessForce = vrmBoneGroup.stiffiness;
         const gravityDir = new THREE.Vector3(
           vrmBoneGroup.gravityDir.x,
           vrmBoneGroup.gravityDir.y,
@@ -82,7 +75,7 @@ export class VRMSpringBoneImporter {
         );
         const gravityPower = vrmBoneGroup.gravityPower;
         const dragForce = vrmBoneGroup.dragForce;
-        const hitRadius = vrmBoneGroup.hitRadius;
+        const radius = vrmBoneGroup.hitRadius;
 
         const colliders: VRMSpringBoneColliderMesh[] = [];
         vrmBoneGroup.colliderGroups.forEach((colliderIndex) => {
@@ -96,7 +89,7 @@ export class VRMSpringBoneImporter {
             const springRootBone: GLTFNode = await gltf.parser.getDependency('node', nodeIndex);
 
             const center: GLTFNode =
-              vrmBoneGroup.center != null ? await gltf.parser.getDependency('node', vrmBoneGroup.center) : null;
+              vrmBoneGroup.center! !== -1 ? await gltf.parser.getDependency('node', vrmBoneGroup.center!) : null;
 
             // it's weird but there might be cases we can't find the root bone
             if (!springRootBone) {
@@ -104,16 +97,15 @@ export class VRMSpringBoneImporter {
             }
 
             springRootBone.traverse((bone) => {
-              const springBone = this._createSpringBone(
-                bone,
-                hitRadius,
-                stiffiness,
+              const springBone = this._createSpringBone(bone, {
+                radius,
+                stiffnessForce,
                 gravityDir,
                 gravityPower,
                 dragForce,
                 colliders,
                 center,
-              );
+              });
               springBoneGroup.push(springBone);
             });
           }),

--- a/src/vrm/springbone/VRMSpringBoneParameters.ts
+++ b/src/vrm/springbone/VRMSpringBoneParameters.ts
@@ -1,0 +1,9 @@
+export interface VRMSpringBoneParameters {
+  radius?: number;
+  stiffnessForce?: number;
+  gravityDir?: THREE.Vector3;
+  gravityPower?: number;
+  dragForce?: number;
+  colliders?: THREE.Mesh[];
+  center?: THREE.Object3D | null;
+}

--- a/src/vrm/springbone/index.ts
+++ b/src/vrm/springbone/index.ts
@@ -2,3 +2,4 @@ export * from './VRMSpringBone';
 export * from './VRMSpringBoneColliderGroup';
 export * from './VRMSpringBoneImporter';
 export * from './VRMSpringBoneManager';
+export * from './VRMSpringBoneParameters';


### PR DESCRIPTION
- 🚨 The interface of `new VRMSpringBone` has changed
    - Used to have so many arguments, now have one required argument and one optional parameters object ( `VRMSpringBoneParameters` )
- Most of members are now mutable
    - Since they don't have to be readonly
