### PR TITLE
Remove unnecessary vertices

### DIFF
--- a/packages/three-vrm/examples/animations.html
+++ b/packages/three-vrm/examples/animations.html
@@ -69,6 +69,7 @@
 
 					const vrm = gltf.userData.vrm;
 
+					THREE_VRM.VRMUtils.removeUnnecessaryVertices( gltf.scene );
 					THREE_VRM.VRMUtils.removeUnnecessaryJoints( gltf.scene );
 
 					scene.add( vrm.scene );

--- a/packages/three-vrm/examples/basic.html
+++ b/packages/three-vrm/examples/basic.html
@@ -70,7 +70,8 @@
 
 					const vrm = gltf.userData.vrm;
 
-					// calling this function greatly improves the performance
+					// calling these functions greatly improves the performance
+					THREE_VRM.VRMUtils.removeUnnecessaryVertices( gltf.scene );
 					THREE_VRM.VRMUtils.removeUnnecessaryJoints( gltf.scene );
 
 					currentVrm = vrm;

--- a/packages/three-vrm/examples/bones.html
+++ b/packages/three-vrm/examples/bones.html
@@ -68,6 +68,7 @@
 
 					const vrm = gltf.userData.vrm;
 
+					THREE_VRM.VRMUtils.removeUnnecessaryVertices( gltf.scene );
 					THREE_VRM.VRMUtils.removeUnnecessaryJoints( gltf.scene );
 
 					scene.add( vrm.scene );

--- a/packages/three-vrm/examples/debug.html
+++ b/packages/three-vrm/examples/debug.html
@@ -77,6 +77,7 @@
 					const vrm = gltf.userData.vrm;
 
 					// calling this function greatly improves the performance
+					THREE_VRM.VRMUtils.removeUnnecessaryVertices( gltf.scene );
 					THREE_VRM.VRMUtils.removeUnnecessaryJoints( gltf.scene );
 
 					currentVrm = vrm;

--- a/packages/three-vrm/examples/dnd.html
+++ b/packages/three-vrm/examples/dnd.html
@@ -70,6 +70,8 @@
 
 						const vrm = gltf.userData.vrm;
 
+						// calling these functions greatly improves the performance
+						THREE_VRM.VRMUtils.removeUnnecessaryVertices( gltf.scene );
 						THREE_VRM.VRMUtils.removeUnnecessaryJoints( gltf.scene );
 
 						if ( currentVrm ) {

--- a/packages/three-vrm/examples/expressions.html
+++ b/packages/three-vrm/examples/expressions.html
@@ -68,6 +68,7 @@
 
 					const vrm = gltf.userData.vrm;
 
+					THREE_VRM.VRMUtils.removeUnnecessaryVertices( gltf.scene );
 					THREE_VRM.VRMUtils.removeUnnecessaryJoints( gltf.scene );
 
 					scene.add( vrm.scene );

--- a/packages/three-vrm/examples/firstperson.html
+++ b/packages/three-vrm/examples/firstperson.html
@@ -68,6 +68,7 @@
 
 					const vrm = gltf.userData.vrm;
 
+					THREE_VRM.VRMUtils.removeUnnecessaryVertices( gltf.scene );
 					THREE_VRM.VRMUtils.removeUnnecessaryJoints( gltf.scene );
 
 					scene.add( vrm.scene );

--- a/packages/three-vrm/examples/lookat-advanced.html
+++ b/packages/three-vrm/examples/lookat-advanced.html
@@ -119,6 +119,7 @@
 
 					const vrm = gltf.userData.vrm;
 
+					THREE_VRM.VRMUtils.removeUnnecessaryVertices( gltf.scene );
 					THREE_VRM.VRMUtils.removeUnnecessaryJoints( gltf.scene );
 
 					// replace the lookAt to our extended one

--- a/packages/three-vrm/examples/lookat.html
+++ b/packages/three-vrm/examples/lookat.html
@@ -72,6 +72,7 @@
 
 					const vrm = gltf.userData.vrm;
 
+					THREE_VRM.VRMUtils.removeUnnecessaryVertices( gltf.scene );
 					THREE_VRM.VRMUtils.removeUnnecessaryJoints( gltf.scene );
 
 					scene.add( vrm.scene );

--- a/packages/three-vrm/examples/materials-debug.html
+++ b/packages/three-vrm/examples/materials-debug.html
@@ -68,6 +68,7 @@
 
 					const vrm = gltf.userData.vrm;
 
+					THREE_VRM.VRMUtils.removeUnnecessaryVertices( gltf.scene );
 					THREE_VRM.VRMUtils.removeUnnecessaryJoints( gltf.scene );
 
 					scene.add( vrm.scene );

--- a/packages/three-vrm/examples/meta.html
+++ b/packages/three-vrm/examples/meta.html
@@ -82,7 +82,7 @@
 
 					const vrm = gltf.userData.vrm;
 
-					// calling this function greatly improves the performance
+					THREE_VRM.VRMUtils.removeUnnecessaryVertices( gltf.scene );
 					THREE_VRM.VRMUtils.removeUnnecessaryJoints( gltf.scene );
 
 					currentVrm = vrm;

--- a/packages/three-vrm/examples/mouse.html
+++ b/packages/three-vrm/examples/mouse.html
@@ -64,6 +64,7 @@
 
 					const vrm = gltf.userData.vrm;
 
+					THREE_VRM.VRMUtils.removeUnnecessaryVertices( gltf.scene );
 					THREE_VRM.VRMUtils.removeUnnecessaryJoints( gltf.scene );
 
 					scene.add( vrm.scene );

--- a/packages/three-vrm/src/VRMUtils/index.ts
+++ b/packages/three-vrm/src/VRMUtils/index.ts
@@ -1,5 +1,6 @@
 import { deepDispose } from './deepDispose';
 import { removeUnnecessaryJoints } from './removeUnnecessaryJoints';
+import { removeUnnecessaryVertices } from './removeUnnecessaryVertices';
 import { rotateVRM0 } from './rotateVRM0';
 
 export class VRMUtils {
@@ -9,5 +10,6 @@ export class VRMUtils {
 
   public static deepDispose = deepDispose;
   public static removeUnnecessaryJoints = removeUnnecessaryJoints;
+  public static removeUnnecessaryVertices = removeUnnecessaryVertices;
   public static rotateVRM0 = rotateVRM0;
 }

--- a/packages/three-vrm/src/VRMUtils/removeUnnecessaryVertices.ts
+++ b/packages/three-vrm/src/VRMUtils/removeUnnecessaryVertices.ts
@@ -80,7 +80,7 @@ export function removeUnnecessaryVertices(root: THREE.Object3D): void {
       const originalAttribute = geometry.attributes[attributeName] as THREE.BufferAttribute;
 
       if ((originalAttribute as any).isInterleavedBufferAttribute) {
-        throw new Error('removeUnnecessaryVertices: InterlavedBufferAttribute is not supported');
+        throw new Error('removeUnnecessaryVertices: InterleavedBufferAttribute is not supported');
       }
 
       const originalAttributeArray = originalAttribute.array;

--- a/packages/three-vrm/src/VRMUtils/removeUnnecessaryVertices.ts
+++ b/packages/three-vrm/src/VRMUtils/removeUnnecessaryVertices.ts
@@ -111,7 +111,7 @@ export function removeUnnecessaryVertices(root: THREE.Object3D): void {
         const originalAttribute = morphs[iMorph] as THREE.BufferAttribute;
 
         if ((originalAttribute as any).isInterleavedBufferAttribute) {
-          throw new Error('removeUnnecessaryVertices: InterlavedBufferAttribute is not supported');
+          throw new Error('removeUnnecessaryVertices: InterleavedBufferAttribute is not supported');
         }
 
         const originalAttributeArray = originalAttribute.array;

--- a/packages/three-vrm/src/VRMUtils/removeUnnecessaryVertices.ts
+++ b/packages/three-vrm/src/VRMUtils/removeUnnecessaryVertices.ts
@@ -1,0 +1,151 @@
+import * as THREE from 'three';
+import { BufferAttribute } from 'three';
+
+/**
+ * Traverse given object and remove unnecessary vertices from every BufferGeometries.
+ * This only processes buffer geometries with index buffer.
+ *
+ * Three.js creates morph textures for each geometries and it sometimes consumes unnecessary amount of VRAM for certain models.
+ * This function will optimize geometries to reduce the size of morph texture.
+ * See: https://github.com/mrdoob/three.js/issues/23095
+ *
+ * @param root Root object that will be traversed
+ */
+export function removeUnnecessaryVertices(root: THREE.Object3D): void {
+  const geometryMap = new Map<THREE.BufferGeometry, THREE.BufferGeometry>();
+
+  // Traverse an entire tree
+  root.traverse((obj) => {
+    if (!(obj as any).isMesh) {
+      return;
+    }
+
+    const mesh = obj as THREE.Mesh;
+    const geometry = mesh.geometry;
+
+    // if the geometry does not have an index buffer it does not need to process
+    const origianlIndex = geometry.index;
+    if (origianlIndex == null) {
+      return;
+    }
+
+    // skip already processed geometry
+    const newGeometryAlreadyExisted = geometryMap.get(geometry);
+    if (newGeometryAlreadyExisted != null) {
+      mesh.geometry = newGeometryAlreadyExisted;
+      return;
+    }
+
+    const newGeometry = new THREE.BufferGeometry();
+
+    newGeometry.morphTargetsRelative = geometry.morphTargetsRelative;
+    newGeometry.setDrawRange(geometry.drawRange.start, geometry.drawRange.count);
+    geometry.groups.forEach((group) => {
+      newGeometry.addGroup(group.start, group.count, group.materialIndex);
+    });
+
+    geometryMap.set(geometry, newGeometry);
+
+    /** from original index to new index */
+    const originalIndexNewIndexMap: number[] = [];
+
+    /** from new index to original index */
+    const newIndexOriginalIndexMap: number[] = [];
+
+    // reorganize indices
+    {
+      const originalIndexArray = origianlIndex.array;
+      const newIndexArray = new (originalIndexArray.constructor as any)(originalIndexArray.length);
+
+      let indexHead = 0;
+
+      for (let i = 0; i < originalIndexArray.length; i++) {
+        const originalIndex = originalIndexArray[i];
+
+        let newIndex = originalIndexNewIndexMap[originalIndex];
+        if (newIndex == null) {
+          originalIndexNewIndexMap[originalIndex] = indexHead;
+          newIndexOriginalIndexMap[indexHead] = originalIndex;
+          newIndex = indexHead;
+          indexHead++;
+        }
+        newIndexArray[i] = newIndex;
+      }
+
+      newGeometry.setIndex(new BufferAttribute(newIndexArray, 1, false));
+    }
+
+    // reorganize attributes
+    Object.keys(geometry.attributes).forEach((attributeName) => {
+      const originalAttribute = geometry.attributes[attributeName] as THREE.BufferAttribute;
+
+      if ((originalAttribute as any).isInterleavedBufferAttribute) {
+        throw new Error('removeUnnecessaryVertices: InterlavedBufferAttribute is not supported');
+      }
+
+      const originalAttributeArray = originalAttribute.array;
+      const { itemSize, normalized } = originalAttribute;
+
+      const newAttributeArray = new (originalAttributeArray.constructor as any)(
+        newIndexOriginalIndexMap.length * itemSize,
+      );
+
+      newIndexOriginalIndexMap.forEach((originalIndex, i) => {
+        for (let j = 0; j < itemSize; j++) {
+          newAttributeArray[i * itemSize + j] = originalAttributeArray[originalIndex * itemSize + j];
+        }
+      });
+
+      newGeometry.setAttribute(attributeName, new BufferAttribute(newAttributeArray, itemSize, normalized));
+    });
+
+    // reorganize morph attributes
+    /** True if all morphs are zero. */
+    let isNullMorph = true;
+
+    Object.keys(geometry.morphAttributes).forEach((attributeName) => {
+      newGeometry.morphAttributes[attributeName] = [];
+
+      const morphs = geometry.morphAttributes[attributeName];
+      for (let iMorph = 0; iMorph < morphs.length; iMorph++) {
+        const originalAttribute = morphs[iMorph] as THREE.BufferAttribute;
+
+        if ((originalAttribute as any).isInterleavedBufferAttribute) {
+          throw new Error('removeUnnecessaryVertices: InterlavedBufferAttribute is not supported');
+        }
+
+        const originalAttributeArray = originalAttribute.array;
+        const { itemSize, normalized } = originalAttribute;
+
+        const newAttributeArray = new (originalAttributeArray.constructor as any)(
+          newIndexOriginalIndexMap.length * itemSize,
+        );
+
+        newIndexOriginalIndexMap.forEach((originalIndex, i) => {
+          for (let j = 0; j < itemSize; j++) {
+            newAttributeArray[i * itemSize + j] = originalAttributeArray[originalIndex * itemSize + j];
+          }
+        });
+
+        isNullMorph = isNullMorph && newAttributeArray.every((v: number) => v === 0);
+
+        newGeometry.morphAttributes[attributeName][iMorph] = new BufferAttribute(
+          newAttributeArray,
+          itemSize,
+          normalized,
+        );
+      }
+    });
+
+    // If all morphs are zero, just discard the morph attributes we've just made
+    if (isNullMorph) {
+      newGeometry.morphAttributes = {};
+    }
+
+    mesh.geometry = newGeometry;
+  });
+
+  Array.from(geometryMap.keys()).forEach((originalGeometry) => {
+    originalGeometry.dispose();
+  });
+}


### PR DESCRIPTION
### Description

Add a new utility function `VRMUtils.removeUnnecessaryVertices`.

This is to address the issue that morph textures consumes gigantic amount of VRAM.
See comments for more details.

I probably have to apply this also for the current v0.x stream.

See: mrdoob/three.js#23095

### Points need review

- [ ] TBD
