### PR TITLE
fix (1.0, schema): fix signatures of `extensions`

### DIFF
--- a/packages/types-vrmc-springbone-1.0/src/SpringBoneCollider.ts
+++ b/packages/types-vrmc-springbone-1.0/src/SpringBoneCollider.ts
@@ -8,6 +8,6 @@ export interface SpringBoneCollider {
 
   shape?: SpringBoneColliderShape;
 
-  extensions?: { [key: string]: { [key: string]: any } };
+  extensions?: { [name: string]: any };
   extras?: any;
 }

--- a/packages/types-vrmc-springbone-1.0/src/SpringBoneColliderGroup.ts
+++ b/packages/types-vrmc-springbone-1.0/src/SpringBoneColliderGroup.ts
@@ -6,6 +6,6 @@ export interface SpringBoneColliderGroup {
 
   colliders?: number[];
 
-  extensions?: { [key: string]: { [key: string]: any } };
+  extensions?: { [name: string]: any };
   extras?: any;
 }

--- a/packages/types-vrmc-vrm-1.0/src/Expression.ts
+++ b/packages/types-vrmc-vrm-1.0/src/Expression.ts
@@ -53,6 +53,6 @@ export interface Expression {
    */
   overrideMouth?: ExpressionOverrideType;
 
-  extensions?: { [key: string]: { [key: string]: any } };
+  extensions?: { [name: string]: any };
   extras?: any;
 }

--- a/packages/types-vrmc-vrm-1.0/src/ExpressionMaterialColorBind.ts
+++ b/packages/types-vrmc-vrm-1.0/src/ExpressionMaterialColorBind.ts
@@ -13,6 +13,6 @@ export interface ExpressionMaterialColorBind {
    */
   targetValue: [number, number, number, number];
 
-  extensions?: { [key: string]: { [key: string]: any } };
+  extensions?: { [name: string]: any };
   extras?: any;
 }

--- a/packages/types-vrmc-vrm-1.0/src/ExpressionMorphTargetBind.ts
+++ b/packages/types-vrmc-vrm-1.0/src/ExpressionMorphTargetBind.ts
@@ -17,6 +17,6 @@ export interface ExpressionMorphTargetBind {
    */
   weight: number;
 
-  extensions?: { [key: string]: { [key: string]: any } };
+  extensions?: { [name: string]: any };
   extras?: any;
 }

--- a/packages/types-vrmc-vrm-1.0/src/ExpressionTextureTransformBind.ts
+++ b/packages/types-vrmc-vrm-1.0/src/ExpressionTextureTransformBind.ts
@@ -14,6 +14,6 @@ export interface ExpressionTextureTransformBind {
    */
   offset?: [number, number];
 
-  extensions?: { [key: string]: { [key: string]: any } };
+  extensions?: { [name: string]: any };
   extras?: any;
 }

--- a/packages/types-vrmc-vrm-1.0/src/FirstPerson.ts
+++ b/packages/types-vrmc-vrm-1.0/src/FirstPerson.ts
@@ -9,6 +9,6 @@ export interface FirstPerson {
    */
   meshAnnotations?: FirstPersonMeshAnnotation[];
 
-  extensions?: { [key: string]: { [key: string]: any } };
+  extensions?: { [name: string]: any };
   extras?: any;
 }

--- a/packages/types-vrmc-vrm-1.0/src/FirstPersonMeshAnnotation.ts
+++ b/packages/types-vrmc-vrm-1.0/src/FirstPersonMeshAnnotation.ts
@@ -12,6 +12,6 @@ export interface FirstPersonMeshAnnotation {
    */
   type: 'auto' | 'both' | 'thirdPersonOnly' | 'firstPersonOnly';
 
-  extensions?: { [key: string]: { [key: string]: any } };
+  extensions?: { [name: string]: any };
   extras?: any;
 }

--- a/packages/types-vrmc-vrm-1.0/src/Humanoid.ts
+++ b/packages/types-vrmc-vrm-1.0/src/Humanoid.ts
@@ -6,6 +6,6 @@ import type { HumanoidHumanBones } from './HumanoidHumanBones';
 export interface Humanoid {
   humanBones: HumanoidHumanBones;
 
-  extensions?: { [key: string]: { [key: string]: any } };
+  extensions?: { [name: string]: any };
   extras?: any;
 }

--- a/packages/types-vrmc-vrm-1.0/src/HumanoidHumanBone.ts
+++ b/packages/types-vrmc-vrm-1.0/src/HumanoidHumanBone.ts
@@ -7,6 +7,6 @@ export interface HumanoidHumanBone {
    */
   node: number;
 
-  extensions?: { [key: string]: { [key: string]: any } };
+  extensions?: { [name: string]: any };
   extras?: any;
 }

--- a/packages/types-vrmc-vrm-1.0/src/LookAt.ts
+++ b/packages/types-vrmc-vrm-1.0/src/LookAt.ts
@@ -31,6 +31,6 @@ export interface LookAt {
    */
   rangeMapVerticalUp?: LookAtRangeMap;
 
-  extensions?: { [key: string]: { [key: string]: any } };
+  extensions?: { [name: string]: any };
   extras?: any;
 }

--- a/packages/types-vrmc-vrm-1.0/src/LookAtRangeMap.ts
+++ b/packages/types-vrmc-vrm-1.0/src/LookAtRangeMap.ts
@@ -12,6 +12,6 @@ export interface LookAtRangeMap {
    */
   outputScale?: number;
 
-  extensions?: { [key: string]: { [key: string]: any } };
+  extensions?: { [name: string]: any };
   extras?: any;
 }

--- a/packages/types-vrmc-vrm-1.0/src/Meta.ts
+++ b/packages/types-vrmc-vrm-1.0/src/Meta.ts
@@ -94,6 +94,6 @@ export interface Meta {
    */
   otherLicenseUrl?: string;
 
-  extensions?: { [key: string]: { [key: string]: any } };
+  extensions?: { [name: string]: any };
   extras?: any;
 }

--- a/packages/types-vrmc-vrm-1.0/src/VRMCVRM.ts
+++ b/packages/types-vrmc-vrm-1.0/src/VRMCVRM.ts
@@ -29,6 +29,6 @@ export interface VRMCVRM {
 
   expressions?: Expressions;
 
-  extensions?: { [key: string]: { [key: string]: any } };
+  extensions?: { [name: string]: any };
   extras?: any;
 }


### PR DESCRIPTION
### Description

Changed type signature of `.extensions` of gltf properties from `{ [key: string]: { [key: string]: any } }` to `{ [name: string]: any }` .

See: https://github.com/pixiv/three-vrm/pull/934#discussion_r822597191

### Points need review

- I think it's obvious based on the previous discussion
