### PR TITLE
`VRMBlendShapeProxy._blendShapeGroups` was unintentionally public

### DIFF
--- a/src/vrm/blendshape/VRMBlendShapeProxy.ts
+++ b/src/vrm/blendshape/VRMBlendShapeProxy.ts
@@ -6,7 +6,7 @@ export class VRMBlendShapeProxy {
   /**
    * List of registered blend shape.
    */
-  public readonly _blendShapeGroups: { [name: string]: VRMBlendShapeGroup } = {};
+  private readonly _blendShapeGroups: { [name: string]: VRMBlendShapeGroup } = {};
 
   /**
    * A map from [[VRMSchema.BlendShapePresetName]] to its actual blend shape name.


### PR DESCRIPTION
I hope no one directly uses it...
