### PR TITLE
fix: apply pre-r137 compat

### DIFF
--- a/packages/three-vrm/src/material/MToonMaterial.ts
+++ b/packages/three-vrm/src/material/MToonMaterial.ts
@@ -3,6 +3,7 @@
 import * as THREE from 'three';
 import vertexShader from './shaders/mtoon.vert';
 import fragmentShader from './shaders/mtoon.frag';
+import { getTexelDecodingFunction } from './getTexelDecodingFunction';
 
 const TAU = 2.0 * Math.PI;
 
@@ -577,6 +578,22 @@ export class MToonMaterial extends THREE.ShaderMaterial {
     // == generate shader code =================================================
     this.vertexShader = vertexShader;
     this.fragmentShader = fragmentShader;
+
+    // == texture encodings ====================================================
+    // COMPAT: pre-r137
+    if (parseInt(THREE.REVISION, 10) < 137) {
+      const encodings =
+        (this.shadeTexture !== null
+          ? getTexelDecodingFunction('shadeTextureTexelToLinear', this.shadeTexture.encoding) + '\n'
+          : '') +
+        (this.sphereAdd !== null
+          ? getTexelDecodingFunction('sphereAddTexelToLinear', this.sphereAdd.encoding) + '\n'
+          : '') +
+        (this.rimTexture !== null
+          ? getTexelDecodingFunction('rimTextureTexelToLinear', this.rimTexture.encoding) + '\n'
+          : '');
+      this.fragmentShader = encodings + fragmentShader;
+    }
 
     // == set needsUpdate flag =================================================
     this.needsUpdate = true;

--- a/packages/three-vrm/src/material/getTexelDecodingFunction.ts
+++ b/packages/three-vrm/src/material/getTexelDecodingFunction.ts
@@ -1,0 +1,57 @@
+import * as THREE from 'three';
+
+// Since these constants are deleted in r136 we have to define by ourselves
+/* eslint-disable @typescript-eslint/naming-convention */
+const RGBEEncoding = 3002;
+const RGBDEncoding = 3006;
+const GammaEncoding = 3007;
+/* eslint-enable @typescript-eslint/naming-convention */
+
+/**
+ * COMPAT: pre-r137
+ * Ref: https://github.com/mrdoob/three.js/blob/r136/src/renderers/webgl/WebGLProgram.js#L22
+ */
+export const getEncodingComponents = (encoding: THREE.TextureEncoding): [string, string] => {
+  if (parseInt(THREE.REVISION, 10) >= 136) {
+    switch (encoding) {
+      case THREE.LinearEncoding:
+        return ['Linear', '( value )'];
+      case THREE.sRGBEncoding:
+        return ['sRGB', '( value )'];
+      default:
+        console.warn('THREE.WebGLProgram: Unsupported encoding:', encoding);
+        return ['Linear', '( value )'];
+    }
+  } else {
+    // COMPAT: pre-r136
+    switch (encoding) {
+      case THREE.LinearEncoding:
+        return ['Linear', '( value )'];
+      case THREE.sRGBEncoding:
+        return ['sRGB', '( value )'];
+      case RGBEEncoding:
+        return ['RGBE', '( value )'];
+      case THREE.RGBM7Encoding:
+        return ['RGBM', '( value, 7.0 )'];
+      case THREE.RGBM16Encoding:
+        return ['RGBM', '( value, 16.0 )'];
+      case RGBDEncoding:
+        return ['RGBD', '( value, 256.0 )'];
+      case GammaEncoding:
+        return ['Gamma', '( value, float( GAMMA_FACTOR ) )'];
+      default:
+        throw new Error('unsupported encoding: ' + encoding);
+    }
+  }
+};
+
+/**
+ * COMPAT: pre-r137
+ * This function is no longer required beginning from r137
+ *
+ * https://github.com/mrdoob/three.js/blob/r136/src/renderers/webgl/WebGLProgram.js#L52
+ */
+export const getTexelDecodingFunction = (functionName: string, encoding: THREE.TextureEncoding): string => {
+  const components = getEncodingComponents(encoding);
+  return 'vec4 ' + functionName + '( vec4 value ) { return ' + components[0] + 'ToLinear' + components[1] + '; }';
+};


### PR DESCRIPTION
sequel of #910 , should fix #914 

### Description

- Revert back `getTexelDecodingFunction` but with pre-137 compat code
    - `RGBEEncoding`, `RGBDEncoding`, and `GammaEncoding` are not defined starting from r136, I have put these constants by hand.

### Points need review

- [ ] is this working properly on r137, r136, r135?
    - optionally more older versions
