### PR TITLE
fix (1.0, expressions): Revert behavior of texture transform bind

### DIFF
--- a/packages/three-vrm-core/src/expressions/VRMExpressionTextureTransformBind.ts
+++ b/packages/three-vrm-core/src/expressions/VRMExpressionTextureTransformBind.ts
@@ -107,8 +107,8 @@ export class VRMExpressionTextureTransformBind implements VRMExpressionBind {
 
         const initialOffset = texture.offset.clone();
         const initialScale = texture.repeat.clone();
-        const deltaOffset = offset.clone().multiply(initialScale);
-        const deltaScale = scale.clone().addScalar(-1).multiply(initialScale);
+        const deltaOffset = offset.clone().sub(initialOffset);
+        const deltaScale = scale.clone().sub(initialScale);
 
         this._properties.push({
           name: propertyName,


### PR DESCRIPTION
Based on closure of https://github.com/vrm-c/vrm-specification/issues/279 , this PR reverts the behavior of texture transform to the previous one.
