### PR TITLE
Bump Three.js to r136

### DIFF
--- a/packages/three-vrm/examples/animations.html
+++ b/packages/three-vrm/examples/animations.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.133.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.133.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.133.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.136.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.136.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.136.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/basic.html
+++ b/packages/three-vrm/examples/basic.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.133.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.133.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.133.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.136.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.136.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.136.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/blendshapes.html
+++ b/packages/three-vrm/examples/blendshapes.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.133.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.133.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.133.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.136.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.136.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.136.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/bones.html
+++ b/packages/three-vrm/examples/bones.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.133.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.133.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.133.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.136.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.136.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.136.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/debug.html
+++ b/packages/three-vrm/examples/debug.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.133.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.133.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.133.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.136.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.136.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.136.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/dnd.html
+++ b/packages/three-vrm/examples/dnd.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.133.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.133.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.133.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.136.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.136.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.136.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/encoding.html
+++ b/packages/three-vrm/examples/encoding.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.133.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.133.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.133.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.136.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.136.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.136.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/envmap.html
+++ b/packages/three-vrm/examples/envmap.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.133.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.133.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.133.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.136.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.136.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.136.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/firstperson.html
+++ b/packages/three-vrm/examples/firstperson.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.133.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.133.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.133.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.136.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.136.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.136.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/lookat-advanced.html
+++ b/packages/three-vrm/examples/lookat-advanced.html
@@ -21,9 +21,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.133.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.133.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.133.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.136.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.136.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.136.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			const _v3A = new THREE.Vector3();

--- a/packages/three-vrm/examples/lookat.html
+++ b/packages/three-vrm/examples/lookat.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.133.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.133.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.133.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.136.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.136.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.136.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/materials-debug.html
+++ b/packages/three-vrm/examples/materials-debug.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.133.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.133.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.133.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.136.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.136.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.136.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/meta.html
+++ b/packages/three-vrm/examples/meta.html
@@ -30,9 +30,9 @@
 	<body>
 		<span id="meta"></span>
 		<img id="thumbnail" alt="thumbnail" />
-		<script src="https://unpkg.com/three@0.133.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.133.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.133.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.136.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.136.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.136.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/mouse.html
+++ b/packages/three-vrm/examples/mouse.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.133.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.133.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.133.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.136.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.136.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.136.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/package.json
+++ b/packages/three-vrm/package.json
@@ -50,14 +50,14 @@
     ]
   },
   "devDependencies": {
-    "@types/three": "^0.132.1",
+    "@types/three": "^0.136.1",
     "gh-pages": "^3.1.0",
     "lint-staged": "10.5.4",
     "quicktype": "^15.0.258",
-    "three": "^0.133.0"
+    "three": "^0.136.0"
   },
   "peerDependencies": {
-    "@types/three": "^0.131.0",
-    "three": "^0.133.0"
+    "@types/three": "^0.136.1",
+    "three": "^0.136.0"
   }
 }

--- a/packages/three-vrm/src/material/MToonMaterial.ts
+++ b/packages/three-vrm/src/material/MToonMaterial.ts
@@ -231,13 +231,13 @@ export class MToonMaterial extends THREE.ShaderMaterial {
     parameters.lights = true;
     parameters.clipping = true;
 
-    // COMPAT
+    // COMPAT: pre-r129
     // See: https://github.com/mrdoob/three.js/pull/21788
     if (parseInt(THREE.REVISION, 10) < 129) {
       (parameters as any).skinning = (parameters as any).skinning || false;
     }
 
-    // COMPAT
+    // COMPAT: pre-r131
     // See: https://github.com/mrdoob/three.js/pull/22169
     if (parseInt(THREE.REVISION, 10) < 131) {
       (parameters as any).morphTargets = (parameters as any).morphTargets || false;

--- a/packages/three-vrm/src/material/VRMMaterialImporter.ts
+++ b/packages/three-vrm/src/material/VRMMaterialImporter.ts
@@ -337,13 +337,13 @@ export class VRMMaterialImporter {
       }
     }
 
-    // COMPAT
+    // COMPAT: pre-r129
     // See: https://github.com/mrdoob/three.js/pull/21788
     if (parseInt(THREE.REVISION, 10) < 129) {
       params.skinning = (originalMaterial as any).skinning || false;
     }
 
-    // COMPAT
+    // COMPAT: pre-r131
     // See: https://github.com/mrdoob/three.js/pull/22169
     if (parseInt(THREE.REVISION, 10) < 131) {
       params.morphTargets = (originalMaterial as any).morphTargets || false;

--- a/packages/three-vrm/src/material/VRMUnlitMaterial.ts
+++ b/packages/three-vrm/src/material/VRMUnlitMaterial.ts
@@ -49,13 +49,13 @@ export class VRMUnlitMaterial extends THREE.ShaderMaterial {
     parameters.fog = true;
     parameters.clipping = true;
 
-    // COMPAT
+    // COMPAT: pre-r129
     // See: https://github.com/mrdoob/three.js/pull/21788
     if (parseInt(THREE.REVISION, 10) < 129) {
       (parameters as any).skinning = (parameters as any).skinning || false;
     }
 
-    // COMPAT
+    // COMPAT: pre-r131
     // See: https://github.com/mrdoob/three.js/pull/22169
     if (parseInt(THREE.REVISION, 10) < 131) {
       (parameters as any).morphTargets = (parameters as any).morphTargets || false;

--- a/packages/three-vrm/src/material/getTexelDecodingFunction.ts
+++ b/packages/three-vrm/src/material/getTexelDecodingFunction.ts
@@ -1,26 +1,45 @@
 import * as THREE from 'three';
 
+/**
+ * Ref: https://github.com/mrdoob/three.js/blob/r136/src/renderers/webgl/WebGLProgram.js#L22
+ */
 export const getEncodingComponents = (encoding: THREE.TextureEncoding): [string, string] => {
-  switch (encoding) {
-    case THREE.LinearEncoding:
-      return ['Linear', '( value )'];
-    case THREE.sRGBEncoding:
-      return ['sRGB', '( value )'];
-    case THREE.RGBEEncoding:
-      return ['RGBE', '( value )'];
-    case THREE.RGBM7Encoding:
-      return ['RGBM', '( value, 7.0 )'];
-    case THREE.RGBM16Encoding:
-      return ['RGBM', '( value, 16.0 )'];
-    case THREE.RGBDEncoding:
-      return ['RGBD', '( value, 256.0 )'];
-    case THREE.GammaEncoding:
-      return ['Gamma', '( value, float( GAMMA_FACTOR ) )'];
-    default:
-      throw new Error('unsupported encoding: ' + encoding);
+  if (parseInt(THREE.REVISION, 10) >= 136) {
+    switch (encoding) {
+      case THREE.LinearEncoding:
+        return ['Linear', '( value )'];
+      case THREE.sRGBEncoding:
+        return ['sRGB', '( value )'];
+      default:
+        console.warn( 'THREE.WebGLProgram: Unsupported encoding:', encoding );
+        return [ 'Linear', '( value )' ];
+    }
+  } else {
+    // COMPAT: pre-r136
+    switch (encoding) {
+      case THREE.LinearEncoding:
+        return ['Linear', '( value )'];
+      case THREE.sRGBEncoding:
+        return ['sRGB', '( value )'];
+      case (THREE as any).RGBEEncoding:
+        return ['RGBE', '( value )'];
+      case THREE.RGBM7Encoding:
+        return ['RGBM', '( value, 7.0 )'];
+      case THREE.RGBM16Encoding:
+        return ['RGBM', '( value, 16.0 )'];
+      case (THREE as any).RGBDEncoding:
+        return ['RGBD', '( value, 256.0 )'];
+      case (THREE as any).GammaEncoding:
+        return ['Gamma', '( value, float( GAMMA_FACTOR ) )'];
+      default:
+        throw new Error('unsupported encoding: ' + encoding);
+    }
   }
 };
 
+/**
+ * https://github.com/mrdoob/three.js/blob/r136/src/renderers/webgl/WebGLProgram.js#L52
+ */
 export const getTexelDecodingFunction = (functionName: string, encoding: THREE.TextureEncoding): string => {
   const components = getEncodingComponents(encoding);
   return 'vec4 ' + functionName + '( vec4 value ) { return ' + components[0] + 'ToLinear' + components[1] + '; }';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1019,10 +1019,10 @@
   resolved "https://registry.yarnpkg.com/@types/parse-json/-/parse-json-4.0.0.tgz#2f8bb441434d163b35fb8ffdccd7138927ffb8c0"
   integrity sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
 
-"@types/three@^0.132.1":
-  version "0.132.1"
-  resolved "https://registry.yarnpkg.com/@types/three/-/three-0.132.1.tgz#16e0889fdbd41259c2fdf18ff2444baa0afc8e57"
-  integrity sha512-d+eB9/zaK7Bo690EmWCrMwutNWiMYGnW+G5cRO4jvRHvKhI/fe2B2d6xHf1MW0yl+nQ0ij+ctezYGePWtVhAAA==
+"@types/three@^0.136.1":
+  version "0.136.1"
+  resolved "https://registry.yarnpkg.com/@types/three/-/three-0.136.1.tgz#030fc01cdc5ce82cad93db17b94a24515cb4b50e"
+  integrity sha512-gzTw6RR4dU8sGf+RpLBWWKHRVIJ4gwKVQPk+IFCgha04Efg/itXYUalX6iBcYeSmaDu0qE5M7uTq0XLQpU4FAg==
 
 "@typescript-eslint/eslint-plugin@^4.6.1":
   version "4.14.2"
@@ -6349,10 +6349,10 @@ thenify-all@^1.0.0:
   dependencies:
     any-promise "^1.0.0"
 
-three@^0.133.0:
-  version "0.133.0"
-  resolved "https://registry.yarnpkg.com/three/-/three-0.133.0.tgz#41427306c731a89407221b7be48c7a63580400e7"
-  integrity sha512-1p8xTXnJD4hMM2Ktm7+FqOOBoImBoftKnKtAZT/b9AQeL3LhRkVu/HnIJhWA69qIMvUYpjfnunNsO4WdObw1ZQ==
+three@^0.136.0:
+  version "0.136.0"
+  resolved "https://registry.yarnpkg.com/three/-/three-0.136.0.tgz#b1504db021b46398ef468aa7849f3dcabb814f50"
+  integrity sha512-+fEMX7nYLz2ZesVP/dyifli5Jf8gR3XPAnFJveQ80aMhibFduzrADnjMbARXh8+W9qLK7rshJCjAIL/6cDxC+A==
 
 through2@^2.0.0, through2@^2.0.2, through2@~2.0.3:
   version "2.0.5"


### PR DESCRIPTION
### Description

- Bump three.js to r136.
- There was a breaking change about color encoding and the forked `getTexelDecodingFunction` affects the change. Fixed this.
