### PR TITLE
[1.0] bump three.js to r133

### DIFF
--- a/packages/three-vrm-core/examples/expressions.html
+++ b/packages/three-vrm-core/examples/expressions.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.126.1/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.126.1/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.126.1/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm-core.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm-core/examples/firstPerson.html
+++ b/packages/three-vrm-core/examples/firstPerson.html
@@ -24,9 +24,9 @@
 
 	<body>
 		<span id="info"></span>
-		<script src="https://unpkg.com/three@0.126.1/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.126.1/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.126.1/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm-core.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm-core/examples/humanoid.html
+++ b/packages/three-vrm-core/examples/humanoid.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.126.1/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.126.1/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.126.1/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm-core.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm-core/examples/lookAt.html
+++ b/packages/three-vrm-core/examples/lookAt.html
@@ -24,9 +24,9 @@
 
 	<body>
 		<span id="info"></span>
-		<script src="https://unpkg.com/three@0.126.1/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.126.1/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.126.1/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm-core.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm-core/examples/meta.html
+++ b/packages/three-vrm-core/examples/meta.html
@@ -31,9 +31,9 @@
 	<body>
 		<span id="meta"></span>
 		<img id="thumbnail" alt="thumbnail" />
-		<script src="https://unpkg.com/three@0.126.1/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.126.1/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.126.1/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm-core.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm-core/package.json
+++ b/packages/three-vrm-core/package.json
@@ -50,12 +50,12 @@
     "@pixiv/types-vrmc-vrm-1.0": "1.0.0-beta.3"
   },
   "devDependencies": {
-    "@types/three": "^0.126.2",
+    "@types/three": "^0.133.1",
     "lint-staged": "10.5.3",
-    "three": "^0.126.1"
+    "three": "^0.133.1"
   },
   "peerDependencies": {
-    "@types/three": "^0.126.2",
-    "three": "^0.126.1"
+    "@types/three": "^0.133.1",
+    "three": "^0.133.1"
   }
 }

--- a/packages/three-vrm-core/src/expressions/VRMExpressionLoaderPlugin.ts
+++ b/packages/three-vrm-core/src/expressions/VRMExpressionLoaderPlugin.ts
@@ -3,6 +3,7 @@ import type * as V1VRMSchema from '@pixiv/types-vrmc-vrm-1.0';
 import * as THREE from 'three';
 import { GLTF, GLTFLoaderPlugin, GLTFParser } from 'three/examples/jsm/loaders/GLTFLoader';
 import { gltfExtractPrimitivesFromNode } from '../utils/gltfExtractPrimitivesFromNode';
+import { gltfGetAssociatedMaterialIndex } from '../utils/gltfGetAssociatedMaterialIndex';
 import { VRMExpression } from './VRMExpression';
 import { VRMExpressionManager } from './VRMExpressionManager';
 import { VRMExpressionMaterialColorBind } from './VRMExpressionMaterialColorBind';
@@ -181,7 +182,8 @@ export class VRMExpressionLoaderPlugin implements GLTFLoaderPlugin {
 
           schemaExpression.materialColorBinds?.forEach(async (bind) => {
             const materials = gltfMaterials.filter((material) => {
-              return this.parser.associations.get(material)?.index === bind.material;
+              const materialIndex = gltfGetAssociatedMaterialIndex(this.parser, material);
+              return bind.material === materialIndex;
             });
 
             materials.forEach((material) => {
@@ -197,7 +199,8 @@ export class VRMExpressionLoaderPlugin implements GLTFLoaderPlugin {
 
           schemaExpression.textureTransformBinds?.forEach(async (bind) => {
             const materials = gltfMaterials.filter((material) => {
-              return this.parser.associations.get(material)?.index === bind.material;
+              const materialIndex = gltfGetAssociatedMaterialIndex(this.parser, material);
+              return bind.material === materialIndex;
             });
 
             materials.forEach((material) => {

--- a/packages/three-vrm-core/src/utils/gltfGetAssociatedMaterialIndex.ts
+++ b/packages/three-vrm-core/src/utils/gltfGetAssociatedMaterialIndex.ts
@@ -1,0 +1,39 @@
+import * as THREE from 'three';
+import { GLTFParser } from 'three/examples/jsm/loaders/GLTFLoader';
+
+/**
+ * Get a material definition index of glTF from associated material.
+ * It's basically a comat code between Three.js r133 or above and previous versions.
+ * @param parser GLTFParser
+ * @param material A material of gltf
+ * @returns Material definition index of glTF
+ */
+export function gltfGetAssociatedMaterialIndex(parser: GLTFParser, material: THREE.Material): number | null {
+  const threeRevision = parseInt(THREE.REVISION, 10);
+
+  let index: number | null = null;
+
+  if (threeRevision >= 133) {
+    index = parser.associations.get(material)?.materials ?? null;
+  } else {
+    // COMPAT: structure of `parser.associations` has been changed @ r133
+    // See: https://github.com/mrdoob/three.js/pull/21737
+    // Ref: https://github.com/three-types/three-ts-types/commit/5246676e479b61a9ff2db71df4119f6f1462580d
+    type GLTFReferencePre133 = {
+      type: 'materials' | 'nodes' | 'textures' | 'meshes';
+      index: number;
+    };
+
+    type GLTFAssociationsPre133 = Map<THREE.Object3D | THREE.Material | THREE.Texture, GLTFReferencePre133>;
+
+    const associations = parser.associations as GLTFAssociationsPre133;
+
+    const reference = associations.get(material);
+
+    if (reference?.type === 'materials') {
+      index = reference.index;
+    }
+  }
+
+  return index;
+}

--- a/packages/three-vrm-materials-hdr-emissive-multiplier/examples/loader-plugin.html
+++ b/packages/three-vrm-materials-hdr-emissive-multiplier/examples/loader-plugin.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.126.1/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.126.1/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.126.1/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm-materials-hdr-emissive-multiplier.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm-materials-hdr-emissive-multiplier/package.json
+++ b/packages/three-vrm-materials-hdr-emissive-multiplier/package.json
@@ -45,11 +45,11 @@
     "@pixiv/types-vrmc-materials-hdr-emissive-multiplier-1.0": "1.0.0-beta.3"
   },
   "devDependencies": {
-    "@types/three": "^0.126.2",
-    "three": "^0.126.1"
+    "@types/three": "^0.133.1",
+    "three": "^0.133.1"
   },
   "peerDependencies": {
-    "@types/three": "^0.126.2",
-    "three": "^0.126.1"
+    "@types/three": "^0.133.1",
+    "three": "^0.133.1"
   }
 }

--- a/packages/three-vrm-materials-hdr-emissive-multiplier/src/utils/gltfGetAssociatedMaterialIndex.ts
+++ b/packages/three-vrm-materials-hdr-emissive-multiplier/src/utils/gltfGetAssociatedMaterialIndex.ts
@@ -1,0 +1,39 @@
+import * as THREE from 'three';
+import { GLTFParser } from 'three/examples/jsm/loaders/GLTFLoader';
+
+/**
+ * Get a material definition index of glTF from associated material.
+ * It's basically a comat code between Three.js r133 or above and previous versions.
+ * @param parser GLTFParser
+ * @param material A material of gltf
+ * @returns Material definition index of glTF
+ */
+export function gltfGetAssociatedMaterialIndex(parser: GLTFParser, material: THREE.Material): number | null {
+  const threeRevision = parseInt(THREE.REVISION, 10);
+
+  let index: number | null = null;
+
+  if (threeRevision >= 133) {
+    index = parser.associations.get(material)?.materials ?? null;
+  } else {
+    // COMPAT: structure of `parser.associations` has been changed @ r133
+    // See: https://github.com/mrdoob/three.js/pull/21737
+    // Ref: https://github.com/three-types/three-ts-types/commit/5246676e479b61a9ff2db71df4119f6f1462580d
+    type GLTFReferencePre133 = {
+      type: 'materials' | 'nodes' | 'textures' | 'meshes';
+      index: number;
+    };
+
+    type GLTFAssociationsPre133 = Map<THREE.Object3D | THREE.Material | THREE.Texture, GLTFReferencePre133>;
+
+    const associations = parser.associations as GLTFAssociationsPre133;
+
+    const reference = associations.get(material);
+
+    if (reference?.type === 'materials') {
+      index = reference.index;
+    }
+  }
+
+  return index;
+}

--- a/packages/three-vrm-materials-mtoon/examples/loader-plugin.html
+++ b/packages/three-vrm-materials-mtoon/examples/loader-plugin.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.126.1/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.126.1/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.126.1/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm-materials-mtoon.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm-materials-mtoon/package.json
+++ b/packages/three-vrm-materials-mtoon/package.json
@@ -46,11 +46,11 @@
     "@pixiv/types-vrmc-materials-mtoon-1.0": "1.0.0-beta.3"
   },
   "devDependencies": {
-    "@types/three": "^0.126.2",
-    "three": "^0.126.1"
+    "@types/three": "^0.133.1",
+    "three": "^0.133.1"
   },
   "peerDependencies": {
-    "@types/three": "^0.126.2",
-    "three": "^0.126.1"
+    "@types/three": "^0.133.1",
+    "three": "^0.133.1"
   }
 }

--- a/packages/three-vrm-materials-mtoon/src/MToonMaterial.ts
+++ b/packages/three-vrm-materials-mtoon/src/MToonMaterial.ts
@@ -336,9 +336,18 @@ export class MToonMaterial extends THREE.ShaderMaterial {
     parameters.lights = true;
     parameters.clipping = true;
 
-    parameters.skinning = parameters.skinning || false;
-    parameters.morphTargets = parameters.morphTargets || false;
-    parameters.morphNormals = parameters.morphNormals || false;
+    // COMPAT
+    // See: https://github.com/mrdoob/three.js/pull/21788
+    if (parseInt(THREE.REVISION, 10) < 129) {
+      (parameters as any).skinning = (parameters as any).skinning || false;
+    }
+
+    // COMPAT
+    // See: https://github.com/mrdoob/three.js/pull/22169
+    if (parseInt(THREE.REVISION, 10) < 131) {
+      (parameters as any).morphTargets = (parameters as any).morphTargets || false;
+      (parameters as any).morphNormals = (parameters as any).morphNormals || false;
+    }
 
     // == uniforms =================================================================================
     this.uniforms = THREE.UniformsUtils.merge([

--- a/packages/three-vrm-materials-mtoon/src/MToonMaterial.ts
+++ b/packages/three-vrm-materials-mtoon/src/MToonMaterial.ts
@@ -446,6 +446,23 @@ export class MToonMaterial extends THREE.ShaderMaterial {
     super.copy(source);
     // uniforms are already copied at this moment
 
+    // Beginning from r133, uniform textures will be cloned instead of reference
+    // See: https://github.com/mrdoob/three.js/blob/a8813be04a849bd155f7cf6f1b23d8ee2e0fb48b/examples/jsm/loaders/GLTFLoader.js#L3047
+    // See: https://github.com/mrdoob/three.js/blob/a8813be04a849bd155f7cf6f1b23d8ee2e0fb48b/src/renderers/shaders/UniformsUtils.js#L22
+    // This will leave their `.version` to be `0`
+    // and these textures won't be uploaded to GPU
+    // We are going to workaround this in here
+    // I've opened an issue for this: https://github.com/mrdoob/three.js/issues/22718
+    this.map = source.map;
+    this.normalMap = source.normalMap;
+    this.emissiveMap = source.emissiveMap;
+    this.shadeMultiplyTexture = source.shadeMultiplyTexture;
+    this.shadingShiftTexture = source.shadingShiftTexture;
+    this.matcapTexture = source.matcapTexture;
+    this.rimMultiplyTexture = source.rimMultiplyTexture;
+    this.outlineWidthMultiplyTexture = source.outlineWidthMultiplyTexture;
+    this.uvAnimationMaskTexture = source.uvAnimationMaskTexture;
+
     // == copy members =============================================================================
     this.normalMapType = source.normalMapType;
 

--- a/packages/three-vrm-materials-mtoon/src/MToonMaterial.ts
+++ b/packages/three-vrm-materials-mtoon/src/MToonMaterial.ts
@@ -520,8 +520,9 @@ export class MToonMaterial extends THREE.ShaderMaterial {
     // == compat ===================================================================================
 
     // COMPAT
-    // Three.js r132 introduces a new shader chunk <alphatest_pars_fragment>
+    // Three.js r132 introduces new shader chunks <normal_pars_fragment> and <alphatest_pars_fragment>
     if (threeRevision < 132) {
+      this.fragmentShader = this.fragmentShader.replace('#include <normal_pars_fragment>', '');
       this.fragmentShader = this.fragmentShader.replace('#include <alphatest_pars_fragment>', '');
     }
 

--- a/packages/three-vrm-materials-mtoon/src/MToonMaterial.ts
+++ b/packages/three-vrm-materials-mtoon/src/MToonMaterial.ts
@@ -17,6 +17,7 @@ import type { MToonMaterialParameters } from './MToonMaterialParameters';
 export class MToonMaterial extends THREE.ShaderMaterial {
   public uniforms: {
     litFactor: THREE.IUniform<THREE.Color>;
+    alphaTest: THREE.IUniform<number>;
     opacity: THREE.IUniform<number>;
     map: THREE.IUniform<THREE.Texture | null>;
     mapUvTransform: THREE.IUniform<THREE.Matrix3>;
@@ -430,6 +431,13 @@ export class MToonMaterial extends THREE.ShaderMaterial {
       this.uniforms.outlineWidthMultiplyTextureUvTransform,
     );
     this._updateTextureMatrix(this.uniforms.uvAnimationMaskTexture, this.uniforms.uvAnimationMaskTextureUvTransform);
+
+    // COMPAT workaround: starting from r132, alphaTest becomes a uniform instead of preprocessor value
+    const threeRevision = parseInt(THREE.REVISION, 10);
+
+    if (threeRevision >= 132) {
+      this.uniforms.alphaTest.value = this.alphaTest;
+    }
 
     this.uniformsNeedUpdate = true;
   }

--- a/packages/three-vrm-materials-mtoon/src/MToonMaterial.ts
+++ b/packages/three-vrm-materials-mtoon/src/MToonMaterial.ts
@@ -477,10 +477,12 @@ export class MToonMaterial extends THREE.ShaderMaterial {
       this.rimMultiplyTexture !== null ||
       this.uvAnimationMaskTexture !== null;
 
+    const threeRevision = parseInt(THREE.REVISION, 10);
+
     this.defines = {
       // Temporary compat against shader change @ Three.js r126
       // See: #21205, #21307, #21299
-      THREE_VRM_THREE_REVISION: parseInt(THREE.REVISION, 10),
+      THREE_VRM_THREE_REVISION: threeRevision,
 
       OUTLINE: this._isOutline,
       MTOON_USE_UV: useUvInVert || useUvInFrag, // we can't use `USE_UV` , it will be redefined in WebGLProgram.js
@@ -514,6 +516,14 @@ export class MToonMaterial extends THREE.ShaderMaterial {
     // == generate shader code =====================================================================
     this.vertexShader = vertexShader;
     this.fragmentShader = encodings + fragmentShader;
+
+    // == compat ===================================================================================
+
+    // COMPAT
+    // Three.js r132 introduces a new shader chunk <alphatest_pars_fragment>
+    if (threeRevision < 132) {
+      this.fragmentShader = this.fragmentShader.replace('#include <alphatest_pars_fragment>', '');
+    }
 
     // == set needsUpdate flag =====================================================================
     this.needsUpdate = true;

--- a/packages/three-vrm-materials-mtoon/src/MToonMaterial.ts
+++ b/packages/three-vrm-materials-mtoon/src/MToonMaterial.ts
@@ -471,7 +471,7 @@ export class MToonMaterial extends THREE.ShaderMaterial {
     this.defines = {
       // Temporary compat against shader change @ Three.js r126
       // See: #21205, #21307, #21299
-      THREE_VRM_THREE_REVISION_126: parseInt(THREE.REVISION) >= 126,
+      THREE_VRM_THREE_REVISION: parseInt(THREE.REVISION, 10),
 
       OUTLINE: this._isOutline,
       MTOON_USE_UV: useUvInVert || useUvInFrag, // we can't use `USE_UV` , it will be redefined in WebGLProgram.js

--- a/packages/three-vrm-materials-mtoon/src/shaders/mtoon.frag
+++ b/packages/three-vrm-materials-mtoon/src/shaders/mtoon.frag
@@ -573,7 +573,11 @@ void main() {
 
     vec3 irradiance = getAmbientLightIrradiance( ambientLightColor );
 
-    irradiance += getLightProbeIrradiance( lightProbe, geometry );
+    #if THREE_VRM_THREE_REVISION >= 133
+      irradiance += getLightProbeIrradiance( lightProbe, geometry.normal );
+    #else
+      irradiance += getLightProbeIrradiance( lightProbe, geometry );
+    #endif
 
     #if ( NUM_HEMI_LIGHTS > 0 )
 

--- a/packages/three-vrm-materials-mtoon/src/shaders/mtoon.frag
+++ b/packages/three-vrm-materials-mtoon/src/shaders/mtoon.frag
@@ -466,7 +466,11 @@ void main() {
 
       pointLight = pointLights[ i ];
 
-      getPointDirectLightIrradiance( pointLight, geometry, directLight );
+      #if THREE_VRM_THREE_REVISION >= 132
+        getPointLightInfo( pointLight, geometry, directLight );
+      #else
+        getPointDirectLightIrradiance( pointLight, geometry, directLight );
+      #endif
 
       float shadow = 1.0;
       #if defined( USE_SHADOWMAP ) && ( UNROLLED_LOOP_INDEX < NUM_POINT_LIGHT_SHADOWS )
@@ -493,7 +497,11 @@ void main() {
 
       spotLight = spotLights[ i ];
 
-      getSpotDirectLightIrradiance( spotLight, geometry, directLight );
+      #if THREE_VRM_THREE_REVISION >= 132
+        getSpotLightInfo( spotLight, geometry, directLight );
+      #else
+        getSpotDirectLightIrradiance( spotLight, geometry, directLight );
+      #endif
 
       float shadow = 1.0;
       #if defined( USE_SHADOWMAP ) && ( UNROLLED_LOOP_INDEX < NUM_SPOT_LIGHT_SHADOWS )
@@ -520,7 +528,11 @@ void main() {
 
       directionalLight = directionalLights[ i ];
 
-      getDirectionalDirectLightIrradiance( directionalLight, geometry, directLight );
+      #if THREE_VRM_THREE_REVISION >= 132
+        getDirectionalLightInfo( directionalLight, geometry, directLight );
+      #else
+        getDirectionalDirectLightIrradiance( directionalLight, geometry, directLight );
+      #endif
 
       float shadow = 1.0;
       #if defined( USE_SHADOWMAP ) && ( UNROLLED_LOOP_INDEX < NUM_DIR_LIGHT_SHADOWS )

--- a/packages/three-vrm-materials-mtoon/src/shaders/mtoon.frag
+++ b/packages/three-vrm-materials-mtoon/src/shaders/mtoon.frag
@@ -190,7 +190,7 @@ void RE_IndirectDiffuse_MToon( const in vec3 irradiance, const in GeometricConte
 
   // Temporary compat against shader change @ Three.js r126
   // See: #21205, #21307, #21299
-  #ifdef THREE_VRM_THREE_REVISION_126
+  #if THREE_VRM_THREE_REVISION >= 126
 
     vec3 perturbNormal2Arb( vec2 uv, vec3 eye_pos, vec3 surf_norm, vec3 mapN, float faceDirection ) {
 
@@ -359,7 +359,7 @@ void main() {
 
       // Temporary compat against shader change @ Three.js r126
       // See: #21205, #21307, #21299
-      #ifdef THREE_VRM_THREE_REVISION_126
+      #if THREE_VRM_THREE_REVISION >= 126
 
         normal = normal * faceDirection;
 
@@ -387,7 +387,7 @@ void main() {
 
       // Temporary compat against shader change @ Three.js r126
       // See: #21205, #21307, #21299
-      #ifdef THREE_VRM_THREE_REVISION_126
+      #if THREE_VRM_THREE_REVISION >= 126
 
         normal = perturbNormal2Arb( uv, -vViewPosition, normal, mapN, faceDirection );
 

--- a/packages/three-vrm-materials-mtoon/src/shaders/mtoon.frag
+++ b/packages/three-vrm-materials-mtoon/src/shaders/mtoon.frag
@@ -80,7 +80,12 @@ uniform float uvAnimationRotationPhase;
 // #include <envmap_pars_fragment>
 // #include <cube_uv_reflection_fragment>
 #include <fog_pars_fragment>
-#include <bsdfs>
+
+// #include <bsdfs>
+vec3 BRDF_Lambert( const in vec3 diffuseColor ) {
+    return RECIPROCAL_PI * diffuseColor;
+}
+
 #include <lights_pars_begin>
 
 // #include <lights_phong_pars_fragment>
@@ -124,14 +129,14 @@ vec3 getDiffuse(
   in vec3 lightColor
 ) {
   #ifdef DEBUG_LITSHADERATE
-    return vec3( BRDF_Diffuse_Lambert( shading * lightColor ) );
+    return vec3( BRDF_Lambert( shading * lightColor ) );
   #endif
 
   #ifndef PHYSICALLY_CORRECT_LIGHTS
     lightColor *= PI;
   #endif
 
-  return lightColor * BRDF_Diffuse_Lambert( mix( material.shadeColor, material.diffuseColor, shading ) );
+  return lightColor * BRDF_Lambert( mix( material.shadeColor, material.diffuseColor, shading ) );
 }
 
 void RE_Direct_MToon( const in IncidentLight directLight, const in GeometricContext geometry, const in MToonMaterial material, const in float shadow, inout ReflectedLight reflectedLight ) {
@@ -153,7 +158,7 @@ void RE_Direct_MToon( const in IncidentLight directLight, const in GeometricCont
 
 void RE_IndirectDiffuse_MToon( const in vec3 irradiance, const in GeometricContext geometry, const in MToonMaterial material, inout ReflectedLight reflectedLight ) {
   // indirect diffuse will be use diffuseColor, no shadeColor involved
-  reflectedLight.indirectDiffuse += irradiance * BRDF_Diffuse_Lambert( material.diffuseColor );
+  reflectedLight.indirectDiffuse += irradiance * BRDF_Lambert( material.diffuseColor );
 
   // directSpecular will be used for rim lighting, not an actual specular
   reflectedLight.directSpecular += irradiance;

--- a/packages/three-vrm-materials-mtoon/src/shaders/mtoon.frag
+++ b/packages/three-vrm-materials-mtoon/src/shaders/mtoon.frag
@@ -88,16 +88,22 @@ uniform float uvAnimationRotationPhase;
 
 // #include <bsdfs>
 vec3 BRDF_Lambert( const in vec3 diffuseColor ) {
-    return RECIPROCAL_PI * diffuseColor;
+  return RECIPROCAL_PI * diffuseColor;
 }
 
 #include <lights_pars_begin>
 
+#if THREE_VRM_THREE_REVISION >= 132
+  #include <normal_pars_fragment>
+#endif
+
 // #include <lights_phong_pars_fragment>
 varying vec3 vViewPosition;
 
-#ifndef FLAT_SHADED
-  varying vec3 vNormal;
+#if THREE_VRM_THREE_REVISION < 132
+  #ifndef FLAT_SHADED
+    varying vec3 vNormal;
+  #endif
 #endif
 
 struct MToonMaterial {

--- a/packages/three-vrm-materials-mtoon/src/shaders/mtoon.frag
+++ b/packages/three-vrm-materials-mtoon/src/shaders/mtoon.frag
@@ -68,6 +68,11 @@ uniform float uvAnimationRotationPhase;
 #endif
 
 // #include <alphamap_pars_fragment>
+
+#if THREE_VRM_THREE_REVISION >= 132
+  #include <alphatest_pars_fragment>
+#endif
+
 #include <aomap_pars_fragment>
 // #include <lightmap_pars_fragment>
 #include <emissivemap_pars_fragment>

--- a/packages/three-vrm-materials-mtoon/src/shaders/mtoon.frag
+++ b/packages/three-vrm-materials-mtoon/src/shaders/mtoon.frag
@@ -143,8 +143,10 @@ vec3 getDiffuse(
     return vec3( BRDF_Lambert( shading * lightColor ) );
   #endif
 
-  #ifndef PHYSICALLY_CORRECT_LIGHTS
-    lightColor *= PI;
+  #if THREE_VRM_THREE_REVISION < 132
+    #ifndef PHYSICALLY_CORRECT_LIGHTS
+      lightColor *= PI;
+    #endif
   #endif
 
   return lightColor * BRDF_Lambert( mix( material.shadeColor, material.diffuseColor, shading ) );
@@ -154,8 +156,10 @@ void RE_Direct_MToon( const in IncidentLight directLight, const in GeometricCont
   float dotNL = saturate( dot( geometry.normal, directLight.direction ) );
   vec3 irradiance = dotNL * directLight.color;
 
-  #ifndef PHYSICALLY_CORRECT_LIGHTS
-    irradiance *= PI;
+  #if THREE_VRM_THREE_REVISION < 132
+    #ifndef PHYSICALLY_CORRECT_LIGHTS
+      irradiance *= PI;
+    #endif
   #endif
 
   float shading = getShading( dotNL, shadow, material.shadingShift );

--- a/packages/three-vrm-materials-v0compat/package.json
+++ b/packages/three-vrm-materials-v0compat/package.json
@@ -46,12 +46,12 @@
     "@pixiv/types-vrmc-materials-mtoon-1.0": "1.0.0-beta.3"
   },
   "devDependencies": {
-    "@types/three": "^0.126.2",
+    "@types/three": "^0.133.1",
     "lint-staged": "10.5.4",
-    "three": "^0.126.1"
+    "three": "^0.133.1"
   },
   "peerDependencies": {
-    "@types/three": "^0.126.2",
-    "three": "^0.126.1"
+    "@types/three": "^0.133.1",
+    "three": "^0.133.1"
   }
 }

--- a/packages/three-vrm-node-constraint/examples/aim.html
+++ b/packages/three-vrm-node-constraint/examples/aim.html
@@ -19,8 +19,8 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.126.1/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.126.1/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm-node-constraint.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm-node-constraint/examples/importer.html
+++ b/packages/three-vrm-node-constraint/examples/importer.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.126.1/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.126.1/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.126.1/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm-node-constraint.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm-node-constraint/examples/position.html
+++ b/packages/three-vrm-node-constraint/examples/position.html
@@ -19,8 +19,8 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.126.1/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.126.1/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm-node-constraint.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm-node-constraint/examples/rotation.html
+++ b/packages/three-vrm-node-constraint/examples/rotation.html
@@ -19,8 +19,8 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.126.1/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.126.1/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm-node-constraint.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm-node-constraint/package.json
+++ b/packages/three-vrm-node-constraint/package.json
@@ -46,12 +46,12 @@
     "@pixiv/types-vrmc-node-constraint-1.0": "1.0.0-beta.3"
   },
   "devDependencies": {
-    "@types/three": "^0.126.2",
+    "@types/three": "^0.133.1",
     "lint-staged": "10.5.4",
-    "three": "^0.126.1"
+    "three": "^0.133.1"
   },
   "peerDependencies": {
-    "@types/three": "^0.126.2",
-    "three": "^0.126.1"
+    "@types/three": "^0.133.1",
+    "three": "^0.133.1"
   }
 }

--- a/packages/three-vrm-springbone/examples/collider.html
+++ b/packages/three-vrm-springbone/examples/collider.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.126.1/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.126.1/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.126.1/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm-springbone.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm-springbone/examples/loader-plugin.html
+++ b/packages/three-vrm-springbone/examples/loader-plugin.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.126.1/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.126.1/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.126.1/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm-springbone.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm-springbone/examples/multiple.html
+++ b/packages/three-vrm-springbone/examples/multiple.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.126.1/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.126.1/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.126.1/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm-springbone.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm-springbone/examples/single.html
+++ b/packages/three-vrm-springbone/examples/single.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.126.1/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.126.1/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.126.1/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm-springbone.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm-springbone/package.json
+++ b/packages/three-vrm-springbone/package.json
@@ -48,9 +48,9 @@
   },
   "devDependencies": {
     "lint-staged": "10.4.2",
-    "three": "^0.126.1"
+    "three": "^0.133.1"
   },
   "peerDependencies": {
-    "three": "^0.126.1"
+    "three": "^0.133.1"
   }
 }

--- a/packages/three-vrm/examples/animations.html
+++ b/packages/three-vrm/examples/animations.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.126.1/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.126.1/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.126.1/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/basic.html
+++ b/packages/three-vrm/examples/basic.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.126.1/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.126.1/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.126.1/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/bones.html
+++ b/packages/three-vrm/examples/bones.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.126.1/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.126.1/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.126.1/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/debug.html
+++ b/packages/three-vrm/examples/debug.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.126.1/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.126.1/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.126.1/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/dnd.html
+++ b/packages/three-vrm/examples/dnd.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.126.1/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.126.1/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.126.1/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/expressions.html
+++ b/packages/three-vrm/examples/expressions.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.126.1/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.126.1/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.126.1/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/firstperson.html
+++ b/packages/three-vrm/examples/firstperson.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.126.1/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.126.1/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.126.1/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/lookat-advanced.html
+++ b/packages/three-vrm/examples/lookat-advanced.html
@@ -21,9 +21,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.126.1/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.126.1/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.126.1/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			const _v3A = new THREE.Vector3();

--- a/packages/three-vrm/examples/lookat.html
+++ b/packages/three-vrm/examples/lookat.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.126.1/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.126.1/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.126.1/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/materials-debug.html
+++ b/packages/three-vrm/examples/materials-debug.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.126.1/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.126.1/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.126.1/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/meta.html
+++ b/packages/three-vrm/examples/meta.html
@@ -31,9 +31,9 @@
 	<body>
 		<span id="meta"></span>
 		<img id="thumbnail" alt="thumbnail" />
-		<script src="https://unpkg.com/three@0.126.1/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.126.1/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.126.1/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/mouse.html
+++ b/packages/three-vrm/examples/mouse.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.126.1/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.126.1/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.126.1/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.133.1/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/package.json
+++ b/packages/three-vrm/package.json
@@ -58,14 +58,14 @@
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^13.0.0",
-    "@types/three": "^0.126.2",
+    "@types/three": "^0.133.1",
     "gh-pages": "^3.1.0",
     "lint-staged": "10.5.4",
     "quicktype": "^15.0.258",
-    "three": "^0.126.1"
+    "three": "^0.133.1"
   },
   "peerDependencies": {
-    "@types/three": "^0.126.2",
-    "three": "^0.126.1"
+    "@types/three": "^0.133.1",
+    "three": "^0.133.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1622,10 +1622,10 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
 
-"@types/three@^0.126.2":
-  version "0.126.2"
-  resolved "https://registry.yarnpkg.com/@types/three/-/three-0.126.2.tgz#68838cc92cc89c156c05be63e54efc91f58a5417"
-  integrity sha512-6JqTgijtfXcTJik8NtiNxr2L90ex6ElM00qilOGeUcrEsJLOdzLJSIkXHUYS+KPAYQYtRJQKD6XaXds3HjS+gg==
+"@types/three@^0.133.1":
+  version "0.133.1"
+  resolved "https://registry.yarnpkg.com/@types/three/-/three-0.133.1.tgz#6007faaf7f6b53339150a2a1fe57121e4c6607c1"
+  integrity sha512-XqBrP/+kbs+o0CYRhCVVE95v7FaL2bO5Z7+3VQJE0nEyjo+9LoLfeNgZITOnndKHxM+7ltEciAIR7uE0SZlsOg==
 
 "@types/yargs-parser@*":
   version "20.2.1"
@@ -8230,10 +8230,10 @@ thenify-all@^1.0.0:
   dependencies:
     any-promise "^1.0.0"
 
-three@^0.126.1:
-  version "0.126.1"
-  resolved "https://registry.yarnpkg.com/three/-/three-0.126.1.tgz#cf4e4e52060fd952f6f0d5440cbd422c66bc4be7"
-  integrity sha512-eOEXnZeE1FDV0XgL1u08auIP13jxdN9LQBAEmlErYzMxtIIfuGIAZbijOyookALUhqVzVOx0Tywj6n192VM+nQ==
+three@^0.133.1:
+  version "0.133.1"
+  resolved "https://registry.yarnpkg.com/three/-/three-0.133.1.tgz#5606f4817d67a09d9212d4ccbd6826564774f8f4"
+  integrity sha512-WydohO8ll949B0FTD6MGz59Yv2Lwj8hvObg/0Heh2r42S6+tQC1WByfCNRdmG4D7+odfGod+n8JPV1I2xrboWw==
 
 throat@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
### Description

This PR will bump three.js from r126 to r133.
There was a lot of issues caused by this bump, mostly on MToonMaterial and its shader.
That was a longer journey than I thought,,,

The part of it is redo of #811 and #825 on `1.0` branch.
See commit log for details if you are interested.
