### PR TITLE
chore: three-vrm should export not minified version in package.json

### DIFF
--- a/packages/three-vrm/package.json
+++ b/packages/three-vrm/package.json
@@ -10,8 +10,8 @@
     "/types/",
     "LICENSE"
   ],
-  "main": "lib/three-vrm.min.js",
-  "module": "lib/three-vrm.module.min.js",
+  "main": "lib/three-vrm.js",
+  "module": "lib/three-vrm.module.js",
   "types": "types/index.d.ts",
   "typesVersions": {
     "<3.9": {


### PR DESCRIPTION
### Description

Thinking about debugging, `@pixiv/three-vrm` should specify not minified version of three-vrm instead of minified one in `package.json`.
Other modules already output their not minified version.
