### PR TITLE
Fix human bone assignment failure for gltf nodes[0]

### DIFF
--- a/packages/three-vrm/src/vrm/humanoid/VRMHumanoidImporter.ts
+++ b/packages/three-vrm/src/vrm/humanoid/VRMHumanoidImporter.ts
@@ -30,7 +30,7 @@ export class VRMHumanoidImporter {
     if (schemaHumanoid.humanBones) {
       await Promise.all(
         schemaHumanoid.humanBones.map(async (bone) => {
-          if (!bone.bone || !bone.node) {
+          if (!bone.bone || typeof bone.node !== 'number') {
             return;
           }
 

--- a/packages/three-vrm/src/vrm/humanoid/VRMHumanoidImporter.ts
+++ b/packages/three-vrm/src/vrm/humanoid/VRMHumanoidImporter.ts
@@ -30,7 +30,7 @@ export class VRMHumanoidImporter {
     if (schemaHumanoid.humanBones) {
       await Promise.all(
         schemaHumanoid.humanBones.map(async (bone) => {
-          if (!bone.bone || typeof bone.node !== 'number') {
+          if (!bone.bone || bone.node == null) {
             return;
           }
 


### PR DESCRIPTION
`VRMHumanoidImporter.import()`  assigns VRM Humanoid bone name to glTF node. But glTF node with its index of zero is unexpectedly excluded from that assignment.