### PR TITLE
chore: fix monorepo precommit

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,11 +12,17 @@
     "lint-fix": "lerna run lint-fix",
     "docs": "lerna run docs"
   },
+  "husky": {
+    "hooks": {
+      "pre-commit": "yarn lerna exec yarn lint-staged"
+    }
+  },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^4.6.1",
     "@typescript-eslint/parser": "^4.6.1",
     "eslint": "^7.12.1",
     "eslint-config-prettier": "^6.15.0",
+    "husky": "^4.3.0",
     "lerna": "^3.22.1",
     "prettier": "^2.1.2",
     "rimraf": "^3.0.2",

--- a/packages/three-vrm/package.json
+++ b/packages/three-vrm/package.json
@@ -43,8 +43,7 @@
   "lint-staged": {
     "./src/**/*.{ts,tsx}": [
       "eslint --fix",
-      "prettier --write",
-      "git add"
+      "prettier --write"
     ]
   },
   "devDependencies": {

--- a/packages/three-vrm/package.json
+++ b/packages/three-vrm/package.json
@@ -40,13 +40,8 @@
     "lint-fix": "eslint \"src/**/*.{ts,tsx}\" --fix && prettier \"src/**/*.{ts,tsx}\" --write",
     "typedefgen": "node ./bin/typedefgen.js"
   },
-  "husky": {
-    "hooks": {
-      "pre-commit": "lint-staged"
-    }
-  },
   "lint-staged": {
-    "src/**/*.{ts,tsx}": [
+    "./src/**/*.{ts,tsx}": [
       "eslint --fix",
       "prettier --write",
       "git add"
@@ -59,7 +54,6 @@
     "downlevel-dts": "^0.6.0",
     "fork-ts-checker-webpack-plugin": "^4.1.4",
     "gh-pages": "^3.1.0",
-    "husky": "^4.3.0",
     "lint-staged": "10.4.2",
     "quicktype": "^15.0.258",
     "raw-loader": "^4.0.1",


### PR DESCRIPTION
precommit job (husky + lint-staged) was not working properly after monorepo #521 happened, this PR fixes this.