### PR TITLE
[1.0] let firstperson and lookat importer work even if humanoid and expressions are null

### DIFF
--- a/packages/three-vrm-core/src/firstPerson/VRMFirstPersonLoaderPlugin.ts
+++ b/packages/three-vrm-core/src/firstPerson/VRMFirstPersonLoaderPlugin.ts
@@ -25,7 +25,11 @@ export class VRMFirstPersonLoaderPlugin implements GLTFLoaderPlugin {
   public async afterRoot(gltf: GLTF): Promise<void> {
     const vrmHumanoid = gltf.userData.vrmHumanoid as VRMHumanoid | undefined;
 
-    if (vrmHumanoid == null) {
+    // explicitly distinguish null and undefined
+    // since vrmHumanoid might be null as a result
+    if (vrmHumanoid === null) {
+      return;
+    } else if (vrmHumanoid === undefined) {
       throw new Error(
         'VRMFirstPersonLoaderPlugin: vrmHumanoid is undefined. VRMHumanoidLoaderPlugin have to be used first',
       );

--- a/packages/three-vrm-core/src/lookAt/VRMLookAtLoaderPlugin.ts
+++ b/packages/three-vrm-core/src/lookAt/VRMLookAtLoaderPlugin.ts
@@ -38,7 +38,11 @@ export class VRMLookAtLoaderPlugin implements GLTFLoaderPlugin {
   public async afterRoot(gltf: GLTF): Promise<void> {
     const vrmHumanoid = gltf.userData.vrmHumanoid as VRMHumanoid | undefined;
 
-    if (vrmHumanoid == null) {
+    // explicitly distinguish null and undefined
+    // since vrmHumanoid might be null as a result
+    if (vrmHumanoid === null) {
+      return;
+    } else if (vrmHumanoid === undefined) {
       throw new Error(
         'VRMFirstPersonLoaderPlugin: vrmHumanoid is undefined. VRMHumanoidLoaderPlugin have to be used first',
       );
@@ -46,7 +50,9 @@ export class VRMLookAtLoaderPlugin implements GLTFLoaderPlugin {
 
     const vrmExpressionManager = gltf.userData.vrmExpressionManager as VRMExpressionManager | undefined;
 
-    if (vrmExpressionManager == null) {
+    if (vrmExpressionManager === null) {
+      return;
+    } else if (vrmExpressionManager === undefined) {
       throw new Error(
         'VRMFirstPersonLoaderPlugin: vrmExpressionManager is undefined. VRMExpressionLoaderPlugin have to be used first',
       );


### PR DESCRIPTION
Sequel of #831 

This will make `VRMFirstPersonLoaderPlugin` and `VRMLookAtLoaderPlugin` work even if `vrmHumanoid` and `vrmExpressions` are `null`
This is required to handle non-VRM glTF properly
