### PR TITLE
examples (1.0, constraint): fix aim.html

### DIFF
--- a/packages/three-vrm-node-constraint/examples/aim.html
+++ b/packages/three-vrm-node-constraint/examples/aim.html
@@ -117,7 +117,7 @@
 			} );
 
 			const constraint = new THREE_VRM_NODE_CONSTRAINT.VRMAimConstraint( aim, lowerArm );
-			constraint.aimAxis = '+Y';
+			constraint.aimAxis = 'PositiveY';
 			constraintManager.addConstraint( constraint );
 
 			// constraint helpers


### PR DESCRIPTION
Fixed an example `aim.html` of 1.0 node_constraint plugin.
The enum format of `aimAxis` was outdated