### PR TITLE
fix (1.0): add name to VRMLoaderPlugin

### DIFF
--- a/packages/three-vrm/src/VRMLoaderPlugin.ts
+++ b/packages/three-vrm/src/VRMLoaderPlugin.ts
@@ -29,6 +29,10 @@ export class VRMLoaderPlugin implements GLTFLoaderPlugin {
   public readonly springBonePlugin: VRMSpringBoneLoaderPlugin;
   public readonly constraintPlugin: VRMNodeConstraintLoaderPlugin;
 
+  public get name(): string {
+    return 'VRMLoaderPlugin';
+  }
+
   public constructor(parser: GLTFParser, options?: VRMLoaderPluginOptions) {
     this.parser = parser;
 


### PR DESCRIPTION
GLTFLoader Plugins should have a name to prevent unwanted behavior