### PR TITLE
[1.0] BREAKING Update LookAt

### DIFF
--- a/packages/three-vrm-core/jest.config.js
+++ b/packages/three-vrm-core/jest.config.js
@@ -1,0 +1,23 @@
+/* eslint-disable */
+
+module.exports = {
+  "roots": [
+    "<rootDir>/src"
+  ],
+  "transform": {
+    "^.+\\.tsx?$": "ts-jest"
+  },
+  "testRegex": "[^.]*\.test\.tsx?$",
+  "moduleFileExtensions": [
+    "ts",
+    "tsx",
+    "js",
+    "jsx",
+    "json",
+    "node"
+  ],
+  "collectCoverageFrom": [
+    "**/*.{ts,tsx}",
+    "!**/tests/**"
+  ]
+}

--- a/packages/three-vrm-core/src/lookAt/VRMLookAt.ts
+++ b/packages/three-vrm-core/src/lookAt/VRMLookAt.ts
@@ -104,7 +104,12 @@ export class VRMLookAt {
    * Does NOT consider {@link faceFront}.
    */
   public get euler(): THREE.Euler {
-    return new THREE.Euler(this._pitch, this._yaw, 0.0, 'YXZ');
+    return new THREE.Euler(
+      THREE.MathUtils.DEG2RAD * this._pitch,
+      THREE.MathUtils.DEG2RAD * this._yaw,
+      0.0,
+      'YXZ',
+    );
   }
 
   /**

--- a/packages/three-vrm-core/src/lookAt/VRMLookAt.ts
+++ b/packages/three-vrm-core/src/lookAt/VRMLookAt.ts
@@ -103,7 +103,7 @@ export class VRMLookAt {
   /**
    * Specifies that angles need to be applied to its [@link applier].
    */
-   protected _needsUpdate: boolean;
+  protected _needsUpdate: boolean;
 
   /**
    * @deprecated Use {@link getEuler} instead.
@@ -136,12 +136,7 @@ export class VRMLookAt {
    * @param target The target euler
    */
   public getEuler(target: THREE.Euler): THREE.Euler {
-    return target.set(
-      THREE.MathUtils.DEG2RAD * this._pitch,
-      THREE.MathUtils.DEG2RAD * this._yaw,
-      0.0,
-      'YXZ',
-    );
+    return target.set(THREE.MathUtils.DEG2RAD * this._pitch, THREE.MathUtils.DEG2RAD * this._yaw, 0.0, 'YXZ');
   }
 
   /**
@@ -215,7 +210,7 @@ export class VRMLookAt {
       return target.identity();
     }
 
-    const [ faceFrontAzimuth, faceFrontAltitude ] = calcAzimuthAltitude(this.faceFront);
+    const [faceFrontAzimuth, faceFrontAltitude] = calcAzimuthAltitude(this.faceFront);
     _eulerA.set(0.0, 0.5 * Math.PI + faceFrontAzimuth, faceFrontAltitude, 'YZX');
     return target.setFromEuler(_eulerA);
   }
@@ -229,11 +224,7 @@ export class VRMLookAt {
     this.getLookAtWorldQuaternion(_quatB);
     this.getFaceFrontQuaternion(_quatC);
 
-    return target
-      .copy(VEC3_POSITIVE_Z)
-      .applyQuaternion(_quatB)
-      .applyQuaternion(_quatC)
-      .applyEuler(this.euler);
+    return target.copy(VEC3_POSITIVE_Z).applyQuaternion(_quatB).applyQuaternion(_quatC).applyEuler(this.euler);
   }
 
   /**
@@ -249,8 +240,8 @@ export class VRMLookAt {
     const lookAtDir = _v3C.copy(position).sub(headPos).applyQuaternion(headRotInv).normalize();
 
     // calculate angles
-    const [ azimuthFrom, altitudeFrom ] = calcAzimuthAltitude(this.faceFront);
-    const [ azimuthTo, altitudeTo ] = calcAzimuthAltitude(lookAtDir);
+    const [azimuthFrom, altitudeFrom] = calcAzimuthAltitude(this.faceFront);
+    const [azimuthTo, altitudeTo] = calcAzimuthAltitude(lookAtDir);
     const yaw = sanitizeAngle(azimuthTo - azimuthFrom);
     const pitch = sanitizeAngle(altitudeFrom - altitudeTo); // spinning (1, 0, 0) CCW around Z axis makes the vector look up, while spinning (0, 0, 1) CCW around X axis makes the vector look down
 

--- a/packages/three-vrm-core/src/lookAt/VRMLookAt.ts
+++ b/packages/three-vrm-core/src/lookAt/VRMLookAt.ts
@@ -224,7 +224,11 @@ export class VRMLookAt {
     this.getLookAtWorldQuaternion(_quatB);
     this.getFaceFrontQuaternion(_quatC);
 
-    return target.copy(VEC3_POSITIVE_Z).applyQuaternion(_quatB).applyQuaternion(_quatC).applyEuler(this.getEuler(_eulerA));
+    return target
+      .copy(VEC3_POSITIVE_Z)
+      .applyQuaternion(_quatB)
+      .applyQuaternion(_quatC)
+      .applyEuler(this.getEuler(_eulerA));
   }
 
   /**

--- a/packages/three-vrm-core/src/lookAt/VRMLookAt.ts
+++ b/packages/three-vrm-core/src/lookAt/VRMLookAt.ts
@@ -266,7 +266,7 @@ export class VRMLookAt {
     if (this._needsUpdate) {
       this._needsUpdate = false;
 
-      this.applier.apply(this._yaw, this._pitch);
+      this.applier.applyYawPitch(this._yaw, this._pitch);
     }
   }
 }

--- a/packages/three-vrm-core/src/lookAt/VRMLookAt.ts
+++ b/packages/three-vrm-core/src/lookAt/VRMLookAt.ts
@@ -219,7 +219,7 @@ export class VRMLookAt {
     if (this._needsUpdate) {
       this._needsUpdate = false;
 
-      this.applier.lookAt(this._yaw, this._pitch);
+      this.applier.apply(this._yaw, this._pitch);
     }
   }
 

--- a/packages/three-vrm-core/src/lookAt/VRMLookAt.ts
+++ b/packages/three-vrm-core/src/lookAt/VRMLookAt.ts
@@ -224,7 +224,7 @@ export class VRMLookAt {
     this.getLookAtWorldQuaternion(_quatB);
     this.getFaceFrontQuaternion(_quatC);
 
-    return target.copy(VEC3_POSITIVE_Z).applyQuaternion(_quatB).applyQuaternion(_quatC).applyEuler(this.euler);
+    return target.copy(VEC3_POSITIVE_Z).applyQuaternion(_quatB).applyQuaternion(_quatC).applyEuler(this.getEuler(_eulerA));
   }
 
   /**

--- a/packages/three-vrm-core/src/lookAt/VRMLookAt.ts
+++ b/packages/three-vrm-core/src/lookAt/VRMLookAt.ts
@@ -106,16 +106,12 @@ export class VRMLookAt {
    protected _needsUpdate: boolean;
 
   /**
-   * Its current yaw-pitch angle in euler.
-   * Does NOT consider {@link faceFront}.
+   * @deprecated Use {@link getEuler} instead.
    */
   public get euler(): THREE.Euler {
-    return new THREE.Euler(
-      THREE.MathUtils.DEG2RAD * this._pitch,
-      THREE.MathUtils.DEG2RAD * this._yaw,
-      0.0,
-      'YXZ',
-    );
+    console.warn('VRMLookAt: euler is deprecated. use getEuler() instead.');
+
+    return this.getEuler(new THREE.Euler());
   }
 
   /**
@@ -131,6 +127,21 @@ export class VRMLookAt {
     this._yaw = 0.0;
     this._pitch = 0.0;
     this._needsUpdate = true;
+  }
+
+  /**
+   * Get its yaw-pitch angles as an `Euler`.
+   * Does NOT consider {@link faceFront}.
+   *
+   * @param target The target euler
+   */
+  public getEuler(target: THREE.Euler): THREE.Euler {
+    return target.set(
+      THREE.MathUtils.DEG2RAD * this._pitch,
+      THREE.MathUtils.DEG2RAD * this._yaw,
+      0.0,
+      'YXZ',
+    );
   }
 
   /**

--- a/packages/three-vrm-core/src/lookAt/VRMLookAt.ts
+++ b/packages/three-vrm-core/src/lookAt/VRMLookAt.ts
@@ -268,7 +268,7 @@ export class VRMLookAt {
    * @param delta deltaTime, it isn't used though. You can use the parameter if you want to use this in your own extended {@link VRMLookAt}.
    */
   public update(delta: number): void {
-    if (this.target && this.autoUpdate) {
+    if (this.target != null && this.autoUpdate) {
       this.lookAt(this.target.getWorldPosition(_v3A));
     }
 

--- a/packages/three-vrm-core/src/lookAt/VRMLookAtApplier.ts
+++ b/packages/three-vrm-core/src/lookAt/VRMLookAtApplier.ts
@@ -11,10 +11,10 @@ export interface VRMLookAtApplier {
    * @param yaw Rotation around Y axis, in degree
    * @param pitch Rotation around X axis, in degree
    */
-  apply: (yaw: number, pitch: number) => void;
+  applyYawPitch: (yaw: number, pitch: number) => void;
 
   /**
-   * @deprecated Use {@link apply} instead.
+   * @deprecated Use {@link applyYawPitch} instead.
    */
   lookAt: (euler: THREE.Euler) => void;
 }

--- a/packages/three-vrm-core/src/lookAt/VRMLookAtApplier.ts
+++ b/packages/three-vrm-core/src/lookAt/VRMLookAtApplier.ts
@@ -1,3 +1,5 @@
+import * as THREE from 'three';
+
 /**
  * This class is used by {@link VRMLookAt}, applies look at direction.
  * There are currently two variant of applier: {@link VRMLookAtBoneApplier} and {@link VRMLookAtExpressionApplier}.
@@ -9,5 +11,10 @@ export interface VRMLookAtApplier {
    * @param yaw Rotation around Y axis, in degree
    * @param pitch Rotation around X axis, in degree
    */
-  lookAt: (yaw: number, pitch: number) => void;
+  apply: (yaw: number, pitch: number) => void;
+
+  /**
+   * @deprecated Use {@link apply} instead.
+   */
+  lookAt: (euler: THREE.Euler) => void;
 }

--- a/packages/three-vrm-core/src/lookAt/VRMLookAtApplier.ts
+++ b/packages/three-vrm-core/src/lookAt/VRMLookAtApplier.ts
@@ -1,12 +1,13 @@
 /**
- * This class is used by {@link VRMLookAtHead}, applies look at direction.
+ * This class is used by {@link VRMLookAt}, applies look at direction.
  * There are currently two variant of applier: {@link VRMLookAtBoneApplier} and {@link VRMLookAtExpressionApplier}.
  */
 export interface VRMLookAtApplier {
   /**
    * Apply look at direction to its associated VRM model.
    *
-   * @param euler `THREE.Euler` object that represents the look at direction
+   * @param yaw Rotation around Y axis, in degree
+   * @param pitch Rotation around X axis, in degree
    */
-  lookAt: (euler: THREE.Euler) => void;
+  lookAt: (yaw: number, pitch: number) => void;
 }

--- a/packages/three-vrm-core/src/lookAt/VRMLookAtBoneApplier.ts
+++ b/packages/three-vrm-core/src/lookAt/VRMLookAtBoneApplier.ts
@@ -109,7 +109,7 @@ export class VRMLookAtBoneApplier implements VRMLookAtApplier {
    * @param yaw Rotation around Y axis, in degree
    * @param pitch Rotation around X axis, in degree
    */
-  public apply(yaw: number, pitch: number): void {
+  public applyYawPitch(yaw: number, pitch: number): void {
     const leftEye = this.humanoid.getBoneNode('leftEye');
     const rightEye = this.humanoid.getBoneNode('rightEye');
 
@@ -159,7 +159,7 @@ export class VRMLookAtBoneApplier implements VRMLookAtApplier {
   }
 
   /**
-   * @deprecated Use {@link apply} instead.
+   * @deprecated Use {@link applyYawPitch} instead.
    */
   public lookAt(euler: THREE.Euler): void {
     console.warn('VRMLookAtBoneApplier: lookAt() is deprecated. use apply() instead.');
@@ -167,7 +167,7 @@ export class VRMLookAtBoneApplier implements VRMLookAtApplier {
     const yaw = THREE.MathUtils.RAD2DEG * euler.y;
     const pitch = THREE.MathUtils.RAD2DEG * euler.x;
 
-    this.apply(yaw, pitch);
+    this.applyYawPitch(yaw, pitch);
   }
 
   /**

--- a/packages/three-vrm-core/src/lookAt/VRMLookAtBoneApplier.ts
+++ b/packages/three-vrm-core/src/lookAt/VRMLookAtBoneApplier.ts
@@ -130,11 +130,7 @@ export class VRMLookAtBoneApplier implements VRMLookAtApplier {
       _quatA.setFromEuler(_eulerA);
       this._getFaceFrontQuaternion(_quatB);
 
-      leftEye.quaternion
-        .copy(_quatB)
-        .premultiply(_quatA)
-        .premultiply(_quatB.invert())
-        .multiply(this._restQuatLeftEye);
+      leftEye.quaternion.copy(_quatB).premultiply(_quatA).premultiply(_quatB.invert()).multiply(this._restQuatLeftEye);
     }
 
     // right
@@ -184,7 +180,7 @@ export class VRMLookAtBoneApplier implements VRMLookAtApplier {
       return target.identity();
     }
 
-    const [ faceFrontAzimuth, faceFrontAltitude ] = calcAzimuthAltitude(this.faceFront);
+    const [faceFrontAzimuth, faceFrontAltitude] = calcAzimuthAltitude(this.faceFront);
     _eulerA.set(0.0, 0.5 * Math.PI + faceFrontAzimuth, faceFrontAltitude, 'YZX');
     return target.setFromEuler(_eulerA);
   }

--- a/packages/three-vrm-core/src/lookAt/VRMLookAtBoneApplier.ts
+++ b/packages/three-vrm-core/src/lookAt/VRMLookAtBoneApplier.ts
@@ -130,6 +130,7 @@ export class VRMLookAtBoneApplier implements VRMLookAtApplier {
       _quatA.setFromEuler(_eulerA);
       this._getFaceFrontQuaternion(_quatB);
 
+      // quatB^-1 * quatA * quatB * restQuatLeftEye
       leftEye.quaternion.copy(_quatB).premultiply(_quatA).premultiply(_quatB.invert()).multiply(this._restQuatLeftEye);
     }
 
@@ -150,6 +151,7 @@ export class VRMLookAtBoneApplier implements VRMLookAtApplier {
       _quatA.setFromEuler(_eulerA);
       this._getFaceFrontQuaternion(_quatB);
 
+      // quatB^-1 * quatA * quatB * restQuatRightEye
       rightEye.quaternion
         .copy(_quatB)
         .premultiply(_quatA)

--- a/packages/three-vrm-core/src/lookAt/VRMLookAtBoneApplier.ts
+++ b/packages/three-vrm-core/src/lookAt/VRMLookAtBoneApplier.ts
@@ -166,6 +166,8 @@ export class VRMLookAtBoneApplier implements VRMLookAtApplier {
    * @deprecated Use {@link apply} instead.
    */
   public lookAt(euler: THREE.Euler): void {
+    console.warn('VRMLookAtBoneApplier: lookAt() is deprecated. use apply() instead.');
+
     const yaw = THREE.MathUtils.RAD2DEG * euler.y;
     const pitch = THREE.MathUtils.RAD2DEG * euler.x;
 

--- a/packages/three-vrm-core/src/lookAt/VRMLookAtBoneApplier.ts
+++ b/packages/three-vrm-core/src/lookAt/VRMLookAtBoneApplier.ts
@@ -70,8 +70,8 @@ export class VRMLookAtBoneApplier implements VRMLookAtApplier {
    * @param angle An input angle
    */
   public lookAt(angle: THREE.Euler): void {
-    const srcX = (angle.x * 180.0) / Math.PI;
-    const srcY = (angle.y * 180.0) / Math.PI;
+    const srcX = THREE.MathUtils.RAD2DEG * angle.x;
+    const srcY = THREE.MathUtils.RAD2DEG * angle.y;
 
     const leftEye = this.humanoid.getBoneNode('leftEye');
     const rightEye = this.humanoid.getBoneNode('rightEye');
@@ -79,15 +79,15 @@ export class VRMLookAtBoneApplier implements VRMLookAtApplier {
     // left
     if (leftEye) {
       if (srcX < 0.0) {
-        _eulerA.x = (-this.rangeMapVerticalDown.map(-srcX) / 180.0) * Math.PI;
+        _eulerA.x = -THREE.MathUtils.DEG2RAD * this.rangeMapVerticalDown.map(-srcX);
       } else {
-        _eulerA.x = (this.rangeMapVerticalUp.map(srcX) / 180.0) * Math.PI;
+        _eulerA.x = THREE.MathUtils.DEG2RAD * this.rangeMapVerticalUp.map(srcX);
       }
 
       if (srcY < 0.0) {
-        _eulerA.y = (-this.rangeMapHorizontalInner.map(-srcY) / 180.0) * Math.PI;
+        _eulerA.y = -THREE.MathUtils.DEG2RAD * this.rangeMapHorizontalInner.map(-srcY);
       } else {
-        _eulerA.y = (this.rangeMapHorizontalOuter.map(srcY) / 180.0) * Math.PI;
+        _eulerA.y = THREE.MathUtils.DEG2RAD * this.rangeMapHorizontalOuter.map(srcY);
       }
 
       leftEye.quaternion.setFromEuler(_eulerA);
@@ -96,15 +96,15 @@ export class VRMLookAtBoneApplier implements VRMLookAtApplier {
     // right
     if (rightEye) {
       if (srcX < 0.0) {
-        _eulerA.x = (-this.rangeMapVerticalDown.map(-srcX) / 180.0) * Math.PI;
+        _eulerA.x = -THREE.MathUtils.DEG2RAD * this.rangeMapVerticalDown.map(-srcX);
       } else {
-        _eulerA.x = (this.rangeMapVerticalUp.map(srcX) / 180.0) * Math.PI;
+        _eulerA.x = THREE.MathUtils.DEG2RAD * this.rangeMapVerticalUp.map(srcX);
       }
 
       if (srcY < 0.0) {
-        _eulerA.y = (-this.rangeMapHorizontalOuter.map(-srcY) / 180.0) * Math.PI;
+        _eulerA.y = -THREE.MathUtils.DEG2RAD * this.rangeMapHorizontalOuter.map(-srcY);
       } else {
-        _eulerA.y = (this.rangeMapHorizontalInner.map(srcY) / 180.0) * Math.PI;
+        _eulerA.y = THREE.MathUtils.DEG2RAD * this.rangeMapHorizontalInner.map(srcY);
       }
 
       rightEye.quaternion.setFromEuler(_eulerA);

--- a/packages/three-vrm-core/src/lookAt/VRMLookAtBoneApplier.ts
+++ b/packages/three-vrm-core/src/lookAt/VRMLookAtBoneApplier.ts
@@ -67,27 +67,25 @@ export class VRMLookAtBoneApplier implements VRMLookAtApplier {
   /**
    * Apply the input angle to its associated VRM model.
    *
-   * @param angle An input angle
+   * @param yaw Rotation around Y axis, in degree
+   * @param pitch Rotation around X axis, in degree
    */
-  public lookAt(angle: THREE.Euler): void {
-    const srcX = THREE.MathUtils.RAD2DEG * angle.x;
-    const srcY = THREE.MathUtils.RAD2DEG * angle.y;
-
+  public lookAt(yaw: number, pitch: number): void {
     const leftEye = this.humanoid.getBoneNode('leftEye');
     const rightEye = this.humanoid.getBoneNode('rightEye');
 
     // left
     if (leftEye) {
-      if (srcX < 0.0) {
-        _eulerA.x = -THREE.MathUtils.DEG2RAD * this.rangeMapVerticalDown.map(-srcX);
+      if (pitch < 0.0) {
+        _eulerA.x = -THREE.MathUtils.DEG2RAD * this.rangeMapVerticalDown.map(-pitch);
       } else {
-        _eulerA.x = THREE.MathUtils.DEG2RAD * this.rangeMapVerticalUp.map(srcX);
+        _eulerA.x = THREE.MathUtils.DEG2RAD * this.rangeMapVerticalUp.map(pitch);
       }
 
-      if (srcY < 0.0) {
-        _eulerA.y = -THREE.MathUtils.DEG2RAD * this.rangeMapHorizontalInner.map(-srcY);
+      if (yaw < 0.0) {
+        _eulerA.y = -THREE.MathUtils.DEG2RAD * this.rangeMapHorizontalInner.map(-yaw);
       } else {
-        _eulerA.y = THREE.MathUtils.DEG2RAD * this.rangeMapHorizontalOuter.map(srcY);
+        _eulerA.y = THREE.MathUtils.DEG2RAD * this.rangeMapHorizontalOuter.map(yaw);
       }
 
       leftEye.quaternion.setFromEuler(_eulerA);
@@ -95,16 +93,16 @@ export class VRMLookAtBoneApplier implements VRMLookAtApplier {
 
     // right
     if (rightEye) {
-      if (srcX < 0.0) {
-        _eulerA.x = -THREE.MathUtils.DEG2RAD * this.rangeMapVerticalDown.map(-srcX);
+      if (pitch < 0.0) {
+        _eulerA.x = -THREE.MathUtils.DEG2RAD * this.rangeMapVerticalDown.map(-pitch);
       } else {
-        _eulerA.x = THREE.MathUtils.DEG2RAD * this.rangeMapVerticalUp.map(srcX);
+        _eulerA.x = THREE.MathUtils.DEG2RAD * this.rangeMapVerticalUp.map(pitch);
       }
 
-      if (srcY < 0.0) {
-        _eulerA.y = -THREE.MathUtils.DEG2RAD * this.rangeMapHorizontalOuter.map(-srcY);
+      if (yaw < 0.0) {
+        _eulerA.y = -THREE.MathUtils.DEG2RAD * this.rangeMapHorizontalOuter.map(-yaw);
       } else {
-        _eulerA.y = THREE.MathUtils.DEG2RAD * this.rangeMapHorizontalInner.map(srcY);
+        _eulerA.y = THREE.MathUtils.DEG2RAD * this.rangeMapHorizontalInner.map(yaw);
       }
 
       rightEye.quaternion.setFromEuler(_eulerA);

--- a/packages/three-vrm-core/src/lookAt/VRMLookAtBoneApplier.ts
+++ b/packages/three-vrm-core/src/lookAt/VRMLookAtBoneApplier.ts
@@ -70,7 +70,7 @@ export class VRMLookAtBoneApplier implements VRMLookAtApplier {
    * @param yaw Rotation around Y axis, in degree
    * @param pitch Rotation around X axis, in degree
    */
-  public lookAt(yaw: number, pitch: number): void {
+  public apply(yaw: number, pitch: number): void {
     const leftEye = this.humanoid.getBoneNode('leftEye');
     const rightEye = this.humanoid.getBoneNode('rightEye');
 
@@ -107,5 +107,15 @@ export class VRMLookAtBoneApplier implements VRMLookAtApplier {
 
       rightEye.quaternion.setFromEuler(_eulerA);
     }
+  }
+
+  /**
+   * @deprecated Use {@link apply} instead.
+   */
+  public lookAt(euler: THREE.Euler): void {
+    const yaw = THREE.MathUtils.RAD2DEG * euler.y;
+    const pitch = THREE.MathUtils.RAD2DEG * euler.x;
+
+    this.apply(yaw, pitch);
   }
 }

--- a/packages/three-vrm-core/src/lookAt/VRMLookAtExpressionApplier.ts
+++ b/packages/three-vrm-core/src/lookAt/VRMLookAtExpressionApplier.ts
@@ -1,5 +1,4 @@
 import { VRMExpressionManager } from '../expressions';
-import * as THREE from 'three';
 import type { VRMLookAtApplier } from './VRMLookAtApplier';
 import { VRMLookAtRangeMap } from './VRMLookAtRangeMap';
 
@@ -66,26 +65,24 @@ export class VRMLookAtExpressionApplier implements VRMLookAtApplier {
   /**
    * Apply the input angle to its associated VRM model.
    *
-   * @param angle An input angle
+   * @param yaw Rotation around Y axis, in degree
+   * @param pitch Rotation around X axis, in degree
    */
-  public lookAt(angle: THREE.Euler): void {
-    const srcX = (angle.x * 180.0) / Math.PI;
-    const srcY = (angle.y * 180.0) / Math.PI;
-
-    if (srcX < 0.0) {
+  public lookAt(yaw: number, pitch: number): void {
+    if (pitch < 0.0) {
       this.expressions.setValue('lookDown', 0.0);
-      this.expressions.setValue('lookUp', this.rangeMapVerticalUp.map(-srcX));
+      this.expressions.setValue('lookUp', this.rangeMapVerticalUp.map(-pitch));
     } else {
       this.expressions.setValue('lookUp', 0.0);
-      this.expressions.setValue('lookDown', this.rangeMapVerticalDown.map(srcX));
+      this.expressions.setValue('lookDown', this.rangeMapVerticalDown.map(pitch));
     }
 
-    if (srcY < 0.0) {
+    if (yaw < 0.0) {
       this.expressions.setValue('lookLeft', 0.0);
-      this.expressions.setValue('lookRight', this.rangeMapHorizontalOuter.map(-srcY));
+      this.expressions.setValue('lookRight', this.rangeMapHorizontalOuter.map(-yaw));
     } else {
       this.expressions.setValue('lookRight', 0.0);
-      this.expressions.setValue('lookLeft', this.rangeMapHorizontalOuter.map(srcY));
+      this.expressions.setValue('lookLeft', this.rangeMapHorizontalOuter.map(yaw));
     }
   }
 }

--- a/packages/three-vrm-core/src/lookAt/VRMLookAtExpressionApplier.ts
+++ b/packages/three-vrm-core/src/lookAt/VRMLookAtExpressionApplier.ts
@@ -1,4 +1,5 @@
 import { VRMExpressionManager } from '../expressions';
+import * as THREE from 'three';
 import type { VRMLookAtApplier } from './VRMLookAtApplier';
 import { VRMLookAtRangeMap } from './VRMLookAtRangeMap';
 
@@ -68,7 +69,7 @@ export class VRMLookAtExpressionApplier implements VRMLookAtApplier {
    * @param yaw Rotation around Y axis, in degree
    * @param pitch Rotation around X axis, in degree
    */
-  public lookAt(yaw: number, pitch: number): void {
+  public apply(yaw: number, pitch: number): void {
     if (pitch < 0.0) {
       this.expressions.setValue('lookDown', 0.0);
       this.expressions.setValue('lookUp', this.rangeMapVerticalUp.map(-pitch));
@@ -84,5 +85,15 @@ export class VRMLookAtExpressionApplier implements VRMLookAtApplier {
       this.expressions.setValue('lookRight', 0.0);
       this.expressions.setValue('lookLeft', this.rangeMapHorizontalOuter.map(yaw));
     }
+  }
+
+  /**
+   * @deprecated Use {@link apply} instead.
+   */
+  public lookAt(euler: THREE.Euler): void {
+    const yaw = THREE.MathUtils.RAD2DEG * euler.y;
+    const pitch = THREE.MathUtils.RAD2DEG * euler.x;
+
+    this.apply(yaw, pitch);
   }
 }

--- a/packages/three-vrm-core/src/lookAt/VRMLookAtExpressionApplier.ts
+++ b/packages/three-vrm-core/src/lookAt/VRMLookAtExpressionApplier.ts
@@ -69,7 +69,7 @@ export class VRMLookAtExpressionApplier implements VRMLookAtApplier {
    * @param yaw Rotation around Y axis, in degree
    * @param pitch Rotation around X axis, in degree
    */
-  public apply(yaw: number, pitch: number): void {
+  public applyYawPitch(yaw: number, pitch: number): void {
     if (pitch < 0.0) {
       this.expressions.setValue('lookDown', 0.0);
       this.expressions.setValue('lookUp', this.rangeMapVerticalUp.map(-pitch));
@@ -88,7 +88,7 @@ export class VRMLookAtExpressionApplier implements VRMLookAtApplier {
   }
 
   /**
-   * @deprecated Use {@link apply} instead.
+   * @deprecated Use {@link applyYawPitch} instead.
    */
   public lookAt(euler: THREE.Euler): void {
     console.warn('VRMLookAtBoneApplier: lookAt() is deprecated. use apply() instead.');
@@ -96,6 +96,6 @@ export class VRMLookAtExpressionApplier implements VRMLookAtApplier {
     const yaw = THREE.MathUtils.RAD2DEG * euler.y;
     const pitch = THREE.MathUtils.RAD2DEG * euler.x;
 
-    this.apply(yaw, pitch);
+    this.applyYawPitch(yaw, pitch);
   }
 }

--- a/packages/three-vrm-core/src/lookAt/VRMLookAtExpressionApplier.ts
+++ b/packages/three-vrm-core/src/lookAt/VRMLookAtExpressionApplier.ts
@@ -91,6 +91,8 @@ export class VRMLookAtExpressionApplier implements VRMLookAtApplier {
    * @deprecated Use {@link apply} instead.
    */
   public lookAt(euler: THREE.Euler): void {
+    console.warn('VRMLookAtBoneApplier: lookAt() is deprecated. use apply() instead.');
+
     const yaw = THREE.MathUtils.RAD2DEG * euler.y;
     const pitch = THREE.MathUtils.RAD2DEG * euler.x;
 

--- a/packages/three-vrm-core/src/lookAt/VRMLookAtLoaderPlugin.ts
+++ b/packages/three-vrm-core/src/lookAt/VRMLookAtLoaderPlugin.ts
@@ -199,6 +199,10 @@ export class VRMLookAtLoaderPlugin implements GLTFLoaderPlugin {
     // VRM 0.0 are facing Z- instead of Z+
     lookAt.faceFront.set(0.0, 0.0, -1.0);
 
+    if (applier instanceof VRMLookAtBoneApplier) {
+      applier.faceFront?.set(0.0, 0.0, -1.0);
+    }
+
     return lookAt;
   }
 

--- a/packages/three-vrm-core/src/lookAt/VRMLookAtLoaderPlugin.ts
+++ b/packages/three-vrm-core/src/lookAt/VRMLookAtLoaderPlugin.ts
@@ -200,7 +200,7 @@ export class VRMLookAtLoaderPlugin implements GLTFLoaderPlugin {
     lookAt.faceFront.set(0.0, 0.0, -1.0);
 
     if (applier instanceof VRMLookAtBoneApplier) {
-      applier.faceFront?.set(0.0, 0.0, -1.0);
+      applier.faceFront.set(0.0, 0.0, -1.0);
     }
 
     return lookAt;

--- a/packages/three-vrm-core/src/lookAt/helpers/VRMLookAtHelper.ts
+++ b/packages/three-vrm-core/src/lookAt/helpers/VRMLookAtHelper.ts
@@ -89,8 +89,8 @@ export class VRMLookAtHelper extends THREE.Group {
     this.vrmLookAt.getLookAtWorldPosition(_v3A);
     this.vrmLookAt.getLookAtWorldQuaternion(_quatA);
 
-    const yaw = this.vrmLookAt.euler.y;
-    const pitch = this.vrmLookAt.euler.x;
+    const yaw = THREE.MathUtils.DEG2RAD * this.vrmLookAt.yaw;
+    const pitch = THREE.MathUtils.DEG2RAD * this.vrmLookAt.pitch;
 
     this._meshYaw.geometry.theta = yaw;
     this._meshYaw.geometry.update();

--- a/packages/three-vrm-core/src/lookAt/helpers/VRMLookAtHelper.ts
+++ b/packages/three-vrm-core/src/lookAt/helpers/VRMLookAtHelper.ts
@@ -86,24 +86,32 @@ export class VRMLookAtHelper extends THREE.Group {
   }
 
   public updateMatrixWorld(force: boolean): void {
+    // update geometries
+    const yaw = THREE.MathUtils.DEG2RAD * this.vrmLookAt.yaw;
+    this._meshYaw.geometry.theta = yaw;
+    this._meshYaw.geometry.update();
+
+    const pitch = THREE.MathUtils.DEG2RAD * this.vrmLookAt.pitch;
+    this._meshPitch.geometry.theta = pitch;
+    this._meshPitch.geometry.update();
+
+    // get world position and quaternion
     this.vrmLookAt.getLookAtWorldPosition(_v3A);
     this.vrmLookAt.getLookAtWorldQuaternion(_quatA);
 
-    const yaw = THREE.MathUtils.DEG2RAD * this.vrmLookAt.yaw;
-    const pitch = THREE.MathUtils.DEG2RAD * this.vrmLookAt.pitch;
+    // calculate rotation using faceFront
+    _quatA.multiply(this.vrmLookAt.getFaceFrontQuaternion(_quatB));
 
-    this._meshYaw.geometry.theta = yaw;
-    this._meshYaw.geometry.update();
+    // set transform to meshes
     this._meshYaw.position.copy(_v3A);
     this._meshYaw.quaternion.copy(_quatA);
 
-    this._meshPitch.geometry.theta = pitch;
-    this._meshPitch.geometry.update();
     this._meshPitch.position.copy(_v3A);
     this._meshPitch.quaternion.copy(_quatA);
     this._meshPitch.quaternion.multiply(_quatB.setFromAxisAngle(VEC3_POSITIVE_Y, yaw));
     this._meshPitch.quaternion.multiply(QUAT_XY_CW90);
 
+    // update target line and sphere
     const target = this.vrmLookAt.target;
     if (target != null) {
       target.getWorldPosition(_v3B).sub(_v3A);
@@ -112,6 +120,7 @@ export class VRMLookAtHelper extends THREE.Group {
       this._lineTarget.position.copy(_v3A);
     }
 
+    // apply transform to meshes
     super.updateMatrixWorld(force);
   }
 }

--- a/packages/three-vrm-core/src/lookAt/helpers/VRMLookAtHelper.ts
+++ b/packages/three-vrm-core/src/lookAt/helpers/VRMLookAtHelper.ts
@@ -112,8 +112,8 @@ export class VRMLookAtHelper extends THREE.Group {
     this._meshPitch.quaternion.multiply(QUAT_XY_CW90);
 
     // update target line and sphere
-    const target = this.vrmLookAt.target;
-    if (target != null) {
+    const { target, autoUpdate } = this.vrmLookAt;
+    if (target != null && autoUpdate) {
       target.getWorldPosition(_v3B).sub(_v3A);
       this._lineTarget.geometry.tail.copy(_v3B);
       this._lineTarget.geometry.update();

--- a/packages/three-vrm-core/src/lookAt/utils/calcAzimuthAltitude.ts
+++ b/packages/three-vrm-core/src/lookAt/utils/calcAzimuthAltitude.ts
@@ -11,9 +11,6 @@ import * as THREE from 'three';
  * @param vector The vector
  * @returns A tuple contains two angles, `[ azimuth, altitude ]`
  */
-export function calcAzimuthAltitude(vector: THREE.Vector3): [ azimuth: number, altitude: number ] {
-  return [
-    Math.atan2(-vector.z, vector.x),
-    Math.atan2(vector.y, Math.sqrt(vector.x * vector.x + vector.z * vector.z)),
-  ];
+export function calcAzimuthAltitude(vector: THREE.Vector3): [azimuth: number, altitude: number] {
+  return [Math.atan2(-vector.z, vector.x), Math.atan2(vector.y, Math.sqrt(vector.x * vector.x + vector.z * vector.z))];
 }

--- a/packages/three-vrm-core/src/lookAt/utils/calcAzimuthAltitude.ts
+++ b/packages/three-vrm-core/src/lookAt/utils/calcAzimuthAltitude.ts
@@ -1,0 +1,19 @@
+import * as THREE from 'three';
+
+/**
+ * Calculate azimuth / altitude angles from a vector.
+ *
+ * This returns a difference of angles from (1, 0, 0).
+ * Azimuth represents an angle around Y axis.
+ * Altitude represents an angle around Z axis.
+ * It is rotated in intrinsic Y-Z order.
+ *
+ * @param vector The vector
+ * @returns A tuple contains two angles, `[ azimuth, altitude ]`
+ */
+export function calcAzimuthAltitude(vector: THREE.Vector3): [ azimuth: number, altitude: number ] {
+  return [
+    Math.atan2(-vector.z, vector.x),
+    Math.atan2(vector.y, Math.sqrt(vector.x * vector.x + vector.z * vector.z)),
+  ];
+}

--- a/packages/three-vrm-core/src/lookAt/utils/sanitizeAngle.ts
+++ b/packages/three-vrm-core/src/lookAt/utils/sanitizeAngle.ts
@@ -1,0 +1,14 @@
+/**
+ * Make sure the angle is within -PI to PI.
+ *
+ * @example
+ * ```js
+ * sanitizeAngle(1.5 * Math.PI) // -0.5 * PI
+ * ```
+ *
+ * @param angle An input angle
+ */
+export function sanitizeAngle(angle: number): number {
+  const roundTurn = Math.round( angle / 2.0 / Math.PI );
+  return angle - 2.0 * Math.PI * roundTurn;
+}

--- a/packages/three-vrm-core/src/lookAt/utils/sanitizeAngle.ts
+++ b/packages/three-vrm-core/src/lookAt/utils/sanitizeAngle.ts
@@ -9,6 +9,6 @@
  * @param angle An input angle
  */
 export function sanitizeAngle(angle: number): number {
-  const roundTurn = Math.round( angle / 2.0 / Math.PI );
+  const roundTurn = Math.round(angle / 2.0 / Math.PI);
   return angle - 2.0 * Math.PI * roundTurn;
 }

--- a/packages/three-vrm-core/src/lookAt/utils/tests/calcAzimuthAltitude.test.ts
+++ b/packages/three-vrm-core/src/lookAt/utils/tests/calcAzimuthAltitude.test.ts
@@ -21,7 +21,7 @@ describe('calcAzimuthAltitude', () => {
   });
 
   it('processes a vector means azimuth = PI / 3, altitude = PI / 3', () => {
-    const [azimuth, altitude] = calcAzimuthAltitude(new THREE.Vector3(0.250, 0.866, -0.433));
+    const [azimuth, altitude] = calcAzimuthAltitude(new THREE.Vector3(0.25, 0.866, -0.433));
     expect(azimuth).toBeCloseTo(Math.PI / 3.0);
     expect(altitude).toBeCloseTo(Math.PI / 3.0);
   });

--- a/packages/three-vrm-core/src/lookAt/utils/tests/calcAzimuthAltitude.test.ts
+++ b/packages/three-vrm-core/src/lookAt/utils/tests/calcAzimuthAltitude.test.ts
@@ -1,0 +1,28 @@
+import * as THREE from 'three';
+import { calcAzimuthAltitude } from '../calcAzimuthAltitude';
+
+describe('calcAzimuthAltitude', () => {
+  it('processes a vector means azimuth = 0, altitude = 0', () => {
+    const [azimuth, altitude] = calcAzimuthAltitude(new THREE.Vector3(1.0, 0.0, 0.0));
+    expect(azimuth).toBeCloseTo(0.0);
+    expect(altitude).toBeCloseTo(0.0);
+  });
+
+  it('processes a vector means azimuth = PI / 4, altitude = 0', () => {
+    const [azimuth, altitude] = calcAzimuthAltitude(new THREE.Vector3(0.707, 0.0, -0.707));
+    expect(azimuth).toBeCloseTo(0.25 * Math.PI);
+    expect(altitude).toBeCloseTo(0.0);
+  });
+
+  it('processes a vector means azimuth = 0, altitude = PI / 4', () => {
+    const [azimuth, altitude] = calcAzimuthAltitude(new THREE.Vector3(0.707, 0.707, 0.0));
+    expect(azimuth).toBeCloseTo(0.0);
+    expect(altitude).toBeCloseTo(0.25 * Math.PI);
+  });
+
+  it('processes a vector means azimuth = PI / 3, altitude = PI / 3', () => {
+    const [azimuth, altitude] = calcAzimuthAltitude(new THREE.Vector3(0.250, 0.866, -0.433));
+    expect(azimuth).toBeCloseTo(Math.PI / 3.0);
+    expect(altitude).toBeCloseTo(Math.PI / 3.0);
+  });
+});

--- a/packages/three-vrm-core/src/lookAt/utils/tests/sanitizeAngle.test.ts
+++ b/packages/three-vrm-core/src/lookAt/utils/tests/sanitizeAngle.test.ts
@@ -1,0 +1,18 @@
+import { sanitizeAngle } from '../sanitizeAngle';
+
+describe('sanitizeAngle', () => {
+  it('does not do anything to an angle within -PI and PI (3 / 4 * PI)', () => {
+    const result = sanitizeAngle(0.75 * Math.PI);
+    expect(result).toBeCloseTo(0.75 * Math.PI);
+  });
+
+  it('converts 1.5 * PI within -PI and PI', () => {
+    const result = sanitizeAngle(1.5 * Math.PI);
+    expect(result).toBeCloseTo(-0.5 * Math.PI);
+  });
+
+  it('converts -3.25 * PI within -PI and PI', () => {
+    const result = sanitizeAngle(-3.25 * Math.PI);
+    expect(result).toBeCloseTo(0.75 * Math.PI);
+  });
+});

--- a/packages/three-vrm/examples/lookat-advanced.html
+++ b/packages/three-vrm/examples/lookat-advanced.html
@@ -35,12 +35,16 @@
 
 					super( humanoid, applier );
 
+					// a factor used for animation
 					this.smoothFactor = 10.0;
 
-					this.horizontalLimit = Math.PI / 4.0;
-					this.verticalLimit = Math.PI / 4.0;
+					// maximum angles the lookAt tracks
+					this.yawLimit = 45.0;
+					this.pitchLimit = 45.0;
 
-					this._eulerTo = new THREE.Euler( 0.0, 0.0, 0.0, THREE_VRM.VRMLookAt.EULER_ORDER );
+					// Actual angles applied, animated
+					this._yawDamped = 0.0;
+					this._pitchDamped = 0.0;
 
 				}
 
@@ -48,26 +52,42 @@
 
 					if ( this.target && this.autoUpdate ) {
 
-						this._calcEuler( this._eulerTo, this.target.getWorldPosition( _v3A ) );
+						// this updates `_yaw` and `_pitch`
+						this.lookAt( this.target.getWorldPosition( _v3A ) );
 
+						// limit angles
 						if (
 
-							this.horizontalLimit < Math.abs( this._eulerTo.y ) ||
-							this.verticalLimit < Math.abs( this._eulerTo.x )
+							this.yawLimit < Math.abs( this._yaw ) ||
+							this.pitchLimit < Math.abs( this._pitch )
 
 						) {
 
-							this._eulerTo.set( 0.0, 0.0, 0.0 );
+							this._yaw = 0.0;
+							this._pitch = 0.0;
 
 						}
 
-
+						// animate angles
 						const k = 1.0 - Math.exp( - this.smoothFactor * delta );
 
-						this._euler.x += ( this._eulerTo.x - this._euler.x ) * k;
-						this._euler.y += ( this._eulerTo.y - this._euler.y ) * k;
+						this._yawDamped += ( this._yaw - this._yawDamped ) * k;
+						this._pitchDamped += ( this._pitch - this._pitchDamped ) * k;
 
-						this.applier.lookAt( this._euler );
+						// apply the animated angles
+						this.applier.apply( this._yawDamped, this._pitchDamped );
+
+						// there is no need to update twice
+						this._needsUpdate = false;
+
+					}
+
+					// usual update procedure
+					if ( this._needsUpdate ) {
+
+						this._needsUpdate = false;
+
+						this.applier.apply( this._yaw, this._pitch );
 
 					}
 

--- a/packages/three-vrm/examples/lookat-advanced.html
+++ b/packages/three-vrm/examples/lookat-advanced.html
@@ -75,7 +75,7 @@
 						this._pitchDamped += ( this._pitch - this._pitchDamped ) * k;
 
 						// apply the animated angles
-						this.applier.apply( this._yawDamped, this._pitchDamped );
+						this.applier.applyYawPitch( this._yawDamped, this._pitchDamped );
 
 						// there is no need to update twice
 						this._needsUpdate = false;
@@ -87,7 +87,7 @@
 
 						this._needsUpdate = false;
 
-						this.applier.apply( this._yaw, this._pitch );
+						this.applier.applyYawPitch( this._yaw, this._pitch );
 
 					}
 


### PR DESCRIPTION
### Description

There are many changes in this PR.
I have added descriptions for each commit; you might want to see each in order.

The primary purpose of this PR is to make `VRMLookAt` able to use manually set `yaw` and `pitch`.

- 💡 LookAt APIs now mainly use yaw-pitch angles instead of Euler.
- ✨ Add an ability to set `yaw` and `pitch` manually.
    ```js
    vrm.lookAt.yaw = 30.0 * Math.sin(time)
    vrm.lookAt.pitch = 30.0 * Math.cos(time)
    ```
- 🐛 VRM0.0 and VRM1.0 now look in the same direction when we manually set `yaw` and `pitch` (formerly `euler`).
- 🐛 `VRMLookAtBoneApplier` is now compatible with eye bones witch have non-uniform rest rotations.
- 🐛 `VRMLookAtHelper` now works properly on VRM0.0.
- 💡 `VRMLookAtHelper` now hides target gizmo when `VRMLookAt.autoUpdate` is `false`.

### Breaking Changes

- 🚨 `VRMLookAt.euler` is deprecated. Use `yaw` and `pitch`, or `getEuler()` instead.
- 🚨 Protected method `VRMLookAt._calcEuler()` is removed. Use `VRMLookAt.lookAt()` instead.
- 🚨 The set value to `VRMLookAt` is now not applied to its applier immediately.
    - `VRMLookAt` has its internal flag `_needsUpdate`, and it's applied when we call its `update()`
- 🚨 `VRMLookAtApplier.lookAt()` is deprecated. Use `applyYawPitch()` instead.
- 🚨 `VRMLookAtBoneApplier` now requires `faceFront` in order to use with VRM0.0 models.
    - It should be handled automatically if you use `VRMLookAtLoaderPlugin`

### Points need review

- [ ] Does the logic look good?
- [ ] Any breaking changes I forgot to mention?
- [ ] Does the breaking changes worth enough?
