### PR TITLE
[1.0] Fix expressions

### DIFF
--- a/packages/three-vrm-core/src/expressions/VRMExpressionLoaderPlugin.ts
+++ b/packages/three-vrm-core/src/expressions/VRMExpressionLoaderPlugin.ts
@@ -5,13 +5,13 @@ import { GLTF, GLTFLoaderPlugin, GLTFParser } from 'three/examples/jsm/loaders/G
 import { gltfExtractPrimitivesFromNode } from '../utils/gltfExtractPrimitivesFromNode';
 import { VRMExpression } from './VRMExpression';
 import { VRMExpressionManager } from './VRMExpressionManager';
-import { VRMExpressionPreset } from './VRMExpressionPreset';
+import { VRMExpressionPresetName } from './VRMExpressionPresetName';
 
 /**
  * A plugin of GLTFLoader that imports a {@link VRMExpressionManager} from a VRM extension of a GLTF.
  */
 export class VRMExpressionLoaderPlugin implements GLTFLoaderPlugin {
-  public static readonly v0v1PresetNameMap: { [v0Name in V0VRM.BlendShapePresetName]?: VRMExpressionPreset } = {
+  public static readonly v0v1PresetNameMap: { [v0Name in V0VRM.BlendShapePresetName]?: VRMExpressionPresetName } = {
     a: 'aa',
     e: 'ee',
     i: 'ih',
@@ -100,7 +100,7 @@ export class VRMExpressionLoaderPlugin implements GLTFLoaderPlugin {
     }
 
     // list expressions
-    const presetNameSet = new Set<string>(Object.values(VRMExpressionPreset));
+    const presetNameSet = new Set<string>(Object.values(VRMExpressionPresetName));
     const nameSchemaExpressionMap = new Map<string, V1VRMSchema.Expression>();
 
     if (schemaExpressions.preset != null) {

--- a/packages/three-vrm-core/src/expressions/VRMExpressionLoaderPlugin.ts
+++ b/packages/three-vrm-core/src/expressions/VRMExpressionLoaderPlugin.ts
@@ -120,7 +120,7 @@ export class VRMExpressionLoaderPlugin implements GLTFLoaderPlugin {
 
     if (schemaExpressions.custom != null) {
       Object.entries(schemaExpressions.custom).forEach(([name, schemaExpression]) => {
-        if (!presetNameSet.has(name)) {
+        if (presetNameSet.has(name)) {
           console.warn(
             `VRMExpressionLoaderPlugin: Custom expression cannot have preset name "${name}". Ignoring the expression`,
           );

--- a/packages/three-vrm-core/src/expressions/VRMExpressionManager.ts
+++ b/packages/three-vrm-core/src/expressions/VRMExpressionManager.ts
@@ -1,4 +1,4 @@
-import { VRMExpressionPreset } from './VRMExpressionPreset';
+import { VRMExpressionPresetName } from './VRMExpressionPresetName';
 import { saturate } from '../utils/saturate';
 import type { VRMExpression } from './VRMExpression';
 
@@ -38,14 +38,14 @@ export class VRMExpressionManager {
   /**
    * A map from name to expression, but excluding custom expressions.
    */
-  public get presetExpressionMap(): { [name in VRMExpressionPreset]?: VRMExpression } {
-    const result: { [name in VRMExpressionPreset]?: VRMExpression } = {};
+  public get presetExpressionMap(): { [name in VRMExpressionPresetName]?: VRMExpression } {
+    const result: { [name in VRMExpressionPresetName]?: VRMExpression } = {};
 
-    const presetNameSet = new Set<string>(Object.values(VRMExpressionPreset));
+    const presetNameSet = new Set<string>(Object.values(VRMExpressionPresetName));
 
     Object.entries(this._expressionMap).forEach(([name, expression]) => {
       if (presetNameSet.has(name)) {
-        result[name as VRMExpressionPreset] = expression;
+        result[name as VRMExpressionPresetName] = expression;
       }
     });
 
@@ -58,7 +58,7 @@ export class VRMExpressionManager {
   public get customExpressionMap(): { [name: string]: VRMExpression } {
     const result: { [name: string]: VRMExpression } = {};
 
-    const presetNameSet = new Set<string>(Object.values(VRMExpressionPreset));
+    const presetNameSet = new Set<string>(Object.values(VRMExpressionPresetName));
 
     Object.entries(this._expressionMap).forEach(([name, expression]) => {
       if (!presetNameSet.has(name)) {
@@ -115,7 +115,7 @@ export class VRMExpressionManager {
    *
    * @param name Name or preset name of the expression
    */
-  public getExpression(name: VRMExpressionPreset | string): VRMExpression | null {
+  public getExpression(name: VRMExpressionPresetName | string): VRMExpression | null {
     return this._expressionMap[name] ?? null;
   }
 
@@ -150,7 +150,7 @@ export class VRMExpressionManager {
    *
    * @param name Name of the expression
    */
-  public getValue(name: VRMExpressionPreset | string): number | null {
+  public getValue(name: VRMExpressionPresetName | string): number | null {
     const expression = this.getExpression(name);
     return expression?.weight ?? null;
   }
@@ -161,7 +161,7 @@ export class VRMExpressionManager {
    * @param name Name of the expression
    * @param weight Weight
    */
-  public setValue(name: VRMExpressionPreset | string, weight: number): void {
+  public setValue(name: VRMExpressionPresetName | string, weight: number): void {
     const expression = this.getExpression(name);
     if (expression) {
       expression.weight = saturate(weight);
@@ -194,7 +194,7 @@ export class VRMExpressionManager {
    *
    * @param name Name of the expression
    */
-  public getExpressionTrackName(name: VRMExpressionPreset | string): string | null {
+  public getExpressionTrackName(name: VRMExpressionPresetName | string): string | null {
     const expression = this.getExpression(name);
     return expression ? `${expression.name}.weight` : null;
   }

--- a/packages/three-vrm-core/src/expressions/VRMExpressionManager.ts
+++ b/packages/three-vrm-core/src/expressions/VRMExpressionManager.ts
@@ -1,4 +1,4 @@
-import type { VRMExpressionPreset } from './VRMExpressionPreset';
+import { VRMExpressionPreset } from './VRMExpressionPreset';
 import { saturate } from '../utils/saturate';
 import type { VRMExpression } from './VRMExpression';
 
@@ -33,6 +33,40 @@ export class VRMExpressionManager {
   private _expressionMap: { [name: string]: VRMExpression } = {};
   public get expressionMap(): { [name: string]: VRMExpression } {
     return Object.assign({}, this._expressionMap);
+  }
+
+  /**
+   * A map from name to expression, but excluding custom expressions.
+   */
+  public get presetExpressionMap(): { [name in VRMExpressionPreset]?: VRMExpression } {
+    const result: { [name in VRMExpressionPreset]?: VRMExpression } = {};
+
+    const presetNameSet = new Set<string>(Object.values(VRMExpressionPreset));
+
+    Object.entries(this._expressionMap).forEach(([name, expression]) => {
+      if (presetNameSet.has(name)) {
+        result[name as VRMExpressionPreset] = expression;
+      }
+    });
+
+    return result;
+  }
+
+  /**
+   * A map from name to expression, but excluding preset expressions.
+   */
+  public get customExpressionMap(): { [name: string]: VRMExpression } {
+    const result: { [name: string]: VRMExpression } = {};
+
+    const presetNameSet = new Set<string>(Object.values(VRMExpressionPreset));
+
+    Object.entries(this._expressionMap).forEach(([name, expression]) => {
+      if (!presetNameSet.has(name)) {
+        result[name] = expression;
+      }
+    });
+
+    return result;
   }
 
   /**

--- a/packages/three-vrm-core/src/expressions/VRMExpressionPresetName.ts
+++ b/packages/three-vrm-core/src/expressions/VRMExpressionPresetName.ts
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 
-export const VRMExpressionPreset = {
+export const VRMExpressionPresetName = {
   Aa: 'aa',
   Ih: 'ih',
   Ou: 'ou',
@@ -21,4 +21,4 @@ export const VRMExpressionPreset = {
   Neutral: 'neutral',
 } as const;
 
-export type VRMExpressionPreset = typeof VRMExpressionPreset[keyof typeof VRMExpressionPreset];
+export type VRMExpressionPresetName = typeof VRMExpressionPresetName[keyof typeof VRMExpressionPresetName];

--- a/packages/three-vrm-core/src/expressions/index.ts
+++ b/packages/three-vrm-core/src/expressions/index.ts
@@ -6,6 +6,6 @@ export type { VRMExpressionMaterialColorBindState } from './VRMExpressionMateria
 export { VRMExpressionMaterialColorType } from './VRMExpressionMaterialColorType';
 export type { VRMExpressionMorphTargetBind } from './VRMExpressionMorphTargetBind';
 export { VRMExpressionOverrideType } from './VRMExpressionOverrideType';
-export { VRMExpressionPreset } from './VRMExpressionPreset';
+export { VRMExpressionPresetName as VRMExpressionPreset } from './VRMExpressionPresetName';
 export type { VRMExpressionTextureTransformBind } from './VRMExpressionTextureTransformBind';
 export type { VRMExpressionTextureTransformBindState } from './VRMExpressionTextureTransformBindState';


### PR DESCRIPTION
- Fix import of custom expressions
- Add new methods to `VRMExpressionManager`
    - `presetExpressionMap`
    - `customExpressionMap`
- 🚨 BREAKING: `VRMExpressionPreset` -> `VRMExpressionPresetName`
