### PR TITLE
[1.0] fix: extensionsUsed might be undefined

### DIFF
--- a/packages/three-vrm-core/src/expressions/VRMExpressionLoaderPlugin.ts
+++ b/packages/three-vrm-core/src/expressions/VRMExpressionLoaderPlugin.ts
@@ -72,7 +72,7 @@ export class VRMExpressionLoaderPlugin implements GLTFLoaderPlugin {
 
   private async _v1Import(gltf: GLTF): Promise<VRMExpressionManager | null> {
     // early abort if it doesn't use vrm
-    const isVRMUsed = this.parser.json.extensionsUsed.indexOf('VRMC_vrm') !== -1;
+    const isVRMUsed = this.parser.json.extensionsUsed?.indexOf('VRMC_vrm') !== -1;
     if (!isVRMUsed) {
       return null;
     }

--- a/packages/three-vrm-core/src/firstPerson/VRMFirstPersonLoaderPlugin.ts
+++ b/packages/three-vrm-core/src/firstPerson/VRMFirstPersonLoaderPlugin.ts
@@ -61,7 +61,7 @@ export class VRMFirstPersonLoaderPlugin implements GLTFLoaderPlugin {
 
   private async _v1Import(gltf: GLTF, humanoid: VRMHumanoid): Promise<VRMFirstPerson | null> {
     // early abort if it doesn't use vrm
-    const isVRMUsed = this.parser.json.extensionsUsed.indexOf('VRMC_vrm') !== -1;
+    const isVRMUsed = this.parser.json.extensionsUsed?.indexOf('VRMC_vrm') !== -1;
     if (!isVRMUsed) {
       return null;
     }

--- a/packages/three-vrm-core/src/humanoid/VRMHumanoidLoaderPlugin.ts
+++ b/packages/three-vrm-core/src/humanoid/VRMHumanoidLoaderPlugin.ts
@@ -45,7 +45,7 @@ export class VRMHumanoidLoaderPlugin implements GLTFLoaderPlugin {
 
   private async _v1Import(gltf: GLTF): Promise<VRMHumanoid | null> {
     // early abort if it doesn't use vrm
-    const isVRMUsed = this.parser.json.extensionsUsed.indexOf('VRMC_vrm') !== -1;
+    const isVRMUsed = this.parser.json.extensionsUsed?.indexOf('VRMC_vrm') !== -1;
     if (!isVRMUsed) {
       return null;
     }

--- a/packages/three-vrm-core/src/lookAt/VRMLookAtLoaderPlugin.ts
+++ b/packages/three-vrm-core/src/lookAt/VRMLookAtLoaderPlugin.ts
@@ -90,7 +90,7 @@ export class VRMLookAtLoaderPlugin implements GLTFLoaderPlugin {
     expressions: VRMExpressionManager,
   ): Promise<VRMLookAt | null> {
     // early abort if it doesn't use vrm
-    const isVRMUsed = this.parser.json.extensionsUsed.indexOf('VRMC_vrm') !== -1;
+    const isVRMUsed = this.parser.json.extensionsUsed?.indexOf('VRMC_vrm') !== -1;
     if (!isVRMUsed) {
       return null;
     }

--- a/packages/three-vrm-core/src/meta/VRMMetaLoaderPlugin.ts
+++ b/packages/three-vrm-core/src/meta/VRMMetaLoaderPlugin.ts
@@ -67,7 +67,7 @@ export class VRMMetaLoaderPlugin implements GLTFLoaderPlugin {
 
   private async _v1Import(gltf: GLTF): Promise<VRM1Meta | null> {
     // early abort if it doesn't use vrm
-    const isVRMUsed = this.parser.json.extensionsUsed.indexOf('VRMC_vrm') !== -1;
+    const isVRMUsed = this.parser.json.extensionsUsed?.indexOf('VRMC_vrm') !== -1;
     if (!isVRMUsed) {
       return null;
     }

--- a/packages/three-vrm-node-constraint/src/VRMNodeConstraintLoaderPlugin.ts
+++ b/packages/three-vrm-node-constraint/src/VRMNodeConstraintLoaderPlugin.ts
@@ -43,7 +43,7 @@ export class VRMNodeConstraintLoaderPlugin implements GLTFLoaderPlugin {
   protected async _import(gltf: GLTF): Promise<VRMNodeConstraintManager | null> {
     // early abort if it doesn't use constraints
     const isConstraintsUsed =
-      this.parser.json.extensionsUsed.indexOf(VRMNodeConstraintLoaderPlugin.EXTENSION_NAME) !== -1;
+      this.parser.json.extensionsUsed?.indexOf(VRMNodeConstraintLoaderPlugin.EXTENSION_NAME) !== -1;
     if (!isConstraintsUsed) {
       return null;
     }

--- a/packages/three-vrm-springbone/src/VRMSpringBoneLoaderPlugin.ts
+++ b/packages/three-vrm-springbone/src/VRMSpringBoneLoaderPlugin.ts
@@ -68,7 +68,7 @@ export class VRMSpringBoneLoaderPlugin implements GLTFLoaderPlugin {
 
   private async _v1Import(gltf: GLTF): Promise<VRMSpringBoneManager | null> {
     // early abort if it doesn't use spring bones
-    const isSpringBoneUsed = gltf.parser.json.extensionsUsed.indexOf(VRMSpringBoneLoaderPlugin.EXTENSION_NAME) !== -1;
+    const isSpringBoneUsed = gltf.parser.json.extensionsUsed?.indexOf(VRMSpringBoneLoaderPlugin.EXTENSION_NAME) !== -1;
     if (!isSpringBoneUsed) {
       return null;
     }
@@ -181,7 +181,7 @@ export class VRMSpringBoneLoaderPlugin implements GLTFLoaderPlugin {
 
   private async _v0Import(gltf: GLTF): Promise<VRMSpringBoneManager | null> {
     // early abort if it doesn't use vrm
-    const isVRMUsed = gltf.parser.json.extensionsUsed.indexOf('VRM') !== -1;
+    const isVRMUsed = gltf.parser.json.extensionsUsed?.indexOf('VRM') !== -1;
     if (!isVRMUsed) {
       return null;
     }


### PR DESCRIPTION
`extensionsUsed` might be undefined where VRM is not defined 

It causes an exception where loading glTF is not VRM
