### PR TITLE
Bump Three.js to r123

### DIFF
--- a/packages/three-vrm/examples/animations.html
+++ b/packages/three-vrm/examples/animations.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.120.1/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.120.1/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.120.1/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.123.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.123.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.123.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/basic.html
+++ b/packages/three-vrm/examples/basic.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.120.1/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.120.1/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.120.1/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.123.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.123.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.123.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/blendshapes.html
+++ b/packages/three-vrm/examples/blendshapes.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.120.1/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.120.1/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.120.1/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.123.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.123.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.123.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/bones.html
+++ b/packages/three-vrm/examples/bones.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.120.1/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.120.1/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.120.1/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.123.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.123.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.123.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/debug.html
+++ b/packages/three-vrm/examples/debug.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.120.1/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.120.1/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.120.1/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.123.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.123.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.123.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/dnd.html
+++ b/packages/three-vrm/examples/dnd.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.120.1/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.120.1/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.120.1/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.123.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.123.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.123.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/encoding.html
+++ b/packages/three-vrm/examples/encoding.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.120.1/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.120.1/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.120.1/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.123.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.123.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.123.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/envmap.html
+++ b/packages/three-vrm/examples/envmap.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.120.1/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.120.1/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.120.1/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.123.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.123.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.123.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/firstperson.html
+++ b/packages/three-vrm/examples/firstperson.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.120.1/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.120.1/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.120.1/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.123.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.123.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.123.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/lookat-advanced.html
+++ b/packages/three-vrm/examples/lookat-advanced.html
@@ -21,9 +21,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.120.1/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.120.1/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.120.1/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.123.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.123.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.123.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			const _v3A = new THREE.Vector3();

--- a/packages/three-vrm/examples/lookat.html
+++ b/packages/three-vrm/examples/lookat.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.120.1/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.120.1/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.120.1/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.123.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.123.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.123.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/materials-debug.html
+++ b/packages/three-vrm/examples/materials-debug.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.120.1/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.120.1/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.120.1/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.123.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.123.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.123.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/meta.html
+++ b/packages/three-vrm/examples/meta.html
@@ -30,9 +30,9 @@
 	<body>
 		<span id="meta"></span>
 		<img id="thumbnail" alt="thumbnail" />
-		<script src="https://unpkg.com/three@0.120.1/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.120.1/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.120.1/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.123.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.123.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.123.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/mouse.html
+++ b/packages/three-vrm/examples/mouse.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.120.1/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.120.1/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.120.1/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.123.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.123.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.123.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/package.json
+++ b/packages/three-vrm/package.json
@@ -56,7 +56,7 @@
     "lint-staged": "10.4.2",
     "quicktype": "^15.0.258",
     "raw-loader": "^4.0.1",
-    "three": "^0.120.1",
+    "three": "^0.123.0",
     "ts-loader": "^6.1.0",
     "ts-node": "^8.4.1",
     "typedoc": "^0.19.2",
@@ -67,6 +67,6 @@
     "worker-loader": "^2.0.0"
   },
   "peerDependencies": {
-    "three": "^0.120.1"
+    "three": "^0.123.0"
   }
 }

--- a/packages/three-vrm/src/vrm/springbone/VRMSpringBone.ts
+++ b/packages/three-vrm/src/vrm/springbone/VRMSpringBone.ts
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import { mat4InvertCompat } from '../utils/mat4InvertCompat';
 import { getWorldQuaternionLite } from '../utils/math';
 import { Matrix4InverseCache } from '../utils/Matrix4InverseCache';
 import { VRMSpringBoneColliderMesh } from './VRMSpringBoneColliderGroup';
@@ -302,7 +303,7 @@ export class VRMSpringBone {
     // Apply rotation, convert vector3 thing into actual quaternion
     // Original UniVRM is doing world unit calculus at here but we're gonna do this on local unit
     // since Three.js is not good at world coordination stuff
-    const initialCenterSpaceMatrixInv = _matA.getInverse(_matB.multiply(this._initialLocalMatrix));
+    const initialCenterSpaceMatrixInv = mat4InvertCompat(_matA.copy(_matB.multiply(this._initialLocalMatrix)));
     const applyRotation = _quatA.setFromUnitVectors(
       this._boneAxis,
       _v3A.copy(this._nextTail).applyMatrix4(initialCenterSpaceMatrixInv).normalize(),

--- a/packages/three-vrm/src/vrm/utils/Matrix4InverseCache.ts
+++ b/packages/three-vrm/src/vrm/utils/Matrix4InverseCache.ts
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import { mat4InvertCompat } from './mat4InvertCompat';
 
 export class Matrix4InverseCache {
   /**
@@ -29,7 +30,7 @@ export class Matrix4InverseCache {
    */
   public get inverse(): THREE.Matrix4 {
     if (this._shouldUpdateInverse) {
-      this._inverseCache.getInverse(this.matrix);
+      mat4InvertCompat(this._inverseCache.copy(this.matrix));
       this._shouldUpdateInverse = false;
     }
 

--- a/packages/three-vrm/src/vrm/utils/mat4InvertCompat.ts
+++ b/packages/three-vrm/src/vrm/utils/mat4InvertCompat.ts
@@ -1,0 +1,19 @@
+import * as THREE from 'three';
+
+const _matA = new THREE.Matrix4();
+
+/**
+ * A compat function for `Matrix4.invert()` / `Matrix4.getInverse()`.
+ * `Matrix4.invert()` is introduced in r123 and `Matrix4.getInverse()` emits a warning.
+ * We are going to use this compat for a while.
+ * @param target A target matrix
+ */
+export function mat4InvertCompat<T extends THREE.Matrix4>(target: T): T {
+  if ((target as any).invert) {
+    target.invert();
+  } else {
+    (target as any).getInverse(_matA.copy(target));
+  }
+
+  return target;
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -8274,10 +8274,10 @@ thenify-all@^1.0.0:
   dependencies:
     any-promise "^1.0.0"
 
-three@^0.120.1:
-  version "0.120.1"
-  resolved "https://registry.yarnpkg.com/three/-/three-0.120.1.tgz#dbd8894f8ab87c109f1602933e7c740c98137377"
-  integrity sha512-ktaCRFUR7JUZcKec+cBRz+oBex5pOVaJhrtxvFF2T7on53o9UkEux+/Nh1g/4zeb4t/pbxIFcADbn/ACu3LC1g==
+three@^0.123.0:
+  version "0.123.0"
+  resolved "https://registry.yarnpkg.com/three/-/three-0.123.0.tgz#3bb6d8f908a432eb7cd450f7eab6dd40fde53085"
+  integrity sha512-KNnx/IbilvoHRkxOtL0ouozoDoElyuvAXhFB21RK7F5IPWSmqyFelICK6x3hJerLNSlAdHxR0hkuvMMhH9pqXg==
 
 through2@^2.0.0, through2@^2.0.2, through2@~2.0.3:
   version "2.0.5"


### PR DESCRIPTION
- 📦 Bump three.js to r123
    - Had to replace `Matrix4.getInverse()` with `Matrix4.invert()`
        - See: https://github.com/mrdoob/three.js/pull/20611
        - Compat is implemented though, I believe it will still work properly in previous versions
