### PR TITLE
Materials: KeywordMap is now okay to be null

### DIFF
--- a/packages/three-vrm/src/vrm/material/VRMMaterialImporter.ts
+++ b/packages/three-vrm/src/vrm/material/VRMMaterialImporter.ts
@@ -338,7 +338,7 @@ export class VRMMaterialImporter {
     }
 
     // TODO: f (https://github.com/dwango/UniVRM/issues/172)
-    if (vrmProps.keywordMap!._ALPHATEST_ON && params.blendMode === MToonMaterialRenderMode.Opaque) {
+    if (vrmProps.keywordMap?._ALPHATEST_ON && params.blendMode === MToonMaterialRenderMode.Opaque) {
       params.blendMode = MToonMaterialRenderMode.Cutout;
     }
 

--- a/packages/three-vrm/src/vrm/material/VRMMaterialImporter.ts
+++ b/packages/three-vrm/src/vrm/material/VRMMaterialImporter.ts
@@ -1,7 +1,7 @@
 import * as THREE from 'three';
 import { GLTF } from 'three/examples/jsm/loaders/GLTFLoader';
 import { GLTFMesh, GLTFPrimitive, GLTFSchema, VRMSchema } from '../types';
-import { MToonMaterial, MToonMaterialOutlineWidthMode, MToonMaterialRenderMode } from './MToonMaterial';
+import { MToonMaterial, MToonMaterialOutlineWidthMode } from './MToonMaterial';
 import { VRMUnlitMaterial, VRMUnlitMaterialRenderType } from './VRMUnlitMaterial';
 
 /**
@@ -335,11 +335,6 @@ export class VRMMaterialImporter {
 
         params[newName] = new THREE.Vector4(...vrmProps.vectorProperties[name]);
       }
-    }
-
-    // TODO: f (https://github.com/dwango/UniVRM/issues/172)
-    if (vrmProps.keywordMap?._ALPHATEST_ON && params.blendMode === MToonMaterialRenderMode.Opaque) {
-      params.blendMode = MToonMaterialRenderMode.Cutout;
     }
 
     // set whether it needs skinning and morphing or not


### PR DESCRIPTION
Seems there was a bug in UniVRM, puts `undefined` to `keywordMap` of `materialProperties` instead of an empty object (it's valid in VRM spec, by the way.)
three-vrm could not handle `materialProperties` without `keywordMap` properly, this PR fixes this.

Considering [this issue comment](https://github.com/vrm-c/UniVRM/issues/172#issuecomment-640425765), the code that uses `keywordMap` seems to be outdated, so I removed the lines.
We have to see if the behavior is even with UniVRM before we merge this.

Issue @ UniVRM: https://github.com/vrm-c/UniVRM/issues/654
