### PR TITLE
add getter for presetNameMap

### DIFF
--- a/src/vrm/blendshape/VRMBlendShapeProxy.ts
+++ b/src/vrm/blendshape/VRMBlendShapeProxy.ts
@@ -28,6 +28,13 @@ export class VRMBlendShapeProxy {
   }
 
   /**
+   * A map from [[VRMSchema.BlendShapePresetName]] to its actual blend shape name.
+   */
+  public get blendShapePresetMap(): { [presetName in VRMSchema.BlendShapePresetName]?: string } {
+    return this._blendShapePresetMap;
+  }
+
+  /**
    * Return registered blend shape group.
    *
    * @param name Name of the blend shape group


### PR DESCRIPTION
VRMBlendShapeProxy へ _blendShapePresetMap の Getter の追加を提案します。

現状のVRMBlendShapeProxy.expressionsにはVRMの仕様で定義されているPresetNameではなく、ユーザーが設定するNameが格納されているためリップシンクなどの表情(A,Joy等)とその他(Unknown)の表情を区別することができません。

VRMBlendShapeProxy._blendShapePresetMapを参照することでユーザー定義の表情を区別することができるようになります。

```js
// unknownの表情の取得
 const expressions = currentVrm.blendShapeProxy.expressions;
 const presetMap = currentVrm.blendShapeProxy.blendShapePresetMap;
 const presetExpressions = Object.values(presetMap);
 const unknownExpressions = expressions.filter(name =>
 	!presetExpressions.includes(name)
 );
```