### PR TITLE
MToon: add a missing line to MToon Shader

### DIFF
--- a/packages/three-vrm/src/vrm/material/shaders/mtoon.frag
+++ b/packages/three-vrm/src/vrm/material/shaders/mtoon.frag
@@ -456,6 +456,9 @@ void main() {
 
   vec3 col = reflectedLight.directDiffuse + reflectedLight.indirectDiffuse;
 
+  // The "comment out if you want to PBR absolutely" line
+  col = min(col, lit);
+
   #if defined( OUTLINE ) && defined( OUTLINE_COLOR_MIXED )
     gl_FragColor = vec4(
       outlineColor.rgb * mix( vec3( 1.0 ), col, outlineLightingMix ),


### PR DESCRIPTION
Because of the missing line the behavior of MToon is being slightly wrong. This PR fixes this.

The equivalent line in the original MToon: https://github.com/Santarh/MToon/blob/master/MToon/Resources/Shaders/MToonCore.cginc#L218
