### PR TITLE
chore: remove removeComments setting from tsconfig

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,7 +6,6 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "declaration": true,
-    "removeComments": true,
     "strict": true
   }
 }


### PR DESCRIPTION
Since `removeComments` was enabled in tsconfig, there were no doc comments on built typedef at all. This PR fixes this.