### PR TITLE
[1.0] VRMHumanoidLoaderPlugin now ensures there are all the required bones

### DIFF
--- a/packages/three-vrm-core/examples/models/cube.gltf
+++ b/packages/three-vrm-core/examples/models/cube.gltf
@@ -429,6 +429,7 @@
   ],
   "extensions": {
     "VRMC_vrm": {
+      "specVersion": "1.0-draft",
       "meta": {
         "name": "Cube",
         "version": "1.0.0",

--- a/packages/three-vrm-core/src/humanoid/VRMHumanBones.ts
+++ b/packages/three-vrm-core/src/humanoid/VRMHumanBones.ts
@@ -1,7 +1,9 @@
 import type { VRMHumanBone } from './VRMHumanBone';
 import type { VRMHumanBoneName } from './VRMHumanBoneName';
+import type { VRMRequiredHumanBoneName } from './VRMRequiredHumanBoneName';
 
 /**
  * A map from {@link VRMHumanBoneName} to {@link VRMHumanBone}.
  */
-export type VRMHumanBones = { [name in VRMHumanBoneName]?: VRMHumanBone };
+export type VRMHumanBones = { [name in VRMHumanBoneName]?: VRMHumanBone } &
+  { [name in VRMRequiredHumanBoneName]: VRMHumanBone };

--- a/packages/three-vrm-core/src/humanoid/VRMRequiredHumanBoneName.ts
+++ b/packages/three-vrm-core/src/humanoid/VRMRequiredHumanBoneName.ts
@@ -1,0 +1,21 @@
+/* eslint-disable @typescript-eslint/naming-convention */
+
+export const VRMRequiredHumanBoneName = {
+  Hips: 'hips',
+  Spine: 'spine',
+  Head: 'head',
+  LeftUpperLeg: 'leftUpperLeg',
+  LeftLowerLeg: 'leftLowerLeg',
+  LeftFoot: 'leftFoot',
+  RightUpperLeg: 'rightUpperLeg',
+  RightLowerLeg: 'rightLowerLeg',
+  RightFoot: 'rightFoot',
+  LeftUpperArm: 'leftUpperArm',
+  LeftLowerArm: 'leftLowerArm',
+  LeftHand: 'leftHand',
+  RightUpperArm: 'rightUpperArm',
+  RightLowerArm: 'rightLowerArm',
+  RightHand: 'rightHand',
+} as const;
+
+export type VRMRequiredHumanBoneName = typeof VRMRequiredHumanBoneName[keyof typeof VRMRequiredHumanBoneName];

--- a/packages/three-vrm-core/src/humanoid/index.ts
+++ b/packages/three-vrm-core/src/humanoid/index.ts
@@ -5,3 +5,4 @@ export { VRMHumanoid } from './VRMHumanoid';
 export { VRMHumanoidLoaderPlugin } from './VRMHumanoidLoaderPlugin';
 export type { VRMPose } from './VRMPose';
 export type { VRMPoseTransform } from './VRMPoseTransform';
+export { VRMRequiredHumanBoneName } from './VRMRequiredHumanBoneName';


### PR DESCRIPTION
- VRMHumanoidLoaderPlugin now ensures there are all the required bones
- New union type / const, `VRMRequiredHumanBoneName`
- `VRMHumanBones` now properly requires required bones as the type definition
- missing `specVersion` on `cube.gltf` of examples, fixed
