### PR TITLE
[1.0] Constraint, freezeAxes -> axes

### DIFF
--- a/packages/three-vrm-node-constraint/examples/models/cubes.gltf
+++ b/packages/three-vrm-node-constraint/examples/models/cubes.gltf
@@ -322,7 +322,7 @@
           "constraint": {
             "rotation": {
               "source": 0,
-              "freezeAxes": [true, false, false],
+              "axes": [true, false, false],
               "weight": 1.0
             }
           }
@@ -355,7 +355,7 @@
           "constraint": {
             "rotation": {
               "source": 0,
-              "freezeAxes": [true, true, true],
+              "axes": [true, true, true],
               "weight": 0.5
             }
           }

--- a/packages/three-vrm-node-constraint/src/VRMAimConstraint.ts
+++ b/packages/three-vrm-node-constraint/src/VRMAimConstraint.ts
@@ -26,7 +26,7 @@ export class VRMAimConstraint extends VRMNodeConstraint {
    */
   public readonly upVector = new THREE.Vector3(0.0, 1.0, 0.0);
 
-  public freezeAxes: [boolean, boolean] = [true, true];
+  public axes: [boolean, boolean] = [true, true];
 
   private readonly _quatInitAim = new THREE.Quaternion();
   private readonly _quatInvInitAim = new THREE.Quaternion();
@@ -64,7 +64,7 @@ export class VRMAimConstraint extends VRMNodeConstraint {
 
   /**
    * Return a quaternion that represents a diff from the initial -> current orientation of the aim direction.
-   * It's aware of its {@link sourceSpace}, {@link freezeAxes}, and {@link weight}.
+   * It's aware of its {@link sourceSpace}, {@link axes}, and {@link weight}.
    * @param target Target quaternion
    */
   private _getAimDiffQuat<T extends THREE.Quaternion>(target: T): T {
@@ -78,7 +78,7 @@ export class VRMAimConstraint extends VRMNodeConstraint {
 
   /**
    * Return a current orientation of the aim direction.
-   * It's aware of its {@link sourceSpace} and {@link freezeAxes}.
+   * It's aware of its {@link sourceSpace} and {@link axes}.
    * @param target Target quaternion
    */
   private _getAimQuat<T extends THREE.Quaternion>(target: T): T {
@@ -88,7 +88,7 @@ export class VRMAimConstraint extends VRMNodeConstraint {
       this._getSourcePosition(_v3GetRotationDir),
       this.aimVector,
       this.upVector,
-      this.freezeAxes,
+      this.axes,
     );
   }
 

--- a/packages/three-vrm-node-constraint/src/VRMNodeConstraintLoaderPlugin.ts
+++ b/packages/three-vrm-node-constraint/src/VRMNodeConstraintLoaderPlugin.ts
@@ -89,7 +89,7 @@ export class VRMNodeConstraintLoaderPlugin implements GLTFLoaderPlugin {
     modelRoot: THREE.Object3D,
     rotation: ConstraintSchema.RotationConstraint,
   ): VRMRotationConstraint {
-    const { source, weight, freezeAxes } = rotation;
+    const { source, weight, axes } = rotation;
     const constraint = new VRMRotationConstraint(destination, modelRoot);
 
     constraint.setSource(nodes[source]);
@@ -100,8 +100,8 @@ export class VRMNodeConstraintLoaderPlugin implements GLTFLoaderPlugin {
     if (weight) {
       constraint.weight = weight;
     }
-    if (freezeAxes) {
-      constraint.freezeAxes = freezeAxes;
+    if (axes) {
+      constraint.axes = axes;
     }
 
     if (this.helperRoot) {

--- a/packages/three-vrm-node-constraint/src/VRMPositionConstraint.ts
+++ b/packages/three-vrm-node-constraint/src/VRMPositionConstraint.ts
@@ -7,7 +7,7 @@ import { VRMNodeConstraint } from './VRMNodeConstraint';
 const _matA = new THREE.Matrix4();
 
 export class VRMPositionConstraint extends VRMNodeConstraint {
-  public freezeAxes: [boolean, boolean, boolean] = [true, true, true];
+  public axes: [boolean, boolean, boolean] = [true, true, true];
 
   private _v3InitDst = new THREE.Vector3();
   private _v3InitSrc = new THREE.Vector3();
@@ -39,14 +39,14 @@ export class VRMPositionConstraint extends VRMNodeConstraint {
 
   /**
    * Return a vector that represents a diff from the initial -> current position of the source.
-   * It's aware of its {@link sourceSpace}, {@link freezeAxes}, and {@link weight}.
+   * It's aware of its {@link sourceSpace}, {@link axes}, and {@link weight}.
    * @param target Target quaternion
    */
   private _getSourceDiffPosition<T extends THREE.Vector3>(target: T): T {
     this._getSourcePosition(target);
     target.sub(this._v3InitSrc);
 
-    vector3FreezeAxes(target, this.freezeAxes);
+    vector3FreezeAxes(target, this.axes);
 
     target.multiplyScalar(this.weight);
 

--- a/packages/three-vrm-node-constraint/src/VRMRotationConstraint.ts
+++ b/packages/three-vrm-node-constraint/src/VRMRotationConstraint.ts
@@ -11,7 +11,7 @@ const _quatA = new THREE.Quaternion();
 const _quatB = new THREE.Quaternion();
 
 export class VRMRotationConstraint extends VRMNodeConstraint {
-  public freezeAxes: [boolean, boolean, boolean] = [true, true, true];
+  public axes: [boolean, boolean, boolean] = [true, true, true];
 
   private _quatInitSrc = new THREE.Quaternion();
   private _quatInvInitSrc = new THREE.Quaternion();
@@ -46,7 +46,7 @@ export class VRMRotationConstraint extends VRMNodeConstraint {
 
   /**
    * Return a quaternion that represents a diff from the initial -> current orientation of the source.
-   * It's aware of its {@link sourceSpace}, {@link freezeAxes}, and {@link weight}.
+   * It's aware of its {@link sourceSpace}, {@link axes}, and {@link weight}.
    * @param target Target quaternion
    */
   private _getSourceDiffQuat<T extends THREE.Quaternion>(target: T): T {
@@ -57,7 +57,7 @@ export class VRMRotationConstraint extends VRMNodeConstraint {
       target.multiply(this._quatInvInitSrc);
     }
 
-    quaternionFreezeAxes(target, this.freezeAxes);
+    quaternionFreezeAxes(target, this.axes);
 
     target.slerp(QUAT_IDENTITY, 1.0 - this.weight);
 

--- a/packages/three-vrm-node-constraint/src/utils/setAimQuaternion.ts
+++ b/packages/three-vrm-node-constraint/src/utils/setAimQuaternion.ts
@@ -19,7 +19,7 @@ export function setAimQuaternion<T extends THREE.Quaternion>(
   to: THREE.Vector3,
   aim: THREE.Vector3,
   up: THREE.Vector3,
-  freezeAxes: [boolean, boolean],
+  axes: [boolean, boolean],
 ): T {
   // this is the target rotation
   _v3Dir.copy(to).sub(from).normalize();
@@ -37,8 +37,8 @@ export function setAimQuaternion<T extends THREE.Quaternion>(
   const phiDir = Math.atan2(_v3PlaneX.dot(_v3Dir), _v3PlaneY.dot(_v3Dir));
 
   // made a quaternion out of calculated phi and theta
-  target.setFromAxisAngle(up, freezeAxes[0] ? phiDir : 0.0);
-  _quatA.setFromAxisAngle(_v3PlaneX, freezeAxes[1] ? thetaAim - thetaDir : 0.0);
+  target.setFromAxisAngle(up, axes[0] ? phiDir : 0.0);
+  _quatA.setFromAxisAngle(_v3PlaneX, axes[1] ? thetaAim - thetaDir : 0.0);
   target.multiply(_quatA);
 
   return target;

--- a/packages/types-vrmc-node-constraint-1.0/src/RotationConstraint.ts
+++ b/packages/types-vrmc-node-constraint-1.0/src/RotationConstraint.ts
@@ -10,7 +10,7 @@ export interface RotationConstraint {
   /**
    * Axes be constrained by this constraint, in X-Y-Z order.
    */
-  freezeAxes?: [boolean, boolean, boolean];
+  axes?: [boolean, boolean, boolean];
 
   /**
    * The weight of the constraint.


### PR DESCRIPTION
### Description

`freezeAxes` has been renamed to `axes` in spec. This PR follows this change.

See: https://github.com/vrm-c/vrm-specification/pull/352
