### PR TITLE
fix (1.0, springbone): install mat4 invert compat

### DIFF
--- a/packages/three-vrm-springbone/src/utils/Matrix4InverseCache.ts
+++ b/packages/three-vrm-springbone/src/utils/Matrix4InverseCache.ts
@@ -1,4 +1,5 @@
 import * as THREE from 'three';
+import { mat4InvertCompat } from './mat4InvertCompat';
 
 export class Matrix4InverseCache {
   /**
@@ -29,7 +30,8 @@ export class Matrix4InverseCache {
    */
   public get inverse(): THREE.Matrix4 {
     if (this._shouldUpdateInverse) {
-      this._inverseCache.getInverse(this.matrix);
+      this._inverseCache.copy(this.matrix);
+      mat4InvertCompat(this._inverseCache);
       this._shouldUpdateInverse = false;
     }
 


### PR DESCRIPTION
SpringBone was emitting `Use matrixInv.copy( matrix ).invert(); instead.` warning. This should fix the issue.