### PR TITLE
[1.0] Fix rim lighting

### DIFF
--- a/packages/three-vrm-materials-mtoon/src/MToonMaterial.ts
+++ b/packages/three-vrm-materials-mtoon/src/MToonMaterial.ts
@@ -281,26 +281,7 @@ export class MToonMaterial extends THREE.ShaderMaterial {
   public set ignoreVertexColor(value: boolean) {
     this._ignoreVertexColor = value;
 
-    this._updateShaderCode();
-  }
-
-  /**
-   * Give the `renderer.capabilities.isWebGL2` here.
-   * Needed from Three.js r133.
-   */
-  private _isWebGL2 = false;
-
-  /**
-   * Give the `renderer.capabilities.isWebGL2` here.
-   * Needed from Three.js r133.
-   */
-  public get isWebGL2(): boolean {
-    return this._isWebGL2;
-  }
-  public set isWebGL2(value: boolean) {
-    this._isWebGL2 = value;
-
-    this._updateShaderCode();
+    this.needsUpdate = true;
   }
 
   private _debugMode: MToonMaterialDebugMode = MToonMaterialDebugMode.None;
@@ -311,7 +292,7 @@ export class MToonMaterial extends THREE.ShaderMaterial {
   set debugMode(m: MToonMaterialDebugMode) {
     this._debugMode = m;
 
-    this._updateShaderCode();
+    this.needsUpdate = true;
   }
 
   private _outlineWidthMode: MToonMaterialOutlineWidthMode = MToonMaterialOutlineWidthMode.None;
@@ -322,7 +303,7 @@ export class MToonMaterial extends THREE.ShaderMaterial {
   set outlineWidthMode(m: MToonMaterialOutlineWidthMode) {
     this._outlineWidthMode = m;
 
-    this._updateShaderCode();
+    this.needsUpdate = true;
   }
 
   private _isOutline = false;
@@ -333,7 +314,7 @@ export class MToonMaterial extends THREE.ShaderMaterial {
   set isOutline(b: boolean) {
     this._isOutline = b;
 
-    this._updateShaderCode();
+    this.needsUpdate = true;
   }
 
   /**
@@ -344,7 +325,7 @@ export class MToonMaterial extends THREE.ShaderMaterial {
   }
 
   constructor(parameters: MToonMaterialParameters = {}) {
-    super();
+    super({ vertexShader, fragmentShader });
 
     // override depthWrite with transparentWithZWrite
     if (parameters.transparentWithZWrite) {
@@ -420,7 +401,83 @@ export class MToonMaterial extends THREE.ShaderMaterial {
     this.setValues(parameters);
 
     // == update shader stuff ======================================================================
-    this._updateShaderCode();
+    this.onBeforeCompile = (shader, renderer) => {
+      /**
+       * Will be needed to determine whether we should inline convert sRGB textures or not.
+       * See: https://github.com/mrdoob/three.js/pull/22551
+       */
+      const isWebGL2 = renderer.capabilities.isWebGL2;
+
+      const useUvInVert = this.outlineWidthMultiplyTexture !== null;
+      const useUvInFrag =
+        this.map !== null ||
+        this.shadeMultiplyTexture !== null ||
+        this.shadingShiftTexture !== null ||
+        this.rimMultiplyTexture !== null ||
+        this.uvAnimationMaskTexture !== null;
+
+      const threeRevision = parseInt(THREE.REVISION, 10);
+
+      const defines =
+        Object.entries({
+          // Temporary compat against shader change @ Three.js r126
+          // See: #21205, #21307, #21299
+          THREE_VRM_THREE_REVISION: threeRevision,
+
+          OUTLINE: this._isOutline,
+          MTOON_USE_UV: useUvInVert || useUvInFrag, // we can't use `USE_UV` , it will be redefined in WebGLProgram.js
+          MTOON_UVS_VERTEX_ONLY: useUvInVert && !useUvInFrag,
+          USE_SHADEMULTIPLYTEXTURE: this.shadeMultiplyTexture !== null,
+          USE_SHADINGSHIFTTEXTURE: this.shadingShiftTexture !== null,
+          USE_MATCAPTEXTURE: this.matcapTexture !== null,
+          USE_RIMMULTIPLYTEXTURE: this.rimMultiplyTexture !== null,
+          USE_OUTLINEWIDTHMULTIPLYTEXTURE: this.outlineWidthMultiplyTexture !== null,
+          USE_UVANIMATIONMASKTEXTURE: this.uvAnimationMaskTexture !== null,
+          IGNORE_VERTEX_COLOR: this._ignoreVertexColor === true,
+          DEBUG_NORMAL: this._debugMode === 'normal',
+          DEBUG_LITSHADERATE: this._debugMode === 'litShadeRate',
+          DEBUG_UV: this._debugMode === 'uv',
+          OUTLINE_WIDTH_WORLD: this._outlineWidthMode === MToonMaterialOutlineWidthMode.WorldCoordinates,
+          OUTLINE_WIDTH_SCREEN: this._outlineWidthMode === MToonMaterialOutlineWidthMode.ScreenCoordinates,
+        })
+          .filter(([token, macro]) => !!macro)
+          .map(([token, macro]) => `#define ${token} ${macro}`)
+          .join('\n') + '\n';
+
+      // -- texture encodings ----------------------------------------------------------------------
+      const encodings =
+        (this.matcapTexture !== null
+          ? getTexelDecodingFunction(
+              'matcapTextureTexelToLinear',
+              getTextureEncodingFromMap(this.matcapTexture, isWebGL2),
+            ) + '\n'
+          : '') +
+        (this.shadeMultiplyTexture !== null
+          ? getTexelDecodingFunction(
+              'shadeMultiplyTextureTexelToLinear',
+              getTextureEncodingFromMap(this.shadeMultiplyTexture, isWebGL2),
+            ) + '\n'
+          : '') +
+        (this.rimMultiplyTexture !== null
+          ? getTexelDecodingFunction(
+              'rimMultiplyTextureTexelToLinear',
+              getTextureEncodingFromMap(this.rimMultiplyTexture, isWebGL2),
+            ) + '\n'
+          : '');
+
+      // -- generate shader code -------------------------------------------------------------------
+      shader.vertexShader = defines + shader.vertexShader;
+      shader.fragmentShader = defines + encodings + shader.fragmentShader;
+
+      // -- compat ---------------------------------------------------------------------------------
+
+      // COMPAT
+      // Three.js r132 introduces new shader chunks <normal_pars_fragment> and <alphatest_pars_fragment>
+      if (threeRevision < 132) {
+        shader.fragmentShader = shader.fragmentShader.replace('#include <normal_pars_fragment>', '');
+        shader.fragmentShader = shader.fragmentShader.replace('#include <alphatest_pars_fragment>', '');
+      }
+    };
   }
 
   /**
@@ -498,7 +555,7 @@ export class MToonMaterial extends THREE.ShaderMaterial {
     this.isOutline = source.isOutline;
 
     // == update shader stuff ======================================================================
-    this._updateShaderCode();
+    this.needsUpdate = true;
 
     return this;
   }
@@ -511,76 +568,5 @@ export class MToonMaterial extends THREE.ShaderMaterial {
 
       dst.value.copy(src.value.matrix);
     }
-  }
-
-  private _updateShaderCode(): void {
-    const useUvInVert = this.outlineWidthMultiplyTexture !== null;
-    const useUvInFrag =
-      this.map !== null ||
-      this.shadeMultiplyTexture !== null ||
-      this.shadingShiftTexture !== null ||
-      this.rimMultiplyTexture !== null ||
-      this.uvAnimationMaskTexture !== null;
-
-    const threeRevision = parseInt(THREE.REVISION, 10);
-
-    this.defines = {
-      // Temporary compat against shader change @ Three.js r126
-      // See: #21205, #21307, #21299
-      THREE_VRM_THREE_REVISION: threeRevision,
-
-      OUTLINE: this._isOutline,
-      MTOON_USE_UV: useUvInVert || useUvInFrag, // we can't use `USE_UV` , it will be redefined in WebGLProgram.js
-      MTOON_UVS_VERTEX_ONLY: useUvInVert && !useUvInFrag,
-      USE_SHADEMULTIPLYTEXTURE: this.shadeMultiplyTexture !== null,
-      USE_SHADINGSHIFTTEXTURE: this.shadingShiftTexture !== null,
-      USE_MATCAPTEXTURE: this.matcapTexture !== null,
-      USE_RIMMULTIPLYTEXTURE: this.rimMultiplyTexture !== null,
-      USE_OUTLINEWIDTHMULTIPLYTEXTURE: this.outlineWidthMultiplyTexture !== null,
-      USE_UVANIMATIONMASKTEXTURE: this.uvAnimationMaskTexture !== null,
-      IGNORE_VERTEX_COLOR: this._ignoreVertexColor === true,
-      DEBUG_NORMAL: this._debugMode === 'normal',
-      DEBUG_LITSHADERATE: this._debugMode === 'litShadeRate',
-      DEBUG_UV: this._debugMode === 'uv',
-      OUTLINE_WIDTH_WORLD: this._outlineWidthMode === MToonMaterialOutlineWidthMode.WorldCoordinates,
-      OUTLINE_WIDTH_SCREEN: this._outlineWidthMode === MToonMaterialOutlineWidthMode.ScreenCoordinates,
-    };
-
-    // == texture encodings ========================================================================
-    const encodings =
-      (this.matcapTexture !== null
-        ? getTexelDecodingFunction(
-            'matcapTextureTexelToLinear',
-            getTextureEncodingFromMap(this.matcapTexture, this.isWebGL2),
-          ) + '\n'
-        : '') +
-      (this.shadeMultiplyTexture !== null
-        ? getTexelDecodingFunction(
-            'shadeMultiplyTextureTexelToLinear',
-            getTextureEncodingFromMap(this.shadeMultiplyTexture, this.isWebGL2),
-          ) + '\n'
-        : '') +
-      (this.rimMultiplyTexture !== null
-        ? getTexelDecodingFunction(
-            'rimMultiplyTextureTexelToLinear',
-            getTextureEncodingFromMap(this.rimMultiplyTexture, this.isWebGL2),
-          ) + '\n'
-        : '');
-
-    // == generate shader code =====================================================================
-    this.vertexShader = vertexShader;
-    this.fragmentShader = encodings + fragmentShader;
-
-    // == compat ===================================================================================
-
-    // COMPAT
-    // Three.js r132 introduces new shader chunks <normal_pars_fragment> and <alphatest_pars_fragment>
-    if (threeRevision < 132) {
-      this.fragmentShader = this.fragmentShader.replace('#include <normal_pars_fragment>', '');
-      this.fragmentShader = this.fragmentShader.replace('#include <alphatest_pars_fragment>', '');
-    }
-
-    // == set needsUpdate flag =====================================================================
-    this.needsUpdate = true;
   }
 }

--- a/packages/three-vrm-materials-mtoon/src/MToonMaterial.ts
+++ b/packages/three-vrm-materials-mtoon/src/MToonMaterial.ts
@@ -7,6 +7,7 @@ import fragmentShader from './shaders/mtoon.frag';
 import { MToonMaterialDebugMode } from './MToonMaterialDebugMode';
 import { MToonMaterialOutlineWidthMode } from './MToonMaterialOutlineWidthMode';
 import type { MToonMaterialParameters } from './MToonMaterialParameters';
+import { getTextureEncodingFromMap } from './utils/getTextureEncodingFromMap';
 
 /**
  * MToon is a material specification that has various features.
@@ -283,6 +284,25 @@ export class MToonMaterial extends THREE.ShaderMaterial {
     this._updateShaderCode();
   }
 
+  /**
+   * Give the `renderer.capabilities.isWebGL2` here.
+   * Needed from Three.js r133.
+   */
+  private _isWebGL2 = false;
+
+  /**
+   * Give the `renderer.capabilities.isWebGL2` here.
+   * Needed from Three.js r133.
+   */
+  public get isWebGL2(): boolean {
+    return this._isWebGL2;
+  }
+  public set isWebGL2(value: boolean) {
+    this._isWebGL2 = value;
+
+    this._updateShaderCode();
+  }
+
   private _debugMode: MToonMaterialDebugMode = MToonMaterialDebugMode.None;
 
   get debugMode(): MToonMaterialDebugMode {
@@ -529,13 +549,22 @@ export class MToonMaterial extends THREE.ShaderMaterial {
     // == texture encodings ========================================================================
     const encodings =
       (this.matcapTexture !== null
-        ? getTexelDecodingFunction('matcapTextureTexelToLinear', this.matcapTexture.encoding) + '\n'
+        ? getTexelDecodingFunction(
+            'matcapTextureTexelToLinear',
+            getTextureEncodingFromMap(this.matcapTexture, this.isWebGL2),
+          ) + '\n'
         : '') +
       (this.shadeMultiplyTexture !== null
-        ? getTexelDecodingFunction('shadeMultiplyTextureTexelToLinear', this.shadeMultiplyTexture.encoding) + '\n'
+        ? getTexelDecodingFunction(
+            'shadeMultiplyTextureTexelToLinear',
+            getTextureEncodingFromMap(this.shadeMultiplyTexture, this.isWebGL2),
+          ) + '\n'
         : '') +
       (this.rimMultiplyTexture !== null
-        ? getTexelDecodingFunction('rimMultiplyTextureTexelToLinear', this.rimMultiplyTexture.encoding) + '\n'
+        ? getTexelDecodingFunction(
+            'rimMultiplyTextureTexelToLinear',
+            getTextureEncodingFromMap(this.rimMultiplyTexture, this.isWebGL2),
+          ) + '\n'
         : '');
 
     // == generate shader code =====================================================================

--- a/packages/three-vrm-materials-mtoon/src/utils/getEncodingComponents.ts
+++ b/packages/three-vrm-materials-mtoon/src/utils/getEncodingComponents.ts
@@ -1,0 +1,24 @@
+import * as THREE from 'three';
+
+export const getEncodingComponents = (encoding: THREE.TextureEncoding): [string, string] => {
+  switch (encoding) {
+    case THREE.LinearEncoding:
+      return ['Linear', '( value )'];
+    case THREE.sRGBEncoding:
+      return ['sRGB', '( value )'];
+    case THREE.RGBEEncoding:
+      return ['RGBE', '( value )'];
+    case THREE.RGBM7Encoding:
+      return ['RGBM', '( value, 7.0 )'];
+    case THREE.RGBM16Encoding:
+      return ['RGBM', '( value, 16.0 )'];
+    case THREE.RGBDEncoding:
+      return ['RGBD', '( value, 256.0 )'];
+    case THREE.GammaEncoding:
+      return ['Gamma', '( value, float( GAMMA_FACTOR ) )'];
+    case THREE.LogLuvEncoding:
+      return ['LogLuv', '( value )'];
+    default:
+      throw new Error('unsupported encoding: ' + encoding);
+  }
+};

--- a/packages/three-vrm-materials-mtoon/src/utils/getTexelDecodingFunction.ts
+++ b/packages/three-vrm-materials-mtoon/src/utils/getTexelDecodingFunction.ts
@@ -1,25 +1,5 @@
 import * as THREE from 'three';
-
-export const getEncodingComponents = (encoding: THREE.TextureEncoding): [string, string] => {
-  switch (encoding) {
-    case THREE.LinearEncoding:
-      return ['Linear', '( value )'];
-    case THREE.sRGBEncoding:
-      return ['sRGB', '( value )'];
-    case THREE.RGBEEncoding:
-      return ['RGBE', '( value )'];
-    case THREE.RGBM7Encoding:
-      return ['RGBM', '( value, 7.0 )'];
-    case THREE.RGBM16Encoding:
-      return ['RGBM', '( value, 16.0 )'];
-    case THREE.RGBDEncoding:
-      return ['RGBD', '( value, 256.0 )'];
-    case THREE.GammaEncoding:
-      return ['Gamma', '( value, float( GAMMA_FACTOR ) )'];
-    default:
-      throw new Error('unsupported encoding: ' + encoding);
-  }
-};
+import { getEncodingComponents } from './getEncodingComponents';
 
 export const getTexelDecodingFunction = (functionName: string, encoding: THREE.TextureEncoding): string => {
   const components = getEncodingComponents(encoding);

--- a/packages/three-vrm-materials-mtoon/src/utils/getTextureEncodingFromMap.ts
+++ b/packages/three-vrm-materials-mtoon/src/utils/getTextureEncodingFromMap.ts
@@ -1,0 +1,36 @@
+import * as THREE from 'three';
+
+/**
+ * Retrieved from https://github.com/mrdoob/three.js/blob/88b6328998d155fa0a7c1f1e5e3bd6bff75268c0/src/renderers/webgl/WebGLPrograms.js#L92
+ *
+ * Diff:
+ *   - Remove WebGLRenderTarget handler because it increases code complexities on TypeScript
+ *   - Add a boolean `isWebGL2` as a second argument.
+ */
+export function getTextureEncodingFromMap(map: THREE.Texture, isWebGL2: boolean): THREE.TextureEncoding {
+  let encoding;
+
+  if (map && map.isTexture) {
+    encoding = map.encoding;
+    // } else if ( map && map.isWebGLRenderTarget ) {
+    //   console.warn( 'THREE.WebGLPrograms.getTextureEncodingFromMap: don\'t use render targets as textures. Use their .texture property instead.' );
+    //   encoding = map.texture.encoding;
+  } else {
+    encoding = THREE.LinearEncoding;
+  }
+
+  if (parseInt(THREE.REVISION, 10) >= 133) {
+    if (
+      isWebGL2 &&
+      map &&
+      map.isTexture &&
+      map.format === THREE.RGBAFormat &&
+      map.type === THREE.UnsignedByteType &&
+      map.encoding === THREE.sRGBEncoding
+    ) {
+      encoding = THREE.LinearEncoding; // disable inline decode for sRGB textures in WebGL 2
+    }
+  }
+
+  return encoding;
+}


### PR DESCRIPTION
- Beginning from Three.js r133, it utilizes `SRGB8_ALPHA8` textures instead of inline conversions. This PR supports the behavior.
    - See: https://github.com/mrdoob/three.js/pull/22551
    - Because of this, procedures in `_updateShaderCode` are replaced by `onBeforeCompile` .
- MatCap was not working as "MatCap", this PR should fix the behavior.
