### PR TITLE
[1.0] Materials, Add VRM0.0 compatibility layer plugin

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,6 +23,7 @@ jobs:
             - packages/three-vrm/node_modules
             - packages/three-vrm-core/node_modules
             - packages/three-vrm-materials-mtoon/node_modules
+            - packages/three-vrm-materials-v0compat/node_modules
             - packages/three-vrm-node-constraint/node_modules
             - packages/three-vrm-springbone/node_modules
             - packages/types-vrm-0.0/node_modules
@@ -56,6 +57,8 @@ jobs:
             - packages/three-vrm-core/types
             - packages/three-vrm-materials-mtoon/lib
             - packages/three-vrm-materials-mtoon/types
+            - packages/three-vrm-materials-v0compat/lib
+            - packages/three-vrm-materials-v0compat/types
             - packages/three-vrm-node-constraint/lib
             - packages/three-vrm-node-constraint/types
             - packages/three-vrm-springbone/lib

--- a/packages/three-vrm-materials-v0compat/README.md
+++ b/packages/three-vrm-materials-v0compat/README.md
@@ -1,0 +1,3 @@
+# @pixiv/three-vrm-materials-v0compat
+
+VRM0.0 materials compatibility layer plugin for @pixiv/three-vrm

--- a/packages/three-vrm-materials-v0compat/package.json
+++ b/packages/three-vrm-materials-v0compat/package.json
@@ -32,7 +32,6 @@
     "build-moduleprod": "cross-env NODE_ENV=production ESM=1 rollup -c -o lib/three-vrm-materials-v0compat.module.min.js",
     "build-types": "tsc --project ./tsconfig.build-types.json && downlevel-dts types ts3.4/types",
     "docs": "typedoc --entryPoints ./src/index.ts --out docs",
-    "test": "jest",
     "lint": "eslint \"src/**/*.{ts,tsx}\" && prettier \"src/**/*.{ts,tsx}\" --check",
     "lint-fix": "eslint \"src/**/*.{ts,tsx}\" --fix && prettier \"src/**/*.{ts,tsx}\" --write"
   },

--- a/packages/three-vrm-materials-v0compat/package.json
+++ b/packages/three-vrm-materials-v0compat/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "@pixiv/three-vrm-materials-v0compat",
+  "version": "0.0.1",
+  "description": "VRM0.0 materials compatibility layer plugin for @pixiv/three-vrm",
+  "license": "MIT",
+  "author": "pixiv",
+  "files": [
+    "/lib/",
+    "/ts*/",
+    "/types/",
+    "LICENSE"
+  ],
+  "main": "lib/three-vrm-materials-v0compat.js",
+  "module": "lib/three-vrm-materials-v0compat.module.js",
+  "types": "types/index.d.ts",
+  "typesVersions": {
+    "<3.9": {
+      "*": [
+        "ts3.4/*"
+      ]
+    }
+  },
+  "scripts": {
+    "version": "yarn all",
+    "all": "yarn && yarn test && yarn lint && yarn clean && yarn build && yarn docs",
+    "dev": "cross-env NODE_ENV=development SERVE=1 rollup -w -c -o lib/three-vrm-materials-v0compat.js",
+    "clean": "rimraf docs/ lib/ ts*/ types/",
+    "build": "yarn build-dev && yarn build-prod && yarn build-moduledev && yarn build-moduleprod && yarn build-types",
+    "build-dev": "cross-env NODE_ENV=development rollup -c -o lib/three-vrm-materials-v0compat.js",
+    "build-prod": "cross-env NODE_ENV=production rollup -c -o lib/three-vrm-materials-v0compat.min.js",
+    "build-moduledev": "cross-env NODE_ENV=development ESM=1 rollup -c -o lib/three-vrm-materials-v0compat.module.js",
+    "build-moduleprod": "cross-env NODE_ENV=production ESM=1 rollup -c -o lib/three-vrm-materials-v0compat.module.min.js",
+    "build-types": "tsc --project ./tsconfig.build-types.json && downlevel-dts types ts3.4/types",
+    "docs": "typedoc --entryPoints ./src/index.ts --out docs",
+    "test": "jest",
+    "lint": "eslint \"src/**/*.{ts,tsx}\" && prettier \"src/**/*.{ts,tsx}\" --check",
+    "lint-fix": "eslint \"src/**/*.{ts,tsx}\" --fix && prettier \"src/**/*.{ts,tsx}\" --write"
+  },
+  "lint-staged": {
+    "./src/**/*.{ts,tsx}": [
+      "eslint --fix",
+      "prettier --write"
+    ]
+  },
+  "dependencies": {
+    "@pixiv/types-vrm-0.0": "0.0.1",
+    "@pixiv/types-vrmc-materials-mtoon-1.0": "0.0.1"
+  },
+  "devDependencies": {
+    "@types/three": "^0.126.0",
+    "lint-staged": "10.5.4",
+    "three": "^0.126.1"
+  },
+  "peerDependencies": {
+    "three": "^0.126.1"
+  }
+}

--- a/packages/three-vrm-materials-v0compat/rollup.config.js
+++ b/packages/three-vrm-materials-v0compat/rollup.config.js
@@ -1,0 +1,65 @@
+/* eslint-env node */
+
+import packageJson from './package.json';
+import serve from 'rollup-plugin-serve';
+import { terser } from 'rollup-plugin-terser';
+import typescript from '@rollup/plugin-typescript';
+
+// == constants ====================================================================================
+/** copyright text */
+const copyright = '(c) 2020 pixiv Inc.';
+
+/** name of the license */
+const licenseName = 'MIT License';
+
+/** url of the license */
+const licenseUri = 'https://github.com/pixiv/three-vrm/blob/master/LICENSE';
+
+/** output name of the module */
+const name = 'THREE_VRM_MATERIALS_V0COMPAT';
+
+// == envs =========================================================================================
+const NODE_ENV = process.env.NODE_ENV;
+const DEV = NODE_ENV === 'development';
+const ESM = process.env.ESM === '1';
+const SERVE = process.env.SERVE === '1';
+
+// == banner =======================================================================================
+const bannerTextDev = `/*!
+* ${packageJson.name} v${packageJson.version}
+* ${packageJson.description}
+*
+* Copyright ${copyright}
+* ${packageJson.name} is distributed under ${licenseName}
+* ${licenseUri}
+*/`;
+
+const bannerTextProd = `/*! ${copyright} - ${licenseUri} */`;
+
+// == module =======================================================================================
+/** will be used to inject the stuff into THREE */
+const outro = `Object.assign(THREE, exports);`;
+
+// == serve ========================================================================================
+const serveOptions = {
+  contentBase: '.',
+};
+
+// == output =======================================================================================
+export default {
+  input: 'src/index.ts',
+  output: {
+    format: ESM ? 'esm' : 'umd',
+    banner: DEV ? bannerTextDev : bannerTextProd,
+    sourcemap: DEV ? 'inline' : false,
+    globals: ESM ? undefined : { three: 'THREE' },
+    name: ESM ? undefined : name,
+    outro: ESM ? undefined : outro,
+  },
+  external: [ 'three' ],
+  plugins: [
+    typescript(),
+    ...(DEV ? [] : [terser()]),
+    ...(SERVE ? [serve(serveOptions)] : []),
+  ],
+};

--- a/packages/three-vrm-materials-v0compat/src/VRMMaterialsV0CompatPlugin.ts
+++ b/packages/three-vrm-materials-v0compat/src/VRMMaterialsV0CompatPlugin.ts
@@ -1,0 +1,5 @@
+export class VRMMaterialsV0CompatPlugin {
+  public constructor() {
+    throw new Error('not implemented');
+  }
+}

--- a/packages/three-vrm-materials-v0compat/src/VRMMaterialsV0CompatPlugin.ts
+++ b/packages/three-vrm-materials-v0compat/src/VRMMaterialsV0CompatPlugin.ts
@@ -63,7 +63,9 @@ export class VRMMaterialsV0CompatPlugin implements GLTFLoaderPlugin {
     const cullMode = materialProperties.floatProperties?.['_CullMode'] ?? 2; // enum, { Off, Front, Back }
     const doubleSided = cullMode === 0;
 
-    const baseColorFactor = materialProperties.vectorProperties?.['_Color']?.map(gammaEOTF);
+    const baseColorFactor = materialProperties.vectorProperties?.['_Color']?.map(
+      (v: number, i: number) => (i === 3 ? v : gammaEOTF(v)), // alpha channel is stored in linear
+    );
     const baseColorTextureIndex = materialProperties.textureProperties?.['_MainTex'];
     const baseColorTexture =
       baseColorTextureIndex != null

--- a/packages/three-vrm-materials-v0compat/src/VRMMaterialsV0CompatPlugin.ts
+++ b/packages/three-vrm-materials-v0compat/src/VRMMaterialsV0CompatPlugin.ts
@@ -222,7 +222,7 @@ export class VRMMaterialsV0CompatPlugin implements GLTFLoaderPlugin {
 
     const isCutoff = materialProperties.shader === 'VRM/UnlitCutout';
     const alphaMode = isTransparent ? 'BLEND' : isCutoff ? 'MASK' : 'OPAQUE';
-    const alphaCutoff = isCutoff ? materialProperties.vectorProperties?.['_Cutoff'] : undefined;
+    const alphaCutoff = isCutoff ? materialProperties.floatProperties?.['_Cutoff'] : undefined;
 
     const baseColorFactor = materialProperties.vectorProperties?.['_Color']?.map(gammaEOTF);
     const baseColorTextureIndex = materialProperties.textureProperties?.['_MainTex'];

--- a/packages/three-vrm-materials-v0compat/src/VRMMaterialsV0CompatPlugin.ts
+++ b/packages/three-vrm-materials-v0compat/src/VRMMaterialsV0CompatPlugin.ts
@@ -1,5 +1,280 @@
-export class VRMMaterialsV0CompatPlugin {
-  public constructor() {
-    throw new Error('not implemented');
+import * as THREE from 'three';
+import { VRM as V0VRM, Material as V0Material } from '@pixiv/types-vrm-0.0';
+import * as V1MToonSchema from '@pixiv/types-vrmc-materials-mtoon-1.0';
+import type { GLTFLoaderPlugin, GLTFParser } from 'three/examples/jsm/loaders/GLTFLoader';
+import { gammaEOTF } from './utils/gammaEOTF';
+
+export class VRMMaterialsV0CompatPlugin implements GLTFLoaderPlugin {
+  public readonly parser: GLTFParser;
+
+  private _haveExecutedBeforeRoot: boolean;
+
+  public get name(): string {
+    return 'VRMMaterialsV0CompatPlugin';
+  }
+
+  public constructor(parser: GLTFParser) {
+    this.parser = parser;
+
+    this._haveExecutedBeforeRoot = false;
+  }
+
+  public async beforeRoot(): Promise<void> {
+    if (this._haveExecutedBeforeRoot) {
+      // someone else have already executed beforeRoot
+      return;
+    }
+
+    // early abort if it doesn't use V0VRM
+    const json = this.parser.json;
+    const v0VRMExtension: V0VRM | undefined = json.extensions?.['VRM'];
+    const v0MaterialProperties = v0VRMExtension?.materialProperties;
+    if (!v0MaterialProperties) {
+      return;
+    }
+
+    // convert V0 material properties into V1 compatible format
+    v0MaterialProperties.forEach((materialProperties, materialIndex) => {
+      if (materialProperties.shader === 'VRM/MToon') {
+        const material = this._parseV0MToonProperties(materialProperties, json.materials[materialIndex]);
+        json.materials[materialIndex] = material;
+      } else if (materialProperties.shader?.startsWith('VRM/Unlit')) {
+        const material = this._parseV0UnlitProperties(materialProperties, json.materials[materialIndex]);
+        json.materials[materialIndex] = material;
+      } else if (materialProperties.shader === 'VRM_USE_GLTFSHADER') {
+        // `json.materials[materialIndex]` should be already valid
+      } else {
+        console.warn(`VRMMaterialsV0CompatPlugin: Unknown shader: ${materialProperties.shader}`);
+      }
+    });
+  }
+
+  private _parseV0MToonProperties(materialProperties: V0Material, schemaMaterial: any): any {
+    const isTransparent = materialProperties.keywordMap?.['_ALPHABLEND_ON'] ?? false;
+    const enabledZWrite = materialProperties.floatProperties?.['_ZWrite'] === 1;
+    const transparentWithZWrite = enabledZWrite && isTransparent;
+
+    const renderQueueOffsetNumber = this._v0ParseRenderQueue(materialProperties);
+
+    const isCutoff = materialProperties.keywordMap?.['_ALPHATEST_ON'] ?? false;
+    const alphaMode = isTransparent ? 'BLEND' : isCutoff ? 'MASK' : 'OPAQUE';
+    const alphaCutoff = isCutoff ? materialProperties.floatProperties?.['_Cutoff'] : undefined;
+
+    const cullMode = materialProperties.floatProperties?.['_CullMode'] ?? 2; // enum, { Off, Front, Back }
+    const doubleSided = cullMode === 0;
+
+    const baseColorFactor = materialProperties.vectorProperties?.['_Color']?.map(gammaEOTF);
+    const baseColorTextureIndex = materialProperties.textureProperties?.['_MainTex'];
+    const baseColorTexture =
+      baseColorTextureIndex != null
+        ? {
+            index: baseColorTextureIndex,
+          }
+        : undefined;
+
+    const normalTextureScale = materialProperties.floatProperties?.['_BumpScale'];
+    const normalTextureIndex = materialProperties.textureProperties?.['_BumpMap'];
+    const normalTexture =
+      normalTextureIndex != null
+        ? {
+            index: normalTextureIndex,
+            scale: normalTextureScale,
+          }
+        : undefined;
+
+    const emissiveFactor = materialProperties.vectorProperties?.['_EmissionColor']?.map(gammaEOTF);
+    const emissiveTextureIndex = materialProperties.textureProperties?.['_EmissionMap'];
+    const emissiveTexture =
+      emissiveTextureIndex != null
+        ? {
+            index: emissiveTextureIndex,
+          }
+        : undefined;
+
+    const shadeColorFactor = materialProperties.vectorProperties?.['_ShadeColor']?.map(gammaEOTF);
+    const shadeMultiplyTextureIndex = materialProperties.textureProperties?.['_ShadeTexture'];
+    const shadeMultiplyTexture =
+      shadeMultiplyTextureIndex != null
+        ? {
+            index: shadeMultiplyTextureIndex,
+          }
+        : undefined;
+
+    // // convert v0 shade shift / shade toony
+    let shadingShiftFactor = materialProperties.floatProperties?.['_ShadeShift'] ?? 0.0;
+    let shadingToonyFactor = materialProperties.floatProperties?.['_ShadeToony'] ?? 0.9;
+    shadingToonyFactor = THREE.MathUtils.lerp(shadingToonyFactor, 1.0, 0.5 + 0.5 * shadingShiftFactor);
+    shadingShiftFactor = -shadingShiftFactor - (1.0 - shadingToonyFactor);
+
+    const giIntensityFactor = materialProperties.floatProperties?.['_IndirectLightIntensity'];
+
+    const matcapTextureIndex = materialProperties.textureProperties?.['_SphereAdd'];
+    const matcapTexture =
+      matcapTextureIndex != null
+        ? {
+            index: matcapTextureIndex,
+          }
+        : undefined;
+
+    const rimLightingMixFactor = materialProperties.floatProperties?.['_RimLightingMix'];
+    const rimMultiplyTextureIndex = materialProperties.textureProperties?.['_RimTexture'];
+    const rimMultiplyTexture =
+      rimMultiplyTextureIndex != null
+        ? {
+            index: rimMultiplyTextureIndex,
+          }
+        : undefined;
+
+    const parametricRimColorFactor = materialProperties.vectorProperties?.['_RimColor']?.map(gammaEOTF);
+    const parametricRimFresnelPowerFactor = materialProperties.floatProperties?.['_RimFresnelPower'];
+    const parametricRimLiftFactor = materialProperties.floatProperties?.['_RimLift'];
+
+    const outlineWidthMode = ['none', 'worldCoordinates', 'screenCoordinates'][
+      materialProperties.floatProperties?.['_OutlineWidthMode'] ?? 0
+    ] as V1MToonSchema.MaterialsMToonOutlineWidthMode;
+
+    // // v0 outlineWidthFactor is in centimeter
+    let outlineWidthFactor = materialProperties.floatProperties?.['_OutlineWidth'] ?? 0.0;
+    outlineWidthFactor = 0.01 * outlineWidthFactor;
+
+    const outlineWidthMultiplyTextureIndex = materialProperties.textureProperties?.['_OutlineWidthTexture'];
+    const outlineWidthMultiplyTexture =
+      outlineWidthMultiplyTextureIndex != null
+        ? {
+            index: outlineWidthMultiplyTextureIndex,
+          }
+        : undefined;
+
+    const outlineColorFactor = materialProperties.vectorProperties?.['_OutlineColor']?.map(gammaEOTF);
+    const outlineColorMode = materialProperties.floatProperties?.['_OutlineColorMode']; // enum, { Fixed, Mixed }
+    const outlineLightingMixFactor =
+      outlineColorMode === 1 ? materialProperties.floatProperties?.['_OutlineLightingMix'] : 0.0;
+
+    const uvAnimationMaskTextureIndex = materialProperties.textureProperties?.['_UvAnimMaskTexture'];
+    const uvAnimationMaskTexture =
+      uvAnimationMaskTextureIndex != null
+        ? {
+            index: uvAnimationMaskTextureIndex,
+          }
+        : undefined;
+
+    const uvAnimationScrollXSpeedFactor = materialProperties.floatProperties?.['_UvAnimScrollX'];
+
+    // uvAnimationScrollYSpeedFactor will be opposite between V0 and V1
+    let uvAnimationScrollYSpeedFactor = materialProperties.floatProperties?.['_UvAnimScrollY'];
+    if (uvAnimationScrollYSpeedFactor != null) {
+      uvAnimationScrollYSpeedFactor = -uvAnimationScrollYSpeedFactor;
+    }
+
+    const uvAnimationRotationSpeedFactor = materialProperties.floatProperties?.['_UvAnimRotation'];
+
+    const mtoonExtension: V1MToonSchema.VRMCMaterialsMToon = {
+      specVersion: '1.0-draft',
+      transparentWithZWrite,
+      renderQueueOffsetNumber,
+      shadeColorFactor,
+      shadeMultiplyTexture,
+      shadingShiftFactor,
+      shadingToonyFactor,
+      giIntensityFactor,
+      matcapTexture,
+      rimLightingMixFactor,
+      rimMultiplyTexture,
+      parametricRimColorFactor,
+      parametricRimFresnelPowerFactor,
+      parametricRimLiftFactor,
+      outlineWidthMode,
+      outlineWidthFactor,
+      outlineWidthMultiplyTexture,
+      outlineColorFactor,
+      outlineLightingMixFactor,
+      uvAnimationMaskTexture,
+      uvAnimationScrollXSpeedFactor,
+      uvAnimationScrollYSpeedFactor,
+      uvAnimationRotationSpeedFactor,
+    };
+
+    return {
+      ...schemaMaterial,
+
+      pbrMetallicRoughness: {
+        baseColorFactor,
+        baseColorTexture,
+      },
+      normalTexture,
+      emissiveTexture,
+      emissiveFactor,
+      alphaMode,
+      alphaCutoff,
+      doubleSided,
+      extensions: {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        VRMC_materials_mtoon: mtoonExtension,
+      },
+    };
+  }
+
+  private _parseV0UnlitProperties(materialProperties: V0Material, schemaMaterial: any): any {
+    const isTransparentZWrite = materialProperties.shader === 'VRM/UnlitTransparentZWrite';
+    const isTransparent = materialProperties.shader === 'VRM/UnlitTransparent' || isTransparentZWrite;
+
+    const renderQueueOffsetNumber = this._v0ParseRenderQueue(materialProperties);
+
+    const isCutoff = materialProperties.shader === 'VRM/UnlitCutout';
+    const alphaMode = isTransparent ? 'BLEND' : isCutoff ? 'MASK' : 'OPAQUE';
+    const alphaCutoff = isCutoff ? materialProperties.vectorProperties?.['_Cutoff'] : undefined;
+
+    const baseColorFactor = materialProperties.vectorProperties?.['_Color']?.map(gammaEOTF);
+    const baseColorTextureIndex = materialProperties.textureProperties?.['_MainTex'];
+    const baseColorTexture =
+      baseColorTextureIndex != null
+        ? {
+            index: baseColorTextureIndex,
+          }
+        : undefined;
+
+    // use mtoon instead of unlit, since there might be VRM0.0 specific features that are not supported by gltf
+    const mtoonExtension: V1MToonSchema.VRMCMaterialsMToon = {
+      specVersion: '1.0-draft',
+      transparentWithZWrite: isTransparentZWrite,
+      renderQueueOffsetNumber,
+      shadeColorFactor: baseColorFactor,
+      shadeMultiplyTexture: baseColorTexture,
+    };
+
+    return {
+      ...schemaMaterial,
+
+      pbrMetallicRoughness: {
+        baseColorFactor,
+        baseColorTexture,
+      },
+      alphaMode,
+      alphaCutoff,
+      extensions: {
+        // eslint-disable-next-line @typescript-eslint/naming-convention
+        VRMC_materials_mtoon: mtoonExtension,
+      },
+    };
+  }
+
+  /**
+   * Convert v0 render order into v1 render order.
+   */
+  private _v0ParseRenderQueue(materialProperties: V0Material): number {
+    const isTransparent = materialProperties.keywordMap?.['_ALPHABLEND_ON'] ?? false;
+    const enabledZWrite = materialProperties.floatProperties?.['_ZWrite'] === 1;
+
+    let offset = 0;
+
+    if (isTransparent && materialProperties.renderQueue) {
+      if (enabledZWrite) {
+        offset = Math.min(Math.max(materialProperties.renderQueue - 2501, 0), 9);
+      } else {
+        offset = Math.min(Math.max(materialProperties.renderQueue - 3000, -9), 0);
+      }
+    }
+
+    return offset;
   }
 }

--- a/packages/three-vrm-materials-v0compat/src/index.ts
+++ b/packages/three-vrm-materials-v0compat/src/index.ts
@@ -1,0 +1,1 @@
+export { VRMMaterialsV0CompatPlugin } from './VRMMaterialsV0CompatPlugin';

--- a/packages/three-vrm-materials-v0compat/src/utils/gammaEOTF.ts
+++ b/packages/three-vrm-materials-v0compat/src/utils/gammaEOTF.ts
@@ -1,0 +1,3 @@
+export function gammaEOTF(e: number): number {
+  return Math.pow(e, 2.2);
+}

--- a/packages/three-vrm-materials-v0compat/tsconfig.build-types.json
+++ b/packages/three-vrm-materials-v0compat/tsconfig.build-types.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "declaration": true,
+    "declarationDir": "./types",
+    "emitDeclarationOnly": true
+  },
+  "exclude": [
+    "**/tests/**"
+  ]
+}

--- a/packages/three-vrm-materials-v0compat/tsconfig.json
+++ b/packages/three-vrm-materials-v0compat/tsconfig.json
@@ -1,0 +1,6 @@
+{
+  "extends": "../../tsconfig.json",
+  "include": [
+    "./src"
+  ]
+}

--- a/packages/three-vrm/package.json
+++ b/packages/three-vrm/package.json
@@ -53,6 +53,7 @@
     "@pixiv/three-vrm-node-constraint": "0.0.1",
     "@pixiv/three-vrm-core": "0.0.1",
     "@pixiv/three-vrm-materials-mtoon": "0.0.1",
+    "@pixiv/three-vrm-materials-v0compat": "0.0.1",
     "@pixiv/three-vrm-springbone": "0.0.1",
     "@rollup/plugin-node-resolve": "^13.0.0",
     "@types/three": "^0.126.0",

--- a/packages/three-vrm/src/VRMLoaderPlugin.ts
+++ b/packages/three-vrm/src/VRMLoaderPlugin.ts
@@ -8,6 +8,7 @@ import {
   VRMMetaLoaderPlugin,
 } from '@pixiv/three-vrm-core';
 import { MToonMaterialLoaderPlugin } from '@pixiv/three-vrm-materials-mtoon';
+import { VRMMaterialsV0CompatPlugin } from '@pixiv/three-vrm-materials-v0compat';
 import { VRMNodeConstraintLoaderPlugin } from '@pixiv/three-vrm-node-constraint';
 import { VRMSpringBoneLoaderPlugin } from '@pixiv/three-vrm-springbone';
 import { VRMLoaderPluginOptions } from './VRMLoaderPluginOptions';
@@ -22,6 +23,7 @@ export class VRMLoaderPlugin implements GLTFLoaderPlugin {
   public readonly lookAtPlugin: VRMLookAtLoaderPlugin;
   public readonly metaPlugin: VRMMetaLoaderPlugin;
   public readonly mtoonMaterialPlugin: MToonMaterialLoaderPlugin;
+  public readonly materialsV0CompatPlugin: VRMMaterialsV0CompatPlugin;
   public readonly springBonePlugin: VRMSpringBoneLoaderPlugin;
   public readonly constraintPlugin: VRMNodeConstraintLoaderPlugin;
 
@@ -36,6 +38,7 @@ export class VRMLoaderPlugin implements GLTFLoaderPlugin {
     this.lookAtPlugin = options?.lookAtPlugin ?? new VRMLookAtLoaderPlugin(parser);
     this.metaPlugin = options?.metaPlugin ?? new VRMMetaLoaderPlugin(parser);
     this.mtoonMaterialPlugin = options?.mtoonMaterialPlugin ?? new MToonMaterialLoaderPlugin(parser);
+    this.materialsV0CompatPlugin = options?.materialsV0CompatPlugin ?? new VRMMaterialsV0CompatPlugin(parser);
 
     this.springBonePlugin =
       options?.springBonePlugin ??
@@ -48,6 +51,7 @@ export class VRMLoaderPlugin implements GLTFLoaderPlugin {
   }
 
   public async beforeRoot(): Promise<void> {
+    await this.materialsV0CompatPlugin.beforeRoot();
     await this.mtoonMaterialPlugin.beforeRoot();
   }
 

--- a/packages/three-vrm/src/VRMLoaderPluginOptions.ts
+++ b/packages/three-vrm/src/VRMLoaderPluginOptions.ts
@@ -7,6 +7,7 @@ import type {
   VRMMetaLoaderPlugin,
 } from '@pixiv/three-vrm-core';
 import type { MToonMaterialLoaderPlugin } from '@pixiv/three-vrm-materials-mtoon';
+import type { VRMMaterialsV0CompatPlugin } from 'packages/three-vrm-materials-v0compat/types';
 import type { VRMNodeConstraintLoaderPlugin } from '@pixiv/three-vrm-node-constraint';
 import type { VRMSpringBoneLoaderPlugin } from '@pixiv/three-vrm-springbone';
 
@@ -17,6 +18,7 @@ export interface VRMLoaderPluginOptions {
   lookAtPlugin?: VRMLookAtLoaderPlugin;
   metaPlugin?: VRMMetaLoaderPlugin;
   mtoonMaterialPlugin?: MToonMaterialLoaderPlugin;
+  materialsV0CompatPlugin?: VRMMaterialsV0CompatPlugin;
   springBonePlugin?: VRMSpringBoneLoaderPlugin;
   constraintPlugin?: VRMNodeConstraintLoaderPlugin;
 

--- a/packages/types-vrmc-materials-mtoon-1.0/src/VRMCMaterialsMToon.ts
+++ b/packages/types-vrmc-materials-mtoon-1.0/src/VRMCMaterialsMToon.ts
@@ -36,7 +36,7 @@ export interface VRMCMaterialsMToon {
   /**
    *
    */
-  shadingShiftTexture: MaterialsMToonShadingShiftTextureInfo;
+  shadingShiftTexture?: MaterialsMToonShadingShiftTextureInfo;
 
   /**
    *


### PR DESCRIPTION
### Description

- Since VRM0.0 can have material properties that maps to materials other than MToon, I've made a separate plugin that converts VRM0.0 material properties into VRM1.0 compatible material definitions.
- Also there was a mistake in the schema of `VRMC_materials_mtoon` , fixed it
    - `shadingShiftTexture` should be optional
