### PR TITLE
fix (mtoon): fix an error on mtoon shader that occurs when there are multiple lights

### DIFF
--- a/packages/three-vrm/src/material/shaders/mtoon.frag
+++ b/packages/three-vrm/src/material/shaders/mtoon.frag
@@ -418,6 +418,10 @@ void main() {
   IncidentLight directLight;
   vec3 lightingSum = vec3( 0.0 );
 
+  // since these variables will be used in unrolled loop, we have to define in prior
+  float atten, shadow, lightIntensity;
+  vec3 lighting;
+
   #if ( NUM_POINT_LIGHTS > 0 )
     PointLight pointLight;
 
@@ -430,15 +434,15 @@ void main() {
       pointLight = pointLights[ i ];
       getPointDirectLightIrradiance( pointLight, geometry, directLight );
 
-      float atten = 1.0;
+      atten = 1.0;
       #if defined( USE_SHADOWMAP ) && ( UNROLLED_LOOP_INDEX < NUM_POINT_LIGHT_SHADOWS )
       pointLightShadow = pointLightShadows[ i ];
       atten = all( bvec2( directLight.visible, receiveShadow ) ) ? getPointShadow( pointShadowMap[ i ], pointLightShadow.shadowMapSize, pointLightShadow.shadowBias, pointLightShadow.shadowRadius, vPointShadowCoord[ i ], pointLightShadow.shadowCameraNear, pointLightShadow.shadowCameraFar ) : 1.0;
       #endif
 
-      float shadow = 1.0 - material.receiveShadow * ( 1.0 - ( 0.5 + 0.5 * atten ) );
-      float lightIntensity = getLightIntensity( directLight, geometry, shadow, material.shadingGrade );
-      vec3 lighting = getLighting( directLight.color );
+      shadow = 1.0 - material.receiveShadow * ( 1.0 - ( 0.5 + 0.5 * atten ) );
+      lightIntensity = getLightIntensity( directLight, geometry, shadow, material.shadingGrade );
+      lighting = getLighting( directLight.color );
       reflectedLight.directDiffuse += getDiffuse( material, lightIntensity, lighting );
       lightingSum += lighting;
     }
@@ -457,15 +461,15 @@ void main() {
       spotLight = spotLights[ i ];
       getSpotDirectLightIrradiance( spotLight, geometry, directLight );
 
-      float atten = 1.0;
+      atten = 1.0;
       #if defined( USE_SHADOWMAP ) && ( UNROLLED_LOOP_INDEX < NUM_SPOT_LIGHT_SHADOWS )
       spotLightShadow = spotLightShadows[ i ];
       atten = all( bvec2( directLight.visible, receiveShadow ) ) ? getShadow( spotShadowMap[ i ], spotLightShadow.shadowMapSize, spotLightShadow.shadowBias, spotLightShadow.shadowRadius, vSpotShadowCoord[ i ] ) : 1.0;
       #endif
 
-      float shadow = 1.0 - material.receiveShadow * ( 1.0 - ( 0.5 + 0.5 * atten ) );
-      float lightIntensity = getLightIntensity( directLight, geometry, shadow, material.shadingGrade );
-      vec3 lighting = getLighting( directLight.color );
+      shadow = 1.0 - material.receiveShadow * ( 1.0 - ( 0.5 + 0.5 * atten ) );
+      lightIntensity = getLightIntensity( directLight, geometry, shadow, material.shadingGrade );
+      lighting = getLighting( directLight.color );
       reflectedLight.directDiffuse += getDiffuse( material, lightIntensity, lighting );
       lightingSum += lighting;
     }
@@ -484,15 +488,15 @@ void main() {
       directionalLight = directionalLights[ i ];
       getDirectionalDirectLightIrradiance( directionalLight, geometry, directLight );
 
-      float atten = 1.0;
+      atten = 1.0;
       #if defined( USE_SHADOWMAP ) && ( UNROLLED_LOOP_INDEX < NUM_DIR_LIGHT_SHADOWS )
       directionalLightShadow = directionalLightShadows[ i ];
       atten = all( bvec2( directLight.visible, receiveShadow ) ) ? getShadow( directionalShadowMap[ i ], directionalLightShadow.shadowMapSize, directionalLightShadow.shadowBias, directionalLightShadow.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;
       #endif
 
-      float shadow = 1.0 - material.receiveShadow * ( 1.0 - ( 0.5 + 0.5 * atten ) );
-      float lightIntensity = getLightIntensity( directLight, geometry, shadow, material.shadingGrade );
-      vec3 lighting = getLighting( directLight.color );
+      shadow = 1.0 - material.receiveShadow * ( 1.0 - ( 0.5 + 0.5 * atten ) );
+      lightIntensity = getLightIntensity( directLight, geometry, shadow, material.shadingGrade );
+      lighting = getLighting( directLight.color );
       reflectedLight.directDiffuse += getDiffuse( material, lightIntensity, lighting );
       lightingSum += lighting;
     }


### PR DESCRIPTION
will resolve #794 

### Description

Certain variables related to lighting are defined inside of unroll loop which causes redifinition errors,
and it only happens when there are multiple lights.
This PR will fix this.

### Points need review

I think the change is pretty obvious.
