### PR TITLE
Promote `VRMC_node_constraint` to 1.0-beta

### DIFF
--- a/packages/three-vrm-node-constraint/examples/models/cubes.gltf
+++ b/packages/three-vrm-node-constraint/examples/models/cubes.gltf
@@ -318,7 +318,7 @@
       "mesh": 1,
       "extensions": {
         "VRMC_node_constraint": {
-          "specVersion": "1.0-draft",
+          "specVersion": "1.0-beta",
           "constraint": {
             "roll": {
               "source": 0,
@@ -351,7 +351,7 @@
       "mesh": 2,
       "extensions": {
         "VRMC_node_constraint": {
-          "specVersion": "1.0-draft",
+          "specVersion": "1.0-beta",
           "constraint": {
             "rotation": {
               "source": 0,

--- a/packages/three-vrm-node-constraint/src/VRMAimConstraint.ts
+++ b/packages/three-vrm-node-constraint/src/VRMAimConstraint.ts
@@ -14,7 +14,7 @@ const _quatC = new THREE.Quaternion();
 /**
  * A constraint that makes it look at a source object.
  *
- * See: https://github.com/vrm-c/vrm-specification/tree/master/specification/VRMC_node_constraint-1.0_draft#roll-constraint
+ * See: https://github.com/vrm-c/vrm-specification/tree/master/specification/VRMC_node_constraint-1.0_beta#roll-constraint
  */
 export class VRMAimConstraint extends VRMNodeConstraint {
   /**

--- a/packages/three-vrm-node-constraint/src/VRMNodeConstraintLoaderPlugin.ts
+++ b/packages/three-vrm-node-constraint/src/VRMNodeConstraintLoaderPlugin.ts
@@ -67,7 +67,7 @@ export class VRMNodeConstraintLoaderPlugin implements GLTFLoaderPlugin {
       }
 
       const specVersion = extension.specVersion;
-      if (specVersion !== '1.0-draft') {
+      if (specVersion !== '1.0-beta') {
         return;
       }
 

--- a/packages/three-vrm-node-constraint/src/VRMRollConstraint.ts
+++ b/packages/three-vrm-node-constraint/src/VRMRollConstraint.ts
@@ -9,7 +9,7 @@ const _quatB = new THREE.Quaternion();
 /**
  * A constraint that transfers a rotation around one axis of a source.
  *
- * See: https://github.com/vrm-c/vrm-specification/tree/master/specification/VRMC_node_constraint-1.0_draft#roll-constraint
+ * See: https://github.com/vrm-c/vrm-specification/tree/master/specification/VRMC_node_constraint-1.0_beta#roll-constraint
  */
 export class VRMRollConstraint extends VRMNodeConstraint {
   /**

--- a/packages/three-vrm-node-constraint/src/VRMRotationConstraint.ts
+++ b/packages/three-vrm-node-constraint/src/VRMRotationConstraint.ts
@@ -8,7 +8,7 @@ const _quatB = new THREE.Quaternion();
 /**
  * A constraint that transfers a rotation around one axis of a source.
  *
- * See: https://github.com/vrm-c/vrm-specification/tree/master/specification/VRMC_node_constraint-1.0_draft#roll-constraint
+ * See: https://github.com/vrm-c/vrm-specification/tree/master/specification/VRMC_node_constraint-1.0_beta#roll-constraint
  */
 export class VRMRotationConstraint extends VRMNodeConstraint {
   /**

--- a/packages/types-vrmc-materials-hdr-emissive-multiplier-1.0/README.md
+++ b/packages/types-vrmc-materials-hdr-emissive-multiplier-1.0/README.md
@@ -2,7 +2,7 @@
 
 Type definitions of VRMC_materials_hdr_emissiveMultiplier 1.0 schema.
 
-https://github.com/vrm-c/vrm-specification/tree/master/specification/VRMC_materials_hdr_emissiveMultiplier-1.0_draft
+https://github.com/vrm-c/vrm-specification/tree/master/specification/VRMC_materials_hdr_emissiveMultiplier-1.0
 
 There should not be any implementation in this package. Just type definitions of the schema.
 

--- a/packages/types-vrmc-materials-mtoon-1.0/README.md
+++ b/packages/types-vrmc-materials-mtoon-1.0/README.md
@@ -2,7 +2,7 @@
 
 Type definitions of VRMC_materials_mtoon 1.0 schema.
 
-https://github.com/vrm-c/vrm-specification/tree/master/specification/VRMC_materials_mtoon-1.0_draft
+https://github.com/vrm-c/vrm-specification/tree/master/specification/VRMC_materials_mtoon-1.0-beta
 
 There should not be any implementation in this package. Just type definitions of the schema.
 

--- a/packages/types-vrmc-node-constraint-1.0/README.md
+++ b/packages/types-vrmc-node-constraint-1.0/README.md
@@ -2,7 +2,7 @@
 
 Type definitions of VRMC_node_constraint 1.0 schema.
 
-https://github.com/vrm-c/vrm-specification/tree/master/specification/VRMC_node_constraint-1.0_draft
+https://github.com/vrm-c/vrm-specification/tree/master/specification/VRMC_node_constraint-1.0_beta
 
 There should not be any implementation in this package. Just type definitions of the schema.
 

--- a/packages/types-vrmc-node-constraint-1.0/src/VRMCNodeConstraint.ts
+++ b/packages/types-vrmc-node-constraint-1.0/src/VRMCNodeConstraint.ts
@@ -7,7 +7,7 @@ export interface VRMCNodeConstraint {
   /**
    * Specification version of VRMC_node_constraint
    */
-  specVersion: '1.0-draft';
+  specVersion: '1.0-beta';
 
   constraint: Constraint;
 

--- a/packages/types-vrmc-springbone-1.0/README.md
+++ b/packages/types-vrmc-springbone-1.0/README.md
@@ -2,7 +2,7 @@
 
 Type definitions of VRMC_springBone 1.0 schema.
 
-https://github.com/vrm-c/vrm-specification/tree/master/specification/VRMC_springBone-1.0_draft
+https://github.com/vrm-c/vrm-specification/tree/master/specification/VRMC_springBone-1.0_beta
 
 There should not be any implementation in this package. Just type definitions of the schema.
 

--- a/packages/types-vrmc-vrm-1.0/README.md
+++ b/packages/types-vrmc-vrm-1.0/README.md
@@ -2,7 +2,7 @@
 
 Type definitions of VRM_vrm 1.0 schema.
 
-https://github.com/vrm-c/vrm-specification/tree/master/specification/VRMC_vrm-1.0_draft
+https://github.com/vrm-c/vrm-specification/tree/master/specification/VRMC_vrm-1.0-beta
 
 There should not be any implementation in this package. Just type definitions of the schema.
 


### PR DESCRIPTION
This PR promotes `VRMC_node_constraint` extension from `1.0-draft` to `1.0-beta` .

See: https://github.com/vrm-c/vrm-specification/pull/369
