### PR TITLE
fix: add compatibility for `getHemisphereLightIrradiance`

### DIFF
--- a/packages/three-vrm/src/material/shaders/mtoon.frag
+++ b/packages/three-vrm/src/material/shaders/mtoon.frag
@@ -554,7 +554,11 @@ void main() {
   #if ( NUM_HEMI_LIGHTS > 0 )
     #pragma unroll_loop_start
     for ( int i = 0; i < NUM_HEMI_LIGHTS; i ++ ) {
-      irradiance += getHemisphereLightIrradiance( hemisphereLights[ i ], geometry );
+      #if THREE_VRM_THREE_REVISION >= 133
+        irradiance += getHemisphereLightIrradiance( hemisphereLights[ i ], geometry.normal );
+      #else
+        irradiance += getHemisphereLightIrradiance( hemisphereLights[ i ], geometry );
+      #endif
     }
     #pragma unroll_loop_end
   #endif


### PR DESCRIPTION
Fix #938 
According to #825, I think the change(check version>=133 and pass geometry.normal) should be correct.