### PR TITLE
fix: add compatibility for `getHemisphereLightIrradiance`

### DIFF
--- a/packages/three-vrm-materials-mtoon/src/shaders/mtoon.frag
+++ b/packages/three-vrm-materials-mtoon/src/shaders/mtoon.frag
@@ -629,7 +629,11 @@ void main() {
       #pragma unroll_loop_start
       for ( int i = 0; i < NUM_HEMI_LIGHTS; i ++ ) {
 
-        irradiance += getHemisphereLightIrradiance( hemisphereLights[ i ], geometry );
+        #if THREE_VRM_THREE_REVISION >= 133
+          irradiance += getHemisphereLightIrradiance( hemisphereLights[ i ], geometry.normal );
+        #else
+          irradiance += getHemisphereLightIrradiance( hemisphereLights[ i ], geometry );
+        #endif
 
       }
       #pragma unroll_loop_end


### PR DESCRIPTION
### Description

The current `getHemisphereLightIrradiance` in `mtoon.frag` does not work starting from Three r133.
This PR fixes this.

Redo of https://github.com/pixiv/three-vrm/pull/954 in the `1.0` branch.

@you74674 makes the original commit.
