### PR TITLE
[1.0] change: VRMLookAt.target should accept null

### DIFF
--- a/packages/three-vrm-core/src/lookAt/VRMLookAt.ts
+++ b/packages/three-vrm-core/src/lookAt/VRMLookAt.ts
@@ -45,7 +45,7 @@ export class VRMLookAt {
    *
    * See also: {@link autoUpdate}
    */
-  public target?: THREE.Object3D;
+  public target?: THREE.Object3D | null;
 
   /**
    * The front direction of the face.


### PR DESCRIPTION
`VRMLookAt.target` already accepts `undefined` but I want to make it accept `null` as well.
This is a very subtle change.
