### PR TITLE
Bump Three.js to r126

### DIFF
--- a/packages/three-vrm/examples/animations.html
+++ b/packages/three-vrm/examples/animations.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.125.2/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.125.2/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.125.2/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.126.1/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.126.1/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.126.1/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/basic.html
+++ b/packages/three-vrm/examples/basic.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.125.2/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.125.2/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.125.2/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.126.1/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.126.1/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.126.1/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/blendshapes.html
+++ b/packages/three-vrm/examples/blendshapes.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.125.2/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.125.2/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.125.2/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.126.1/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.126.1/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.126.1/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/bones.html
+++ b/packages/three-vrm/examples/bones.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.125.2/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.125.2/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.125.2/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.126.1/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.126.1/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.126.1/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/debug.html
+++ b/packages/three-vrm/examples/debug.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.125.2/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.125.2/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.125.2/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.126.1/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.126.1/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.126.1/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/dnd.html
+++ b/packages/three-vrm/examples/dnd.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.125.2/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.125.2/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.125.2/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.126.1/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.126.1/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.126.1/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/encoding.html
+++ b/packages/three-vrm/examples/encoding.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.125.2/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.125.2/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.125.2/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.126.1/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.126.1/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.126.1/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/envmap.html
+++ b/packages/three-vrm/examples/envmap.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.125.2/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.125.2/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.125.2/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.126.1/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.126.1/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.126.1/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/firstperson.html
+++ b/packages/three-vrm/examples/firstperson.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.125.2/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.125.2/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.125.2/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.126.1/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.126.1/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.126.1/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/lookat-advanced.html
+++ b/packages/three-vrm/examples/lookat-advanced.html
@@ -21,9 +21,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.125.2/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.125.2/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.125.2/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.126.1/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.126.1/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.126.1/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			const _v3A = new THREE.Vector3();

--- a/packages/three-vrm/examples/lookat.html
+++ b/packages/three-vrm/examples/lookat.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.125.2/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.125.2/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.125.2/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.126.1/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.126.1/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.126.1/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/materials-debug.html
+++ b/packages/three-vrm/examples/materials-debug.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.125.2/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.125.2/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.125.2/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.126.1/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.126.1/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.126.1/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/meta.html
+++ b/packages/three-vrm/examples/meta.html
@@ -30,9 +30,9 @@
 	<body>
 		<span id="meta"></span>
 		<img id="thumbnail" alt="thumbnail" />
-		<script src="https://unpkg.com/three@0.125.2/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.125.2/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.125.2/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.126.1/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.126.1/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.126.1/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/mouse.html
+++ b/packages/three-vrm/examples/mouse.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.125.2/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.125.2/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.125.2/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.126.1/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.126.1/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.126.1/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/package.json
+++ b/packages/three-vrm/package.json
@@ -50,12 +50,14 @@
     ]
   },
   "devDependencies": {
+    "@types/three": "^0.126.0",
     "gh-pages": "^3.1.0",
     "lint-staged": "10.5.4",
     "quicktype": "^15.0.258",
-    "three": "^0.125.2"
+    "three": "^0.126.1"
   },
   "peerDependencies": {
-    "three": "^0.125.2"
+    "@types/three": "^0.126.0",
+    "three": "^0.126.1"
   }
 }

--- a/packages/three-vrm/src/material/MToonMaterial.ts
+++ b/packages/three-vrm/src/material/MToonMaterial.ts
@@ -530,6 +530,10 @@ export class MToonMaterial extends THREE.ShaderMaterial {
 
   private _updateShaderCode(): void {
     this.defines = {
+      // Temporary compat against shader change @ Three.js r126
+      // See: #21205, #21307, #21299
+      THREE_VRM_THREE_REVISION_126: parseInt(THREE.REVISION) >= 126,
+
       OUTLINE: this._isOutline,
       BLENDMODE_OPAQUE: this._blendMode === MToonMaterialRenderMode.Opaque,
       BLENDMODE_CUTOUT: this._blendMode === MToonMaterialRenderMode.Cutout,

--- a/packages/three-vrm/src/material/shaders/mtoon.frag
+++ b/packages/three-vrm/src/material/shaders/mtoon.frag
@@ -106,49 +106,85 @@ varying vec3 vViewPosition;
 
   // three-vrm specific change: it requires `uv` as an input in order to support uv scrolls
 
-  vec3 perturbNormal2Arb( vec2 uv, vec3 eye_pos, vec3 surf_norm, vec3 mapN ) {
+  // Temporary compat against shader change @ Three.js r126
+  // See: #21205, #21307, #21299
+  #ifdef THREE_VRM_THREE_REVISION_126
 
-    // Workaround for Adreno 3XX dFd*( vec3 ) bug. See #9988
+    vec3 perturbNormal2Arb( vec2 uv, vec3 eye_pos, vec3 surf_norm, vec3 mapN, float faceDirection ) {
 
-    vec3 q0 = vec3( dFdx( eye_pos.x ), dFdx( eye_pos.y ), dFdx( eye_pos.z ) );
-    vec3 q1 = vec3( dFdy( eye_pos.x ), dFdy( eye_pos.y ), dFdy( eye_pos.z ) );
-    vec2 st0 = dFdx( uv.st );
-    vec2 st1 = dFdy( uv.st );
+      vec3 q0 = vec3( dFdx( eye_pos.x ), dFdx( eye_pos.y ), dFdx( eye_pos.z ) );
+      vec3 q1 = vec3( dFdy( eye_pos.x ), dFdy( eye_pos.y ), dFdy( eye_pos.z ) );
+      vec2 st0 = dFdx( uv.st );
+      vec2 st1 = dFdy( uv.st );
 
-    float scale = sign( st1.t * st0.s - st0.t * st1.s ); // we do not care about the magnitude
+      vec3 N = normalize( surf_norm );
 
-    vec3 S = ( q0 * st1.t - q1 * st0.t ) * scale;
-    vec3 T = ( - q0 * st1.s + q1 * st0.s ) * scale;
+      vec3 q1perp = cross( q1, N );
+      vec3 q0perp = cross( N, q0 );
 
-    // three-vrm specific change: Workaround for the issue that happens when delta of uv = 0.0
-    // TODO: Is this still required? Or shall I make a PR about it?
+      vec3 T = q1perp * st0.x + q0perp * st1.x;
+      vec3 B = q1perp * st0.y + q0perp * st1.y;
 
-    if ( length( S ) == 0.0 || length( T ) == 0.0 ) {
-      return surf_norm;
+      // three-vrm specific change: Workaround for the issue that happens when delta of uv = 0.0
+      // TODO: Is this still required? Or shall I make a PR about it?
+      if ( length( T ) == 0.0 || length( B ) == 0.0 ) {
+        return surf_norm;
+      }
+
+      float det = max( dot( T, T ), dot( B, B ) );
+      float scale = ( det == 0.0 ) ? 0.0 : faceDirection * inversesqrt( det );
+
+      return normalize( T * ( mapN.x * scale ) + B * ( mapN.y * scale ) + N * mapN.z );
+
     }
 
-    S = normalize( S );
-    T = normalize( T );
-    vec3 N = normalize( surf_norm );
+  #else
 
-    #ifdef DOUBLE_SIDED
+    vec3 perturbNormal2Arb( vec2 uv, vec3 eye_pos, vec3 surf_norm, vec3 mapN ) {
 
-      // Workaround for Adreno GPUs gl_FrontFacing bug. See #15850 and #10331
+      // Workaround for Adreno 3XX dFd*( vec3 ) bug. See #9988
 
-      bool frontFacing = dot( cross( S, T ), N ) > 0.0;
+      vec3 q0 = vec3( dFdx( eye_pos.x ), dFdx( eye_pos.y ), dFdx( eye_pos.z ) );
+      vec3 q1 = vec3( dFdy( eye_pos.x ), dFdy( eye_pos.y ), dFdy( eye_pos.z ) );
+      vec2 st0 = dFdx( uv.st );
+      vec2 st1 = dFdy( uv.st );
 
-      mapN.xy *= ( float( frontFacing ) * 2.0 - 1.0 );
+      float scale = sign( st1.t * st0.s - st0.t * st1.s ); // we do not care about the magnitude
 
-    #else
+      vec3 S = ( q0 * st1.t - q1 * st0.t ) * scale;
+      vec3 T = ( - q0 * st1.s + q1 * st0.s ) * scale;
 
-      mapN.xy *= ( float( gl_FrontFacing ) * 2.0 - 1.0 );
+      // three-vrm specific change: Workaround for the issue that happens when delta of uv = 0.0
+      // TODO: Is this still required? Or shall I make a PR about it?
 
-    #endif
+      if ( length( S ) == 0.0 || length( T ) == 0.0 ) {
+        return surf_norm;
+      }
 
-    mat3 tsn = mat3( S, T, N );
-    return normalize( tsn * mapN );
+      S = normalize( S );
+      T = normalize( T );
+      vec3 N = normalize( surf_norm );
 
-  }
+      #ifdef DOUBLE_SIDED
+
+        // Workaround for Adreno GPUs gl_FrontFacing bug. See #15850 and #10331
+
+        bool frontFacing = dot( cross( S, T ), N ) > 0.0;
+
+        mapN.xy *= ( float( frontFacing ) * 2.0 - 1.0 );
+
+      #else
+
+        mapN.xy *= ( float( gl_FrontFacing ) * 2.0 - 1.0 );
+
+      #endif
+
+      mat3 tsn = mat3( S, T, N );
+      return normalize( tsn * mapN );
+
+    }
+
+  #endif
 
 #endif
 
@@ -379,7 +415,17 @@ void main() {
 
     #ifdef DOUBLE_SIDED
 
-      normal = normal * ( float( gl_FrontFacing ) * 2.0 - 1.0 );
+      // Temporary compat against shader change @ Three.js r126
+      // See: #21205, #21307, #21299
+      #ifdef THREE_VRM_THREE_REVISION_126
+
+        normal = normal * faceDirection;
+
+      #else
+
+        normal = normal * ( float( gl_FrontFacing ) * 2.0 - 1.0 );
+
+      #endif
 
     #endif
 
@@ -396,7 +442,17 @@ void main() {
 
     #else
 
-      normal = perturbNormal2Arb( uv, -vViewPosition, normal, mapN );
+      // Temporary compat against shader change @ Three.js r126
+      // See: #21205, #21307, #21299
+      #ifdef THREE_VRM_THREE_REVISION_126
+
+        normal = perturbNormal2Arb( uv, -vViewPosition, normal, mapN, faceDirection );
+
+      #else
+
+        normal = perturbNormal2Arb( uv, -vViewPosition, normal, mapN );
+
+      #endif
 
     #endif
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1019,6 +1019,11 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
+"@types/three@^0.126.0":
+  version "0.126.0"
+  resolved "https://registry.yarnpkg.com/@types/three/-/three-0.126.0.tgz#58f80e13ab5f8084741e8a9d7e804b9a31039043"
+  integrity sha512-C7cFOWQpcGQAJ0PJSdU6ncZFn51fWKaV8o1Dz2fvikFRGWY8cI5/M/q5JHX7/TzCfMRadLP690Ksh8QvanSW8Q==
+
 "@typescript-eslint/eslint-plugin@^4.6.1":
   version "4.14.2"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.14.2.tgz#47a15803cfab89580b96933d348c2721f3d2f6fe"
@@ -6469,10 +6474,10 @@ thenify-all@^1.0.0:
   dependencies:
     any-promise "^1.0.0"
 
-three@^0.125.2:
-  version "0.125.2"
-  resolved "https://registry.yarnpkg.com/three/-/three-0.125.2.tgz#dcba12749a2eb41522e15212b919cd3fbf729b12"
-  integrity sha512-7rIRO23jVKWcAPFdW/HREU2NZMGWPBZ4XwEMt0Ak0jwLUKVJhcKM55eCBWyGZq/KiQbeo1IeuAoo/9l2dzhTXA==
+three@^0.126.1:
+  version "0.126.1"
+  resolved "https://registry.yarnpkg.com/three/-/three-0.126.1.tgz#cf4e4e52060fd952f6f0d5440cbd422c66bc4be7"
+  integrity sha512-eOEXnZeE1FDV0XgL1u08auIP13jxdN9LQBAEmlErYzMxtIIfuGIAZbijOyookALUhqVzVOx0Tywj6n192VM+nQ==
 
 through2@^2.0.0, through2@^2.0.2, through2@~2.0.3:
   version "2.0.5"


### PR DESCRIPTION
- 📦 Bump three to r126
- 💪 MToon: Catch up with latest shader changes in r126
    - Had to implement a compat ( `THREE_VRM_THREE_REVISION_126` ) since <r126 doesn't have a variable `faceDirection` defined in `normal_fragment_begin`
