### PR TITLE
[1.0] MToon: add v0CompatShade mode

### DIFF
--- a/packages/three-vrm-materials-mtoon/src/MToonMaterial.ts
+++ b/packages/three-vrm-materials-mtoon/src/MToonMaterial.ts
@@ -558,6 +558,7 @@ export class MToonMaterial extends THREE.ShaderMaterial {
 
     this.ignoreVertexColor = source.ignoreVertexColor;
 
+    this.v0CompatShade = source.v0CompatShade;
     this.debugMode = source.debugMode;
     this.outlineWidthMode = source.outlineWidthMode;
 

--- a/packages/three-vrm-materials-mtoon/src/MToonMaterial.ts
+++ b/packages/three-vrm-materials-mtoon/src/MToonMaterial.ts
@@ -310,9 +310,22 @@ export class MToonMaterial extends THREE.ShaderMaterial {
 
   private _debugMode: MToonMaterialDebugMode = MToonMaterialDebugMode.None;
 
+  /**
+   * Debug mode for the material.
+   * You can visualize several components for diagnosis using debug mode.
+   *
+   * See: {@link MToonMaterialDebugMode}
+   */
   get debugMode(): MToonMaterialDebugMode {
     return this._debugMode;
   }
+
+  /**
+   * Debug mode for the material.
+   * You can visualize several components for diagnosis using debug mode.
+   *
+   * See: {@link MToonMaterialDebugMode}
+   */
   set debugMode(m: MToonMaterialDebugMode) {
     this._debugMode = m;
 

--- a/packages/three-vrm-materials-mtoon/src/MToonMaterial.ts
+++ b/packages/three-vrm-materials-mtoon/src/MToonMaterial.ts
@@ -284,6 +284,28 @@ export class MToonMaterial extends THREE.ShaderMaterial {
     this.needsUpdate = true;
   }
 
+  private _v0CompatShade = false;
+
+  /**
+   * There is a line of the shader called "comment out if you want to PBR absolutely" in VRM0.0 MToon.
+   * When this is true, the material enables the line to make it compatible with the legacy rendering of VRM.
+   * Usually not recommended to turn this on.
+   */
+  get v0CompatShade(): boolean {
+    return this._v0CompatShade;
+  }
+
+  /**
+   * There is a line of the shader called "comment out if you want to PBR absolutely" in VRM0.0 MToon.
+   * When this is true, the material enables the line to make it compatible with the legacy rendering of VRM.
+   * Usually not recommended to turn this on.
+   */
+  set v0CompatShade(v: boolean) {
+    this._v0CompatShade = v;
+
+    this.needsUpdate = true;
+  }
+
   private _debugMode: MToonMaterialDebugMode = MToonMaterialDebugMode.None;
 
   get debugMode(): MToonMaterialDebugMode {
@@ -404,6 +426,7 @@ export class MToonMaterial extends THREE.ShaderMaterial {
     this.customProgramCacheKey = () =>
       [
         this._ignoreVertexColor ? 'ignoreVertexColor' : '',
+        this._v0CompatShade ? 'v0CompatShade' : '',
         this._debugMode !== 'none' ? `debugMode:${this._debugMode}` : '',
         this._outlineWidthMode !== 'none' ? `outlineWidthMode:${this._outlineWidthMode}` : '',
         this._isOutline ? 'isOutline' : '',
@@ -567,6 +590,7 @@ export class MToonMaterial extends THREE.ShaderMaterial {
       OUTLINE: this._isOutline,
       MTOON_USE_UV: useUvInVert || useUvInFrag, // we can't use `USE_UV` , it will be redefined in WebGLProgram.js
       MTOON_UVS_VERTEX_ONLY: useUvInVert && !useUvInFrag,
+      V0_COMPAT_SHADE: this._v0CompatShade,
       USE_SHADEMULTIPLYTEXTURE: this.shadeMultiplyTexture !== null,
       USE_SHADINGSHIFTTEXTURE: this.shadingShiftTexture !== null,
       USE_MATCAPTEXTURE: this.matcapTexture !== null,

--- a/packages/three-vrm-materials-mtoon/src/MToonMaterial.ts
+++ b/packages/three-vrm-materials-mtoon/src/MToonMaterial.ts
@@ -290,6 +290,7 @@ export class MToonMaterial extends THREE.ShaderMaterial {
    * There is a line of the shader called "comment out if you want to PBR absolutely" in VRM0.0 MToon.
    * When this is true, the material enables the line to make it compatible with the legacy rendering of VRM.
    * Usually not recommended to turn this on.
+   * `false` by default.
    */
   get v0CompatShade(): boolean {
     return this._v0CompatShade;
@@ -299,6 +300,7 @@ export class MToonMaterial extends THREE.ShaderMaterial {
    * There is a line of the shader called "comment out if you want to PBR absolutely" in VRM0.0 MToon.
    * When this is true, the material enables the line to make it compatible with the legacy rendering of VRM.
    * Usually not recommended to turn this on.
+   * `false` by default.
    */
   set v0CompatShade(v: boolean) {
     this._v0CompatShade = v;

--- a/packages/three-vrm-materials-mtoon/src/MToonMaterialDebugMode.ts
+++ b/packages/three-vrm-materials-mtoon/src/MToonMaterialDebugMode.ts
@@ -1,9 +1,29 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 
+/**
+ * Specifiers of debug mode of {@link MToonMaterial}.
+ *
+ * See: {@link MToonMaterial.debugMode}
+ */
 export const MToonMaterialDebugMode = {
+  /**
+   * Render normally.
+   */
   None: 'none',
+
+  /**
+   * Visualize normals of the surface.
+   */
   Normal: 'normal',
+
+  /**
+   * Visualize lit/shade of the surface.
+   */
   LitShadeRate: 'litShadeRate',
+
+  /**
+   * Visualize UV of the surface.
+   */
   UV: 'uv',
 } as const;
 

--- a/packages/three-vrm-materials-mtoon/src/MToonMaterialLoaderPlugin.ts
+++ b/packages/three-vrm-materials-mtoon/src/MToonMaterialLoaderPlugin.ts
@@ -5,6 +5,7 @@ import { MToonMaterial } from './MToonMaterial';
 import type { MToonMaterialParameters } from './MToonMaterialParameters';
 import { MToonMaterialOutlineWidthMode } from './MToonMaterialOutlineWidthMode';
 import { GLTFMToonMaterialParamsAssignHelper } from './GLTFMToonMaterialParamsAssignHelper';
+import { MToonMaterialLoaderPluginOptions } from './MToonMaterialLoaderPluginOptions';
 
 export class MToonMaterialLoaderPlugin implements GLTFLoaderPlugin {
   public static EXTENSION_NAME = 'VRMC_materials_mtoon';
@@ -15,6 +16,14 @@ export class MToonMaterialLoaderPlugin implements GLTFLoaderPlugin {
    * `0` by default.
    */
   public renderOrderOffset: number;
+
+  /**
+   * There is a line of the shader called "comment out if you want to PBR absolutely" in VRM0.0 MToon.
+   * When this is true, the material enables the line to make it compatible with the legacy rendering of VRM.
+   * Usually not recommended to turn this on.
+   * `false` by default.
+   */
+  public v0CompatShade: boolean;
 
   public readonly parser: GLTFParser;
 
@@ -28,20 +37,11 @@ export class MToonMaterialLoaderPlugin implements GLTFLoaderPlugin {
     return MToonMaterialLoaderPlugin.EXTENSION_NAME;
   }
 
-  public constructor(
-    parser: GLTFParser,
-    options: {
-      /**
-       * This value will be added to every meshes who have MaterialsMToon.
-       * The final renderOrder will be sum of this `renderOrderOffset` and `renderQueueOffsetNumber` for each materials.
-       * `0` by default.
-       */
-      renderOrderOffset?: number;
-    } = {},
-  ) {
+  public constructor(parser: GLTFParser, options: MToonMaterialLoaderPluginOptions = {}) {
     this.parser = parser;
 
     this.renderOrderOffset = options.renderOrderOffset ?? 0;
+    this.v0CompatShade = options.v0CompatShade ?? false;
 
     this._mToonMaterialSet = new Set();
   }
@@ -177,6 +177,8 @@ export class MToonMaterialLoaderPlugin implements GLTFLoaderPlugin {
     assignHelper.assignPrimitive('uvAnimationScrollXSpeedFactor', extension.uvAnimationScrollXSpeedFactor);
     assignHelper.assignPrimitive('uvAnimationScrollYSpeedFactor', extension.uvAnimationScrollYSpeedFactor);
     assignHelper.assignPrimitive('uvAnimationRotationSpeedFactor', extension.uvAnimationRotationSpeedFactor);
+
+    assignHelper.assignPrimitive('v0CompatShade', this.v0CompatShade);
 
     await assignHelper.pending;
   }

--- a/packages/three-vrm-materials-mtoon/src/MToonMaterialLoaderPlugin.ts
+++ b/packages/three-vrm-materials-mtoon/src/MToonMaterialLoaderPlugin.ts
@@ -6,6 +6,7 @@ import type { MToonMaterialParameters } from './MToonMaterialParameters';
 import { MToonMaterialOutlineWidthMode } from './MToonMaterialOutlineWidthMode';
 import { GLTFMToonMaterialParamsAssignHelper } from './GLTFMToonMaterialParamsAssignHelper';
 import { MToonMaterialLoaderPluginOptions } from './MToonMaterialLoaderPluginOptions';
+import type { MToonMaterialDebugMode } from './MToonMaterialDebugMode';
 
 export class MToonMaterialLoaderPlugin implements GLTFLoaderPlugin {
   public static EXTENSION_NAME = 'VRMC_materials_mtoon';
@@ -25,6 +26,14 @@ export class MToonMaterialLoaderPlugin implements GLTFLoaderPlugin {
    */
   public v0CompatShade: boolean;
 
+  /**
+   * Debug mode for the material.
+   * You can visualize several components for diagnosis using debug mode.
+   *
+   * See: {@link MToonMaterialDebugMode}
+   */
+  public debugMode: MToonMaterialDebugMode;
+
   public readonly parser: GLTFParser;
 
   /**
@@ -42,6 +51,7 @@ export class MToonMaterialLoaderPlugin implements GLTFLoaderPlugin {
 
     this.renderOrderOffset = options.renderOrderOffset ?? 0;
     this.v0CompatShade = options.v0CompatShade ?? false;
+    this.debugMode = options.debugMode ?? 'none';
 
     this._mToonMaterialSet = new Set();
   }
@@ -179,6 +189,7 @@ export class MToonMaterialLoaderPlugin implements GLTFLoaderPlugin {
     assignHelper.assignPrimitive('uvAnimationRotationSpeedFactor', extension.uvAnimationRotationSpeedFactor);
 
     assignHelper.assignPrimitive('v0CompatShade', this.v0CompatShade);
+    assignHelper.assignPrimitive('debugMode', this.debugMode);
 
     await assignHelper.pending;
   }

--- a/packages/three-vrm-materials-mtoon/src/MToonMaterialLoaderPluginOptions.ts
+++ b/packages/three-vrm-materials-mtoon/src/MToonMaterialLoaderPluginOptions.ts
@@ -1,3 +1,5 @@
+import type { MToonMaterialDebugMode } from './MToonMaterialDebugMode';
+
 export interface MToonMaterialLoaderPluginOptions {
   /**
    * This value will be added to every meshes who have MaterialsMToon.
@@ -13,4 +15,12 @@ export interface MToonMaterialLoaderPluginOptions {
    * `false` by default.
    */
   v0CompatShade?: boolean;
+
+  /**
+   * Debug mode for the material.
+   * You can visualize several components for diagnosis using debug mode.
+   *
+   * See: {@link MToonMaterialDebugMode}
+   */
+  debugMode?: MToonMaterialDebugMode;
 }

--- a/packages/three-vrm-materials-mtoon/src/MToonMaterialLoaderPluginOptions.ts
+++ b/packages/three-vrm-materials-mtoon/src/MToonMaterialLoaderPluginOptions.ts
@@ -1,0 +1,16 @@
+export interface MToonMaterialLoaderPluginOptions {
+  /**
+   * This value will be added to every meshes who have MaterialsMToon.
+   * The final renderOrder will be sum of this `renderOrderOffset` and `renderQueueOffsetNumber` for each materials.
+   * `0` by default.
+   */
+  renderOrderOffset?: number;
+
+  /**
+   * There is a line of the shader called "comment out if you want to PBR absolutely" in VRM0.0 MToon.
+   * When this is true, the material enables the line to make it compatible with the legacy rendering of VRM.
+   * Usually not recommended to turn this on.
+   * `false` by default.
+   */
+  v0CompatShade?: boolean;
+}

--- a/packages/three-vrm-materials-mtoon/src/MToonMaterialParameters.ts
+++ b/packages/three-vrm-materials-mtoon/src/MToonMaterialParameters.ts
@@ -44,7 +44,13 @@ export interface MToonMaterialParameters extends THREE.ShaderMaterialParameters 
    */
   ignoreVertexColor?: boolean;
 
-  debugMode?: MToonMaterialDebugMode | number;
+  /**
+   * Debug mode for the material.
+   * You can visualize several components for diagnosis using debug mode.
+   *
+   * See: {@link MToonMaterialDebugMode}
+   */
+  debugMode?: MToonMaterialDebugMode;
 
   /**
    * There is a line of the shader called "comment out if you want to PBR absolutely" in VRM0.0 MToon.

--- a/packages/three-vrm-materials-mtoon/src/MToonMaterialParameters.ts
+++ b/packages/three-vrm-materials-mtoon/src/MToonMaterialParameters.ts
@@ -47,6 +47,14 @@ export interface MToonMaterialParameters extends THREE.ShaderMaterialParameters 
   debugMode?: MToonMaterialDebugMode | number;
 
   /**
+   * There is a line of the shader called "comment out if you want to PBR absolutely" in VRM0.0 MToon.
+   * When this is true, the material enables the line to make it compatible with the legacy rendering of VRM.
+   * Usually not recommended to turn this on.
+   * `false` by default.
+   */
+  v0CompatShade?: boolean;
+
+  /**
    * It will draw its outline instead when it's `true`.
    */
   isOutline?: boolean;

--- a/packages/three-vrm-materials-mtoon/src/shaders/mtoon.frag
+++ b/packages/three-vrm-materials-mtoon/src/shaders/mtoon.frag
@@ -148,7 +148,14 @@ vec3 getDiffuse(
     #endif
   #endif
 
-  return lightColor * BRDF_Lambert( mix( material.shadeColor, material.diffuseColor, shading ) );
+  vec3 col = lightColor * BRDF_Lambert( mix( material.shadeColor, material.diffuseColor, shading ) );
+
+  // The "comment out if you want to PBR absolutely" line
+  #ifdef V0_COMPAT_SHADE
+    col = min( col, material.diffuseColor );
+  #endif
+
+  return col;
 }
 
 void RE_Direct_MToon( const in IncidentLight directLight, const in GeometricContext geometry, const in MToonMaterial material, const in float shadow, inout ReflectedLight reflectedLight ) {


### PR DESCRIPTION
### Description

✨ Add an option to `MToonMaterial` to make it render shades in VRM0.0 compatible mode (`MToonMaterial.v0CompatShade: boolean`).
There used to be a code called "comment out if you want to PBR absolutely" in VRM0.0 mtoon, and it drastically changes how the shade part appears.

https://github.com/Santarh/MToon/blob/e7b15eed3be9aec5400ec31f21ce664350368d3f/MToon/Resources/Shaders/MToonCore.cginc#L220

Some environments might want to do a compatibility implementation for it, so I've added a feature to render MToon materials in the legacy way.

![v0CompatShade](https://user-images.githubusercontent.com/7824814/140871282-c1a017d3-770f-4b2a-9500-55f89932f2d8.png)

Sample model: [ball_without_shade_texture_gray.zip](https://github.com/pixiv/three-vrm/files/7502341/ball_without_shade_texture_gray.zip)

### Also

- ✨ Add `v0CompatShade` to `MToonMaterialParameters` and `MToonMaterialLoaderPluginOptions`.
- ✨ Unrelated but add `debugMode` to `MToonMaterialLoaderPluginOptions`.
    - 📄 Add doc comments for debugMode.
