### PR TITLE
[1.0] bump three.js to r140

### DIFF
--- a/packages/three-vrm-core/examples/expressions.html
+++ b/packages/three-vrm-core/examples/expressions.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.137.4/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.137.4/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.137.4/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm-core.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm-core/examples/firstPerson.html
+++ b/packages/three-vrm-core/examples/firstPerson.html
@@ -24,9 +24,9 @@
 
 	<body>
 		<span id="info"></span>
-		<script src="https://unpkg.com/three@0.137.4/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.137.4/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.137.4/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm-core.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm-core/examples/humanoid.html
+++ b/packages/three-vrm-core/examples/humanoid.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.137.4/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.137.4/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.137.4/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm-core.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm-core/examples/lookAt.html
+++ b/packages/three-vrm-core/examples/lookAt.html
@@ -24,9 +24,9 @@
 
 	<body>
 		<span id="info"></span>
-		<script src="https://unpkg.com/three@0.137.4/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.137.4/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.137.4/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm-core.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm-core/examples/meta.html
+++ b/packages/three-vrm-core/examples/meta.html
@@ -31,9 +31,9 @@
 	<body>
 		<span id="meta"></span>
 		<img id="thumbnail" alt="thumbnail" />
-		<script src="https://unpkg.com/three@0.137.4/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.137.4/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.137.4/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm-core.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm-core/package.json
+++ b/packages/three-vrm-core/package.json
@@ -50,12 +50,12 @@
     "@pixiv/types-vrmc-vrm-1.0": "1.0.0-beta.14"
   },
   "devDependencies": {
-    "@types/three": "^0.137.0",
+    "@types/three": "^0.140.0",
     "lint-staged": "10.5.3",
-    "three": "^0.137.4"
+    "three": "^0.140.2"
   },
   "peerDependencies": {
-    "@types/three": "^0.137.0",
-    "three": "^0.137.4"
+    "@types/three": "^0.140.0",
+    "three": "^0.140.2"
   }
 }

--- a/packages/three-vrm-materials-hdr-emissive-multiplier/examples/loader-plugin.html
+++ b/packages/three-vrm-materials-hdr-emissive-multiplier/examples/loader-plugin.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.137.4/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.137.4/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.137.4/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm-materials-hdr-emissive-multiplier.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm-materials-hdr-emissive-multiplier/package.json
+++ b/packages/three-vrm-materials-hdr-emissive-multiplier/package.json
@@ -43,11 +43,11 @@
     "@pixiv/types-vrmc-materials-hdr-emissive-multiplier-1.0": "1.0.0-beta.14"
   },
   "devDependencies": {
-    "@types/three": "^0.137.0",
-    "three": "^0.137.4"
+    "@types/three": "^0.140.0",
+    "three": "^0.140.2"
   },
   "peerDependencies": {
-    "@types/three": "^0.137.0",
-    "three": "^0.137.4"
+    "@types/three": "^0.140.0",
+    "three": "^0.140.2"
   }
 }

--- a/packages/three-vrm-materials-mtoon/examples/loader-plugin.html
+++ b/packages/three-vrm-materials-mtoon/examples/loader-plugin.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.137.4/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.137.4/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.137.4/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm-materials-mtoon.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm-materials-mtoon/package.json
+++ b/packages/three-vrm-materials-mtoon/package.json
@@ -44,11 +44,11 @@
     "@pixiv/types-vrmc-materials-mtoon-1.0": "1.0.0-beta.14"
   },
   "devDependencies": {
-    "@types/three": "^0.137.0",
-    "three": "^0.137.4"
+    "@types/three": "^0.140.0",
+    "three": "^0.140.2"
   },
   "peerDependencies": {
-    "@types/three": "^0.137.0",
-    "three": "^0.137.4"
+    "@types/three": "^0.140.0",
+    "three": "^0.140.2"
   }
 }

--- a/packages/three-vrm-materials-mtoon/src/MToonMaterial.ts
+++ b/packages/three-vrm-materials-mtoon/src/MToonMaterial.ts
@@ -259,6 +259,12 @@ export class MToonMaterial extends THREE.ShaderMaterial {
   public uvAnimationRotationSpeedFactor = 0.0;
 
   /**
+   * Whether the material is affected by fog.
+   * `true` by default.
+   */
+  public fog = true;
+
+  /**
    * Will be read in WebGLPrograms
    *
    * See: https://github.com/mrdoob/three.js/blob/4f5236ac3d6f41d904aa58401b40554e8fbdcb15/src/renderers/webgl/WebGLPrograms.js#L190-L191

--- a/packages/three-vrm-materials-mtoon/src/MToonMaterialParameters.ts
+++ b/packages/three-vrm-materials-mtoon/src/MToonMaterialParameters.ts
@@ -39,6 +39,12 @@ export interface MToonMaterialParameters extends THREE.ShaderMaterialParameters 
   uvAnimationRotationSpeedFactor?: number;
 
   /**
+   * Whether the material is affected by fog.
+   * `true` by default.
+   */
+  fog?: boolean;
+
+  /**
    * When this is `true`, vertex colors will be ignored.
    * `true` by default.
    */

--- a/packages/three-vrm-materials-v0compat/package.json
+++ b/packages/three-vrm-materials-v0compat/package.json
@@ -44,12 +44,12 @@
     "@pixiv/types-vrmc-materials-mtoon-1.0": "1.0.0-beta.14"
   },
   "devDependencies": {
-    "@types/three": "^0.137.0",
+    "@types/three": "^0.140.0",
     "lint-staged": "10.5.4",
-    "three": "^0.137.4"
+    "three": "^0.140.2"
   },
   "peerDependencies": {
-    "@types/three": "^0.137.0",
-    "three": "^0.137.4"
+    "@types/three": "^0.140.0",
+    "three": "^0.140.2"
   }
 }

--- a/packages/three-vrm-node-constraint/examples/aim.html
+++ b/packages/three-vrm-node-constraint/examples/aim.html
@@ -19,8 +19,8 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.137.4/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.137.4/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/examples/js/controls/OrbitControls.js"></script>
 		<script src="https://unpkg.com/tweakpane@3.0"></script>
 		<script src="https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1"></script>
 		<script src="../lib/three-vrm-node-constraint.js"></script>

--- a/packages/three-vrm-node-constraint/examples/importer.html
+++ b/packages/three-vrm-node-constraint/examples/importer.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.137.4/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.137.4/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.137.4/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/examples/js/controls/OrbitControls.js"></script>
 		<script src="https://unpkg.com/tweakpane@3.0"></script>
 		<script src="https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1"></script>
 		<script src="../lib/three-vrm-node-constraint.js"></script>

--- a/packages/three-vrm-node-constraint/examples/roll.html
+++ b/packages/three-vrm-node-constraint/examples/roll.html
@@ -19,8 +19,8 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.137.4/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.137.4/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/examples/js/controls/OrbitControls.js"></script>
 		<script src="https://unpkg.com/tweakpane@3.0"></script>
 		<script src="https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1"></script>
 		<script src="../lib/three-vrm-node-constraint.js"></script>

--- a/packages/three-vrm-node-constraint/examples/rotation.html
+++ b/packages/three-vrm-node-constraint/examples/rotation.html
@@ -19,8 +19,8 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.137.4/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.137.4/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/examples/js/controls/OrbitControls.js"></script>
 		<script src="https://unpkg.com/tweakpane@3.0"></script>
 		<script src="https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1"></script>
 		<script src="../lib/three-vrm-node-constraint.js"></script>

--- a/packages/three-vrm-node-constraint/examples/upper-arm.html
+++ b/packages/three-vrm-node-constraint/examples/upper-arm.html
@@ -19,8 +19,8 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.137.4/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.137.4/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/examples/js/controls/OrbitControls.js"></script>
 		<script src="https://unpkg.com/tweakpane@3.0"></script>
 		<script src="https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1"></script>
 		<script src="../lib/three-vrm-node-constraint.js"></script>

--- a/packages/three-vrm-node-constraint/package.json
+++ b/packages/three-vrm-node-constraint/package.json
@@ -44,12 +44,12 @@
     "@pixiv/types-vrmc-node-constraint-1.0": "1.0.0-beta.14"
   },
   "devDependencies": {
-    "@types/three": "^0.137.0",
+    "@types/three": "^0.140.0",
     "lint-staged": "10.5.4",
-    "three": "^0.137.4"
+    "three": "^0.140.2"
   },
   "peerDependencies": {
-    "@types/three": "^0.137.0",
-    "three": "^0.137.4"
+    "@types/three": "^0.140.0",
+    "three": "^0.140.2"
   }
 }

--- a/packages/three-vrm-springbone/examples/collider.html
+++ b/packages/three-vrm-springbone/examples/collider.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.137.4/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.137.4/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.137.4/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm-springbone.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm-springbone/examples/loader-plugin.html
+++ b/packages/three-vrm-springbone/examples/loader-plugin.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.137.4/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.137.4/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.137.4/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm-springbone.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm-springbone/examples/multiple.html
+++ b/packages/three-vrm-springbone/examples/multiple.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.137.4/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.137.4/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.137.4/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm-springbone.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm-springbone/examples/single.html
+++ b/packages/three-vrm-springbone/examples/single.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.137.4/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.137.4/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.137.4/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm-springbone.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm-springbone/package.json
+++ b/packages/three-vrm-springbone/package.json
@@ -46,9 +46,9 @@
   },
   "devDependencies": {
     "lint-staged": "10.4.2",
-    "three": "^0.137.4"
+    "three": "^0.140.2"
   },
   "peerDependencies": {
-    "three": "^0.137.4"
+    "three": "^0.140.2"
   }
 }

--- a/packages/three-vrm-springbone/src/VRMSpringBoneJoint.ts
+++ b/packages/three-vrm-springbone/src/VRMSpringBoneJoint.ts
@@ -9,8 +9,8 @@ import type { VRMSpringBoneJointSettings } from './VRMSpringBoneJointSettings';
 // http://rocketjump.skr.jp/unity3d/109/
 // https://github.com/dwango/UniVRM/blob/master/Scripts/SpringBone/VRMSpringBone.cs
 
-const IDENTITY_MATRIX4 = Object.freeze(new THREE.Matrix4());
-const IDENTITY_QUATERNION = Object.freeze(new THREE.Quaternion());
+const IDENTITY_MATRIX4 = new THREE.Matrix4();
+const IDENTITY_QUATERNION = new THREE.Quaternion();
 
 // 計算中の一時保存用変数（一度インスタンスを作ったらあとは使い回す）
 const _v3A = new THREE.Vector3();

--- a/packages/three-vrm/examples/animations.html
+++ b/packages/three-vrm/examples/animations.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.137.4/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.137.4/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.137.4/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/basic.html
+++ b/packages/three-vrm/examples/basic.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.137.4/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.137.4/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.137.4/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/bones.html
+++ b/packages/three-vrm/examples/bones.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.137.4/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.137.4/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.137.4/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/debug.html
+++ b/packages/three-vrm/examples/debug.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.137.4/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.137.4/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.137.4/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/dnd.html
+++ b/packages/three-vrm/examples/dnd.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.137.4/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.137.4/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.137.4/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/expressions.html
+++ b/packages/three-vrm/examples/expressions.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.137.4/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.137.4/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.137.4/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/firstperson.html
+++ b/packages/three-vrm/examples/firstperson.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.137.4/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.137.4/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.137.4/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/lookat-advanced.html
+++ b/packages/three-vrm/examples/lookat-advanced.html
@@ -21,9 +21,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.137.4/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.137.4/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.137.4/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			const _v3A = new THREE.Vector3();

--- a/packages/three-vrm/examples/lookat.html
+++ b/packages/three-vrm/examples/lookat.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.137.4/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.137.4/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.137.4/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/materials-debug.html
+++ b/packages/three-vrm/examples/materials-debug.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.137.4/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.137.4/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.137.4/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/meta.html
+++ b/packages/three-vrm/examples/meta.html
@@ -31,9 +31,9 @@
 	<body>
 		<span id="meta"></span>
 		<img id="thumbnail" alt="thumbnail" />
-		<script src="https://unpkg.com/three@0.137.4/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.137.4/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.137.4/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/examples/mouse.html
+++ b/packages/three-vrm/examples/mouse.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.137.4/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.137.4/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.137.4/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.140.2/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm/package.json
+++ b/packages/three-vrm/package.json
@@ -54,13 +54,13 @@
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^13.0.0",
-    "@types/three": "^0.137.0",
+    "@types/three": "^0.140.0",
     "lint-staged": "10.5.4",
     "quicktype": "^15.0.258",
-    "three": "^0.137.4"
+    "three": "^0.140.2"
   },
   "peerDependencies": {
-    "@types/three": "^0.137.0",
-    "three": "^0.137.4"
+    "@types/three": "^0.140.0",
+    "three": "^0.140.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1629,10 +1629,10 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
 
-"@types/three@^0.137.0":
-  version "0.137.0"
-  resolved "https://registry.yarnpkg.com/@types/three/-/three-0.137.0.tgz#6047e0658262b4de7c464a40288f9071ddd9a6d5"
-  integrity sha512-Xc5EAlfYmgrCLI/VlSVqiRJAtzhWF0Rw2jSq48nqJy+Hcb5sfDOXyfZn1+RNcHyi9l8CeCAXCZygO8IyeOJVEA==
+"@types/three@^0.140.0":
+  version "0.140.0"
+  resolved "https://registry.yarnpkg.com/@types/three/-/three-0.140.0.tgz#3b74a021a69a6e2cd0e2550def15aa4c1c20e924"
+  integrity sha512-YPJLSIY6uKUOp1k6BZYDq5GtEIdhfeK04UCbc9IPAVbdn/RNjkfrbnyd7smrsNkJhc0IFASLpd3AAYgwqgXKVQ==
 
 "@types/yargs-parser@*":
   version "20.2.1"
@@ -8115,10 +8115,10 @@ thenify-all@^1.0.0:
   dependencies:
     any-promise "^1.0.0"
 
-three@^0.137.4:
-  version "0.137.4"
-  resolved "https://registry.yarnpkg.com/three/-/three-0.137.4.tgz#ec73b6a6c40b733d56544b13d0c3cdb0bce5d0a7"
-  integrity sha512-kUyOZNX+dMbvaS0mGYM1BaXHkHVNQdpryWH8dBg3mn725dJcTo9/5rjyH+OJ8V0r+XbZPz7sncV+c3Gjpc9UBA==
+three@^0.140.2:
+  version "0.140.2"
+  resolved "https://registry.yarnpkg.com/three/-/three-0.140.2.tgz#ca0b7390d1ce4f7f2850e80afd00ef48fc244491"
+  integrity sha512-DdT/AHm/TbZXEhQKQpGt5/iSgBrmXpjU26FNtj1KhllVPTKj1eG4X/ShyD5W2fngE+I1s1wa4ttC4C3oCJt7Ag==
 
 throat@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
Bump Three.js to r140.

### Description

- Since `.fog` has been transferred to each subclass of `Material`, `MToonMaterial` now has its own `.fog` property.
- Remove use of `Object.freeze` which causes TypeScript type error.
    - Note that TypeScript in this repo is outdated and can be fixed by updating the TypeScript. So it's a workaround.

### Points need review

- [x] How do you think about the removal of `Object.freeze` ?
