### PR TITLE
[1.0] fix: change default value of spring bone colliders

### DIFF
--- a/packages/three-vrm-springbone/src/VRMSpringBoneColliderShapeCapsule.ts
+++ b/packages/three-vrm-springbone/src/VRMSpringBoneColliderShapeCapsule.ts
@@ -29,7 +29,7 @@ export class VRMSpringBoneColliderShapeCapsule extends VRMSpringBoneColliderShap
 
     this.offset = params?.offset ?? new THREE.Vector3(0.0, 0.0, 0.0);
     this.tail = params?.tail ?? new THREE.Vector3(0.0, 0.0, 0.0);
-    this.radius = params?.radius ?? 1.0;
+    this.radius = params?.radius ?? 0.0;
   }
 
   public calculateCollision(

--- a/packages/three-vrm-springbone/src/VRMSpringBoneColliderShapeSphere.ts
+++ b/packages/three-vrm-springbone/src/VRMSpringBoneColliderShapeSphere.ts
@@ -20,7 +20,7 @@ export class VRMSpringBoneColliderShapeSphere extends VRMSpringBoneColliderShape
     super();
 
     this.offset = params?.offset ?? new THREE.Vector3(0.0, 0.0, 0.0);
-    this.radius = params?.radius ?? 1.0;
+    this.radius = params?.radius ?? 0.0;
   }
 
   public calculateCollision(


### PR DESCRIPTION
### Description

The default value of SpringBone colliders should be `0.0` instead of `1.0` . Fixed this.

See: https://github.com/vrm-c/vrm-specification/blob/master/specification/VRMC_springBone-1.0-beta/schema/VRMC_springBone.shape.schema.json#L24