### PR TITLE
fix: replace deprecated `Quaterion.inverse` with `invert`

### DIFF
--- a/packages/three-vrm/src/vrm/humanoid/VRMHumanoid.ts
+++ b/packages/three-vrm/src/vrm/humanoid/VRMHumanoid.ts
@@ -71,7 +71,7 @@ export class VRMHumanoid {
         _v3A.fromArray(restState.position).negate();
       }
       if (restState?.rotation) {
-        _quatA.fromArray(restState.rotation).inverse();
+        _quatA.fromArray(restState.rotation).invert();
       }
 
       // Get the position / rotation from the node

--- a/packages/three-vrm/src/vrm/lookat/VRMLookAtHead.ts
+++ b/packages/three-vrm/src/vrm/lookat/VRMLookAtHead.ts
@@ -99,7 +99,7 @@ export class VRMLookAtHead {
     const lookAtDir = _v3C.copy(position).sub(headPosition).normalize();
 
     // Transform the direction into local coordinate from the first person bone
-    lookAtDir.applyQuaternion(getWorldQuaternionLite(this.firstPerson.firstPersonBone, _quat).inverse());
+    lookAtDir.applyQuaternion(getWorldQuaternionLite(this.firstPerson.firstPersonBone, _quat).invert());
 
     // convert the direction into euler
     target.x = Math.atan2(lookAtDir.y, Math.sqrt(lookAtDir.x * lookAtDir.x + lookAtDir.z * lookAtDir.z));


### PR DESCRIPTION
Sequel of #551 
I've replaced `Matrix4.getInverse()` but forgot replacing `Quaternion.inverse()`
