### PR TITLE
fix (VRMUtils.extractThumbnailBlob): forgot to unassign the texture

### DIFF
--- a/src/vrm/VRMUtils/extractThumbnailBlob.ts
+++ b/src/vrm/VRMUtils/extractThumbnailBlob.ts
@@ -39,6 +39,9 @@ export function extractThumbnailBlob(renderer: THREE.WebGLRenderer, vrm: VRM, si
   // render
   renderer.render(_scene, _camera);
 
+  // unassign the texture
+  _plane.material.map = null;
+
   // get blob
   return new Promise((resolve, reject) => {
     (renderer.getContext().canvas as HTMLCanvasElement).toBlob((blob) => {


### PR DESCRIPTION
Sequel of #482 

Texture should be unassigned after the rendering
