### PR TITLE
fix MToon lighting

### DIFF
--- a/packages/three-vrm/src/material/shaders/mtoon.frag
+++ b/packages/three-vrm/src/material/shaders/mtoon.frag
@@ -230,8 +230,10 @@ vec3 getLighting( const in vec3 lightColor ) {
     lightColorAttenuation
   );
 
-  #ifndef PHYSICALLY_CORRECT_LIGHTS
-    lighting *= PI;
+  #if THREE_VRM_THREE_REVISION < 132
+    #ifndef PHYSICALLY_CORRECT_LIGHTS
+      lighting *= PI;
+    #endif
   #endif
 
   return lighting;


### PR DESCRIPTION
PHYSICALLY_CORRECT_LIGHTS part in getLighting should not exist since r132
