### PR TITLE
fix (humanoid): getPose / setPose is now working as intended

### DIFF
--- a/src/vrm/humanoid/VRMHumanoid.ts
+++ b/src/vrm/humanoid/VRMHumanoid.ts
@@ -130,6 +130,13 @@ export class VRMHumanoid {
   }
 
   /**
+   * Reset the humanoid to its rest pose.
+   */
+  public resetPose(): void {
+    this.setPose({});
+  }
+
+  /**
    * Return a bone bound to a specified [[HumanBone]], as a [[VRMHumanBone]].
    *
    * See also: [[VRMHumanoid.getBones]]

--- a/src/vrm/humanoid/VRMHumanoid.ts
+++ b/src/vrm/humanoid/VRMHumanoid.ts
@@ -27,7 +27,7 @@ export class VRMHumanoid {
    * A [[VRMPose]] that is its default state.
    * Note that it's not compatible with `setPose` and `getPose`, since it contains non-relative values of each local transforms.
    */
-  private readonly _restPose: VRMPose = {};
+  public readonly restPose: VRMPose = {};
 
   /**
    * Create a new [[VRMHumanoid]].
@@ -38,7 +38,7 @@ export class VRMHumanoid {
     this.humanBones = this._createHumanBones(boneArray);
     this.humanDescription = humanDescription;
 
-    this._restPose = this.getPose();
+    this.restPose = this.getPose();
   }
 
   /**
@@ -64,7 +64,7 @@ export class VRMHumanoid {
       _v3A.set(0, 0, 0);
       _quatA.identity();
 
-      const restState = this._restPose[vrmBoneName];
+      const restState = this.restPose[vrmBoneName];
       if (restState?.position) {
         _v3A.fromArray(restState.position).negate();
       }
@@ -106,7 +106,7 @@ export class VRMHumanoid {
         return;
       }
 
-      const restState = this._restPose[boneName];
+      const restState = this.restPose[boneName];
       if (!restState) {
         return;
       }

--- a/src/vrm/humanoid/VRMHumanoid.ts
+++ b/src/vrm/humanoid/VRMHumanoid.ts
@@ -43,6 +43,8 @@ export class VRMHumanoid {
 
   /**
    * Return the current pose of this humanoid as a [[VRMPose]].
+   *
+   * Each transform is a local transform relative from rest pose (T-pose).
    */
   public getPose(): VRMPose {
     const pose: VRMPose = {};
@@ -93,6 +95,9 @@ export class VRMHumanoid {
 
   /**
    * Let the humanoid do a specified pose.
+   *
+   * Each transform have to be a local transform relative from rest pose (T-pose).
+   * You can pass what you got from {@link getPose}.
    *
    * @param poseObject A [[VRMPose]] that represents a single pose
    */

--- a/src/vrm/humanoid/VRMHumanoid.ts
+++ b/src/vrm/humanoid/VRMHumanoid.ts
@@ -74,13 +74,6 @@ export class VRMHumanoid {
         _quatA.fromArray(restState.rotation).inverse();
       }
 
-      // 🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥🔥
-      if (!restState) {
-        if (vrmBoneName === VRMSchema.HumanoidBoneName.LeftUpperArm) {
-          node.rotation.x = 0.5 * Math.PI;
-        }
-      }
-
       // Get the position / rotation from the node
       _v3A.add(node.position);
       _quatA.premultiply(node.quaternion);


### PR DESCRIPTION
Should resolve #503 

- 🚨💡 Greatly changed the behavior of `getPose` / `setPose`
    - It now explicitly receives / returns local, relative transforms that is described in `VRMPose`
- ✨ New method: `resetPose`
    - It just resets the pose to its restPose (that should be T stance)
- 🚨💡 `restPose` is now explicitly not compatible with `getPose` / `setPose`
    - If you want to reset its pose, I have introduced `resetPose` so use this instead
