### PR TITLE
[1.0] Update texture transform bind

### DIFF
--- a/packages/three-vrm-core/src/expressions/VRMExpression.ts
+++ b/packages/three-vrm-core/src/expressions/VRMExpression.ts
@@ -202,9 +202,9 @@ export class VRMExpression extends THREE.Object3D {
         (material as any)[propertyName] = texture; // because the texture is cloned
 
         const initialOffset = texture.offset.clone();
-        const deltaOffset = bind.offset.clone().sub(initialOffset);
         const initialScale = texture.repeat.clone();
-        const deltaScale = bind.scale.clone().multiply(initialScale);
+        const deltaOffset = bind.offset.clone().multiply(initialScale);
+        const deltaScale = bind.scale.clone().addScalar(-1).multiply(initialScale);
 
         properties.push({
           name: propertyName,

--- a/packages/three-vrm-core/src/expressions/VRMExpression.ts
+++ b/packages/three-vrm-core/src/expressions/VRMExpression.ts
@@ -203,15 +203,15 @@ export class VRMExpression extends THREE.Object3D {
 
         const initialOffset = texture.offset.clone();
         const deltaOffset = bind.offset.clone().sub(initialOffset);
-        const initialScaling = texture.repeat.clone();
-        const deltaScaling = bind.scaling.clone().multiply(initialScaling);
+        const initialScale = texture.repeat.clone();
+        const deltaScale = bind.scale.clone().multiply(initialScale);
 
         properties.push({
           name: propertyName,
           initialOffset,
           deltaOffset,
-          initialScaling,
-          deltaScaling,
+          initialScale,
+          deltaScale,
         });
       }
     });
@@ -268,7 +268,7 @@ export class VRMExpression extends THREE.Object3D {
         } // TODO: we should kick this at `addMaterialValue`
 
         target.offset.add(_v2.copy(property.deltaOffset).multiplyScalar(actualWeight));
-        target.repeat.add(_v2.copy(property.deltaScaling).multiplyScalar(actualWeight));
+        target.repeat.add(_v2.copy(property.deltaScale).multiplyScalar(actualWeight));
 
         target.needsUpdate = true;
       });
@@ -311,7 +311,7 @@ export class VRMExpression extends THREE.Object3D {
         } // TODO: we should kick this at `addMaterialValue`
 
         target.offset.copy(property.initialOffset);
-        target.repeat.copy(property.initialScaling);
+        target.repeat.copy(property.initialScale);
 
         target.needsUpdate = true;
       });

--- a/packages/three-vrm-core/src/expressions/VRMExpressionLoaderPlugin.ts
+++ b/packages/three-vrm-core/src/expressions/VRMExpressionLoaderPlugin.ts
@@ -207,7 +207,7 @@ export class VRMExpressionLoaderPlugin implements GLTFLoaderPlugin {
               expression.addTextureTransformBind({
                 material,
                 offset: new THREE.Vector2().fromArray(bind.offset ?? [0.0, 0.0]),
-                scaling: new THREE.Vector2().fromArray(bind.scaling ?? [1.0, 1.0]),
+                scale: new THREE.Vector2().fromArray(bind.scale ?? [1.0, 1.0]),
               });
             });
           });

--- a/packages/three-vrm-core/src/expressions/VRMExpressionTextureTransformBind.ts
+++ b/packages/three-vrm-core/src/expressions/VRMExpressionTextureTransformBind.ts
@@ -10,9 +10,9 @@ export interface VRMExpressionTextureTransformBind {
   material: THREE.Material;
 
   /**
-   * The uv scaling of the texture.
+   * The uv scale of the texture.
    */
-  scaling: THREE.Vector2;
+  scale: THREE.Vector2;
 
   /**
    * The uv offset of the texture.

--- a/packages/three-vrm-core/src/expressions/VRMExpressionTextureTransformBindState.ts
+++ b/packages/three-vrm-core/src/expressions/VRMExpressionTextureTransformBindState.ts
@@ -10,8 +10,8 @@ export interface VRMExpressionTextureTransformBindState {
   properties: {
     name: string;
     initialOffset: THREE.Vector2;
-    initialScaling: THREE.Vector2;
+    initialScale: THREE.Vector2;
     deltaOffset: THREE.Vector2;
-    deltaScaling: THREE.Vector2;
+    deltaScale: THREE.Vector2;
   }[];
 }

--- a/packages/three-vrm-materials-mtoon/src/shaders/mtoon.vert
+++ b/packages/three-vrm-materials-mtoon/src/shaders/mtoon.vert
@@ -27,6 +27,7 @@ varying vec3 vViewPosition;
 
 #ifdef USE_OUTLINEWIDTHMULTIPLYTEXTURE
   uniform sampler2D outlineWidthMultiplyTexture;
+  uniform mat3 outlineWidthMultiplyTextureUvTransform;
 #endif
 
 uniform float outlineWidthFactor;
@@ -70,7 +71,8 @@ void main() {
 
   #ifdef OUTLINE
     #ifdef USE_OUTLINEWIDTHMULTIPLYTEXTURE
-      outlineTex = texture2D( outlineWidthMultiplyTexture, vUv ).g;
+      vec2 outlineWidthMultiplyTextureUv = ( outlineWidthMultiplyTextureUvTransform * vec3( vUv, 1 ) ).xy;
+      outlineTex = texture2D( outlineWidthMultiplyTexture, outlineWidthMultiplyTextureUv ).g;
     #endif
 
     #ifdef OUTLINE_WIDTH_WORLD

--- a/packages/types-vrmc-vrm-1.0/src/ExpressionTextureTransformBind.ts
+++ b/packages/types-vrmc-vrm-1.0/src/ExpressionTextureTransformBind.ts
@@ -5,9 +5,9 @@ export interface ExpressionTextureTransformBind {
   material: number;
 
   /**
-   * uv scaling for TEXCOORD_0
+   * uv scale for TEXCOORD_0
    */
-  scaling?: [number, number];
+  scale?: [number, number];
 
   /**
    * uv offset for TEXCOORD_0


### PR DESCRIPTION
- Adopt to the latest change of schema
    - texture transform bind of expressions, `scaling` -> `scale`
- Update procedure of texture transform bind of expressions based on https://github.com/vrm-c/vrm-specification/pull/316
- MToon now supports texture transforms of individual textures
