### PR TITLE
Introducing VRMMeta, has an ability to load its thumbnail texture

### DIFF
--- a/examples/meta.html
+++ b/examples/meta.html
@@ -19,11 +19,17 @@
 				position: absolute;
 				background: #fff;
 			}
+			#thumbnail {
+				position: absolute;
+				top: 0;
+				right: 0;
+			}
 		</style>
 	</head>
 
 	<body>
 		<span id="meta"></span>
+		<img id="thumbnail" alt="thumbnail" />
 		<script src="https://unpkg.com/three@0.118.3/build/three.js"></script>
 		<script src="https://unpkg.com/three@0.118.3/examples/js/loaders/GLTFLoader.js"></script>
 		<script src="https://unpkg.com/three@0.118.3/examples/js/controls/OrbitControls.js"></script>
@@ -78,6 +84,14 @@
 						Object.keys( vrm.meta ).forEach( ( key ) => {
 
 							document.getElementById( 'meta' ).innerText += key + ' : ' + vrm.meta[ key ] + '\n';
+
+						} );
+
+						// show thumbnail
+						THREE.VRMUtils.extractThumbnailBlob( renderer, vrm, 256 ).then( ( blob ) => {
+
+							const url = URL.createObjectURL( blob );
+							document.getElementById( 'thumbnail' ).src = url;
 
 						} );
 

--- a/src/vrm/VRM.ts
+++ b/src/vrm/VRM.ts
@@ -156,5 +156,7 @@ export class VRM {
     if (scene) {
       deepDispose(scene);
     }
+
+    this.meta?.texture?.dispose();
   }
 }

--- a/src/vrm/VRM.ts
+++ b/src/vrm/VRM.ts
@@ -4,8 +4,8 @@ import { VRMBlendShapeProxy } from './blendshape';
 import { VRMFirstPerson } from './firstperson';
 import { VRMHumanoid } from './humanoid';
 import { VRMLookAtHead } from './lookat';
+import { VRMMeta } from './meta/VRMMeta';
 import { VRMSpringBoneManager } from './springbone';
-import { VRMSchema } from './types';
 import { deepDispose } from './utils/disposer';
 import { VRMImporter, VRMImporterOptions } from './VRMImporter';
 
@@ -20,7 +20,7 @@ export interface VRMParameters {
   lookAt?: VRMLookAtHead;
   materials?: THREE.Material[];
   springBoneManager?: VRMSpringBoneManager;
-  meta?: VRMSchema.Meta;
+  meta?: VRMMeta;
 }
 
 /**
@@ -95,7 +95,7 @@ export class VRM {
    * Contains meta fields of the VRM.
    * You might want to refer these license fields before use your VRMs.
    */
-  public readonly meta?: VRMSchema.Meta;
+  public readonly meta?: VRMMeta;
 
   /**
    * A [[VRMSpringBoneManager]] manipulates all spring bones attached on the VRM.

--- a/src/vrm/VRMUtils/extractThumbnailBlob.ts
+++ b/src/vrm/VRMUtils/extractThumbnailBlob.ts
@@ -1,0 +1,55 @@
+import * as THREE from 'three';
+import { VRM } from '../VRM';
+
+const _v2A = new THREE.Vector2();
+
+const _camera = new THREE.OrthographicCamera(-1, 1, -1, 1, -1, 1);
+const _plane = new THREE.Mesh(
+  new THREE.PlaneBufferGeometry(2, 2),
+  new THREE.MeshBasicMaterial({ color: 0xffffff, side: THREE.DoubleSide }),
+);
+const _scene = new THREE.Scene();
+_scene.add(_plane);
+
+/**
+ * Extract a thumbnail image blob from a {@link VRM}.
+ * If the vrm does not have a thumbnail, it will throw an error.
+ * @param renderer Renderer
+ * @param vrm VRM with a thumbnail
+ * @param size width / height of the image
+ */
+export function extractThumbnailBlob(renderer: THREE.WebGLRenderer, vrm: VRM, size = 512): Promise<Blob> {
+  // get the texture
+  const texture = vrm.meta?.texture;
+  if (!texture) {
+    throw new Error('extractThumbnailBlob: This VRM does not have a thumbnail');
+  }
+
+  // store the current resolution
+  renderer.getSize(_v2A);
+  const prevWidth = _v2A.x;
+  const prevHeight = _v2A.y;
+
+  // overwrite the resolution
+  renderer.setSize(size, size);
+
+  // assign the texture to plane
+  _plane.material.map = texture;
+
+  // render
+  renderer.render(_scene, _camera);
+
+  // get blob
+  return new Promise((resolve, reject) => {
+    (renderer.getContext().canvas as HTMLCanvasElement).toBlob((blob) => {
+      // revert to previous resolution
+      renderer.setSize(prevWidth, prevHeight);
+
+      if (blob == null) {
+        reject('extractThumbnailBlob: Failed to create a blob');
+      } else {
+        resolve(blob);
+      }
+    });
+  });
+}

--- a/src/vrm/VRMUtils/index.ts
+++ b/src/vrm/VRMUtils/index.ts
@@ -1,3 +1,4 @@
+import { extractThumbnailBlob } from './extractThumbnailBlob';
 import { removeUnnecessaryJoints } from './removeUnnecessaryJoints';
 
 export class VRMUtils {
@@ -5,5 +6,6 @@ export class VRMUtils {
     // this class is not meant to be instantiated
   }
 
+  public static extractThumbnailBlob = extractThumbnailBlob;
   public static removeUnnecessaryJoints = removeUnnecessaryJoints;
 }

--- a/src/vrm/meta/VRMMeta.ts
+++ b/src/vrm/meta/VRMMeta.ts
@@ -1,0 +1,72 @@
+import * as THREE from 'three';
+import { VRMSchema } from '../types';
+
+/**
+ * Interface represents metadata of a VRM.
+ */
+export interface VRMMeta {
+  /**
+   * Enum indicates a condition who can perform with this avatar.
+   */
+  allowedUserName?: VRMSchema.MetaAllowedUserName;
+
+  /**
+   * Author of the model.
+   */
+  author?: string;
+
+  /**
+   * Enum indicates allow or disallow commercial use.
+   */
+  commercialUssageName?: VRMSchema.MetaUssageName;
+
+  /**
+   * Contact Information of its author.
+   */
+  contactInformation?: string;
+
+  /**
+   * Enum indicates a license type.
+   */
+  licenseName?: VRMSchema.MetaLicenseName;
+
+  /**
+   * If `Other` is selected for {@link licenseName}, put the URL link of the license document here.
+   */
+  otherLicenseUrl?: string;
+
+  /**
+   * If there are any conditions not mentioned in {@link licenseName} or {@link otherLicenseUrl}, put the URL link of the license document here.
+   */
+  otherPermissionUrl?: string;
+
+  /**
+   * Reference of the model.
+   */
+  reference?: string;
+
+  /**
+   * Enum indicates allow or disallow sexual expressions.
+   */
+  sexualUssageName?: VRMSchema.MetaUssageName;
+
+  /**
+   * Thumbnail of the model.
+   */
+  texture?: THREE.Texture;
+
+  /**
+   * Title of the model.
+   */
+  title?: string;
+
+  /**
+   * Version of the model.
+   */
+  version?: string;
+
+  /**
+   * Enum indicates allow or disallow violent expressions.
+   */
+  violentUssageName?: VRMSchema.MetaUssageName;
+}

--- a/src/vrm/meta/VRMMetaImporter.ts
+++ b/src/vrm/meta/VRMMetaImporter.ts
@@ -1,11 +1,22 @@
+import * as THREE from 'three';
 import { VRMSchema } from '../types';
 import { GLTF } from 'three/examples/jsm/loaders/GLTFLoader';
 import { VRMMeta } from './VRMMeta';
+import { VRMMetaImporterOptions } from './VRMMetaImporterOptions';
 
 /**
  * An importer that imports a {@link VRMMeta} from a VRM extension of a GLTF.
  */
 export class VRMMetaImporter {
+  /**
+   * If `true`, it won't load its thumbnail texture ({@link VRMMeta.texture}). `false` by default.
+   */
+  public ignoreTexture: boolean;
+
+  constructor(options: VRMMetaImporterOptions) {
+    this.ignoreTexture = options.ignoreTexture ?? false;
+  }
+
   public async import(gltf: GLTF): Promise<VRMMeta | null> {
     const vrmExt: VRMSchema.VRM | undefined = gltf.parser.json.extensions?.VRM;
     if (!vrmExt) {
@@ -17,10 +28,10 @@ export class VRMMetaImporter {
       return null;
     }
 
-    const texture =
-      schemaMeta.texture != null && schemaMeta.texture !== -1
-        ? await gltf.parser.getDependency('texture', schemaMeta.texture)
-        : null;
+    let texture: THREE.Texture | null | undefined;
+    if (!this.ignoreTexture && schemaMeta.texture != null && schemaMeta.texture !== -1) {
+      texture = await gltf.parser.getDependency('texture', schemaMeta.texture);
+    }
 
     return {
       allowedUserName: schemaMeta.allowedUserName,

--- a/src/vrm/meta/VRMMetaImporter.ts
+++ b/src/vrm/meta/VRMMetaImporter.ts
@@ -13,8 +13,8 @@ export class VRMMetaImporter {
    */
   public ignoreTexture: boolean;
 
-  constructor(options: VRMMetaImporterOptions) {
-    this.ignoreTexture = options.ignoreTexture ?? false;
+  constructor(options?: VRMMetaImporterOptions) {
+    this.ignoreTexture = options?.ignoreTexture ?? false;
   }
 
   public async import(gltf: GLTF): Promise<VRMMeta | null> {

--- a/src/vrm/meta/VRMMetaImporter.ts
+++ b/src/vrm/meta/VRMMetaImporter.ts
@@ -1,0 +1,41 @@
+import { VRMSchema } from '../types';
+import { GLTF } from 'three/examples/jsm/loaders/GLTFLoader';
+import { VRMMeta } from './VRMMeta';
+
+/**
+ * An importer that imports a {@link VRMMeta} from a VRM extension of a GLTF.
+ */
+export class VRMMetaImporter {
+  public async import(gltf: GLTF): Promise<VRMMeta | null> {
+    const vrmExt: VRMSchema.VRM | undefined = gltf.parser.json.extensions?.VRM;
+    if (!vrmExt) {
+      return null;
+    }
+
+    const schemaMeta: VRMSchema.Meta | undefined = vrmExt.meta;
+    if (!schemaMeta) {
+      return null;
+    }
+
+    const texture =
+      schemaMeta.texture != null && schemaMeta.texture !== -1
+        ? await gltf.parser.getDependency('texture', schemaMeta.texture)
+        : null;
+
+    return {
+      allowedUserName: schemaMeta.allowedUserName,
+      author: schemaMeta.author,
+      commercialUssageName: schemaMeta.commercialUssageName,
+      contactInformation: schemaMeta.contactInformation,
+      licenseName: schemaMeta.licenseName,
+      otherLicenseUrl: schemaMeta.otherLicenseUrl,
+      otherPermissionUrl: schemaMeta.otherPermissionUrl,
+      reference: schemaMeta.reference,
+      sexualUssageName: schemaMeta.sexualUssageName,
+      texture: texture ?? undefined,
+      title: schemaMeta.title,
+      version: schemaMeta.version,
+      violentUssageName: schemaMeta.violentUssageName,
+    };
+  }
+}

--- a/src/vrm/meta/VRMMetaImporterOptions.ts
+++ b/src/vrm/meta/VRMMetaImporterOptions.ts
@@ -1,0 +1,9 @@
+/**
+ * Options for a {@link VRMMetaImporter} instance.
+ */
+export interface VRMMetaImporterOptions {
+  /**
+   * If `true`, it won't load its thumbnail texture ({@link VRMMeta.texture}). `false` by default.
+   */
+  ignoreTexture?: boolean;
+}


### PR DESCRIPTION
- `vrm.meta` is now an interface `VRMMeta` instead of `VRMSchema.Meta`
- 🚨 Interface of `vrm.meta.texture` has been changed (`number` -> `THREE.Texture`)
- 🚨 Importing a VRM from a glTF now loads a thumbnail texture by default!
    - Which may cause you unnecessary memory consumption
    - Set `VRMMetaImporter.ignoreTexture = true` to disable this behavior
- ✨ now you can extract thumbnail as a Blob using `VRMUtils.extractThumbnailBlob(renderer, vrm, resolution)`
    - See the `meta.html` example
