### PR TITLE
Implement compat of `Quaternion.invert` for previous versions of Three.js

### DIFF
--- a/packages/three-vrm/src/vrm/humanoid/VRMHumanoid.ts
+++ b/packages/three-vrm/src/vrm/humanoid/VRMHumanoid.ts
@@ -1,5 +1,6 @@
 import * as THREE from 'three';
 import { GLTFNode, RawVector3, RawVector4, VRMPose, VRMSchema } from '../types';
+import { quatInvertCompat } from '../utils/quatInvertCompat';
 import { VRMHumanBone } from './VRMHumanBone';
 import { VRMHumanBoneArray } from './VRMHumanBoneArray';
 import { VRMHumanBones } from './VRMHumanBones';
@@ -71,7 +72,7 @@ export class VRMHumanoid {
         _v3A.fromArray(restState.position).negate();
       }
       if (restState?.rotation) {
-        _quatA.fromArray(restState.rotation).invert();
+        quatInvertCompat(_quatA.fromArray(restState.rotation));
       }
 
       // Get the position / rotation from the node

--- a/packages/three-vrm/src/vrm/lookat/VRMLookAtHead.ts
+++ b/packages/three-vrm/src/vrm/lookat/VRMLookAtHead.ts
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 import { VRMFirstPerson } from '../firstperson/VRMFirstPerson';
 import { getWorldQuaternionLite } from '../utils/math';
+import { quatInvertCompat } from '../utils/quatInvertCompat';
 import { VRMLookAtApplyer } from './VRMLookAtApplyer';
 
 const VECTOR3_FRONT = Object.freeze(new THREE.Vector3(0.0, 0.0, -1.0));
@@ -99,7 +100,7 @@ export class VRMLookAtHead {
     const lookAtDir = _v3C.copy(position).sub(headPosition).normalize();
 
     // Transform the direction into local coordinate from the first person bone
-    lookAtDir.applyQuaternion(getWorldQuaternionLite(this.firstPerson.firstPersonBone, _quat).invert());
+    lookAtDir.applyQuaternion(quatInvertCompat(getWorldQuaternionLite(this.firstPerson.firstPersonBone, _quat)));
 
     // convert the direction into euler
     target.x = Math.atan2(lookAtDir.y, Math.sqrt(lookAtDir.x * lookAtDir.x + lookAtDir.z * lookAtDir.z));

--- a/packages/three-vrm/src/vrm/utils/quatInvertCompat.ts
+++ b/packages/three-vrm/src/vrm/utils/quatInvertCompat.ts
@@ -1,0 +1,17 @@
+import * as THREE from 'three';
+
+/**
+ * A compat function for `Quaternion.invert()` / `Quaternion.inverse()`.
+ * `Quaternion.invert()` is introduced in r123 and `Quaternion.inverse()` emits a warning.
+ * We are going to use this compat for a while.
+ * @param target A target quaternion
+ */
+export function quatInvertCompat<T extends THREE.Quaternion>(target: T): T {
+  if ((target as any).invert) {
+    target.invert();
+  } else {
+    (target as any).inverse();
+  }
+
+  return target;
+}


### PR DESCRIPTION
Sequel of #555 
`Quaternion.invert` won't work with previous versions of Three.js, I've implemented a compat function
