### PR TITLE
Clarified source of magic number in VRMSpringBone.ts

### DIFF
--- a/packages/three-vrm/src/springbone/VRMSpringBone.ts
+++ b/packages/three-vrm/src/springbone/VRMSpringBone.ts
@@ -194,7 +194,7 @@ export class VRMSpringBone {
     if (this.bone.children.length === 0) {
       // 末端のボーン。子ボーンがいないため「自分の少し先」が子ボーンということにする
       // https://github.com/dwango/UniVRM/blob/master/Assets/VRM/UniVRM/Scripts/SpringBone/VRMSpringBone.cs#L246
-      this._initialLocalChildPosition.copy(this.bone.position).normalize().multiplyScalar(0.07); // magic number! derives from original source
+      this._initialLocalChildPosition.copy(this.bone.position).normalize().multiplyScalar(0.07); // vrm0 requires a 7cm fixed bone length for the final node in a chain - see https://github.com/vrm-c/vrm-specification/tree/master/specification/VRMC_springBone-1.0-beta#about-spring-configuration
     } else {
       const firstChild = this.bone.children[0];
       this._initialLocalChildPosition.copy(firstChild.position);


### PR DESCRIPTION
Previously, this was just listed as "some magic number". I've clarified the source/reason for this 7cm magic length for the final bone based on the VRM 1.0 spec.

https://github.com/vrm-c/vrm-specification/tree/master/specification/VRMC_springBone-1.0-beta#about-spring-configuration