### PR TITLE
[1.0] Re-introduce springbone center

### DIFF
--- a/.github/workflows/inspect.yml
+++ b/.github/workflows/inspect.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Setup Node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: '14'
     - name: Cache Deps
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           node_modules
@@ -33,13 +33,13 @@ jobs:
     needs: fetch
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Setup Node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: '14'
     - name: Cache Deps
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           node_modules
@@ -55,13 +55,13 @@ jobs:
     needs: fetch
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Setup Node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: '14'
     - name: Cache Deps
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           node_modules
@@ -77,13 +77,13 @@ jobs:
     needs: fetch
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Setup Node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: '14'
     - name: Cache Deps
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           node_modules
@@ -94,7 +94,7 @@ jobs:
     - name: Build
       run: yarn build
     - name: Upload Builds
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: build
         path: |
@@ -107,13 +107,13 @@ jobs:
     needs: build
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Setup Node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: '14'
     - name: Cache Deps
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           node_modules
@@ -122,14 +122,14 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-yarn-
     - name: Download Builds
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: build
         path: packages
     - name: Build Docs
       run: yarn docs
     - name: Upload Docs
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v3
       with:
         name: docs
         path: |
@@ -143,13 +143,13 @@ jobs:
     - docs
     steps:
     - name: Checkout
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Setup Node
-      uses: actions/setup-node@v2
+      uses: actions/setup-node@v3
       with:
         node-version: '14'
     - name: Cache Deps
-      uses: actions/cache@v2
+      uses: actions/cache@v3
       with:
         path: |
           node_modules
@@ -158,12 +158,12 @@ jobs:
         restore-keys: |
           ${{ runner.os }}-yarn-
     - name: Download Builds
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: build
         path: public/packages
     - name: Download Docs
-      uses: actions/download-artifact@v2
+      uses: actions/download-artifact@v3
       with:
         name: docs
         path: public/packages

--- a/packages/three-vrm-springbone/src/VRMSpringBoneJoint.ts
+++ b/packages/three-vrm-springbone/src/VRMSpringBoneJoint.ts
@@ -250,11 +250,7 @@ export class VRMSpringBoneJoint {
       .applyMatrix4(matrixCenterToWorld); // tailをworld spaceに戻す
 
     // normalize bone length
-    _nextTail
-      .sub(_worldSpacePosition)
-      .normalize()
-      .multiplyScalar(this._worldSpaceBoneLength)
-      .add(_worldSpacePosition);
+    _nextTail.sub(_worldSpacePosition).normalize().multiplyScalar(this._worldSpaceBoneLength).add(_worldSpacePosition);
 
     // Collisionで移動
     this._collision(_nextTail);
@@ -267,7 +263,9 @@ export class VRMSpringBoneJoint {
 
     // Apply rotation, convert vector3 thing into actual quaternion
     // Original UniVRM is doing center unit calculus at here but we're gonna do this on local unit
-    const worldSpaceInitialMatrixInv = mat4InvertCompat(_matA.copy(this._parentMatrixWorld).multiply(this._initialLocalMatrix));
+    const worldSpaceInitialMatrixInv = mat4InvertCompat(
+      _matA.copy(this._parentMatrixWorld).multiply(this._initialLocalMatrix),
+    );
     const applyRotation = _quatA.setFromUnitVectors(
       this._boneAxis,
       _v3A.copy(_nextTail).applyMatrix4(worldSpaceInitialMatrixInv).normalize(),
@@ -295,11 +293,7 @@ export class VRMSpringBoneJoint {
           tail.add(_v3A.multiplyScalar(-dist));
 
           // normalize bone length
-          tail
-            .sub(_worldSpacePosition)
-            .normalize()
-            .multiplyScalar(this._worldSpaceBoneLength)
-            .add(_worldSpacePosition);
+          tail.sub(_worldSpacePosition).normalize().multiplyScalar(this._worldSpaceBoneLength).add(_worldSpacePosition);
         }
       });
     });

--- a/packages/three-vrm-springbone/src/VRMSpringBoneLoaderPlugin.ts
+++ b/packages/three-vrm-springbone/src/VRMSpringBoneLoaderPlugin.ts
@@ -149,6 +149,8 @@ export class VRMSpringBoneLoaderPlugin implements GLTFLoaderPlugin {
         return group;
       });
 
+      const center = schemaSpring.center != null ? threeNodes[schemaSpring.center] : undefined;
+
       let prevJoint: V1SpringBoneSchema.SpringBoneJoint | undefined;
       schemaJoints.forEach((joint) => {
         if (prevJoint) {
@@ -169,6 +171,10 @@ export class VRMSpringBoneLoaderPlugin implements GLTFLoaderPlugin {
 
           // create spring bones
           const spring = this._importJoint(node, child, setting, colliderGroupsForSpring);
+          if (center) {
+            spring.center = center;
+          }
+
           manager.addSpringBone(spring);
         }
 
@@ -251,6 +257,9 @@ export class VRMSpringBoneLoaderPlugin implements GLTFLoaderPlugin {
         } else {
           gravityDir.set(0.0, -1.0, 0.0);
         }
+
+      const center = schemaBoneGroup.center != null ? threeNodes[schemaBoneGroup.center] : undefined;
+
         const setting: Partial<VRMSpringBoneJointSettings> = {
           hitRadius: schemaBoneGroup.hitRadius,
           dragForce: schemaBoneGroup.dragForce,
@@ -275,7 +284,12 @@ export class VRMSpringBoneLoaderPlugin implements GLTFLoaderPlugin {
         // create spring bones
         root.traverse((node) => {
           const child: THREE.Object3D | null = node.children[0] ?? null;
+
           const spring = this._importJoint(node, child, setting, colliderGroupsForSpring);
+          if (center) {
+            spring.center = center;
+          }
+
           manager.addSpringBone(spring);
         });
       });

--- a/packages/three-vrm-springbone/src/VRMSpringBoneLoaderPlugin.ts
+++ b/packages/three-vrm-springbone/src/VRMSpringBoneLoaderPlugin.ts
@@ -151,34 +151,34 @@ export class VRMSpringBoneLoaderPlugin implements GLTFLoaderPlugin {
 
       const center = schemaSpring.center != null ? threeNodes[schemaSpring.center] : undefined;
 
-      let prevJoint: V1SpringBoneSchema.SpringBoneJoint | undefined;
-      schemaJoints.forEach((joint) => {
-        if (prevJoint) {
+      let prevSchemaJoint: V1SpringBoneSchema.SpringBoneJoint | undefined;
+      schemaJoints.forEach((schemaJoint) => {
+        if (prevSchemaJoint) {
           // prepare node
-          const nodeIndex = prevJoint.node;
+          const nodeIndex = prevSchemaJoint.node;
           const node = threeNodes[nodeIndex];
-          const childIndex = joint.node;
+          const childIndex = schemaJoint.node;
           const child = threeNodes[childIndex];
 
           // prepare setting
           const setting: Partial<VRMSpringBoneJointSettings> = {
-            hitRadius: prevJoint.hitRadius,
-            dragForce: prevJoint.dragForce,
-            gravityPower: prevJoint.gravityPower,
-            stiffness: prevJoint.stiffness,
-            gravityDir: new THREE.Vector3().fromArray(prevJoint.gravityDir ?? [0.0, 1.0, 0.0]),
+            hitRadius: prevSchemaJoint.hitRadius,
+            dragForce: prevSchemaJoint.dragForce,
+            gravityPower: prevSchemaJoint.gravityPower,
+            stiffness: prevSchemaJoint.stiffness,
+            gravityDir: new THREE.Vector3().fromArray(prevSchemaJoint.gravityDir ?? [0.0, 1.0, 0.0]),
           };
 
           // create spring bones
-          const spring = this._importJoint(node, child, setting, colliderGroupsForSpring);
+          const joint = this._importJoint(node, child, setting, colliderGroupsForSpring);
           if (center) {
-            spring.center = center;
+            joint.center = center;
           }
 
-          manager.addSpringBone(spring);
+          manager.addSpringBone(joint);
         }
 
-        prevJoint = joint;
+        prevSchemaJoint = schemaJoint;
       });
     });
 
@@ -285,12 +285,12 @@ export class VRMSpringBoneLoaderPlugin implements GLTFLoaderPlugin {
         root.traverse((node) => {
           const child: THREE.Object3D | null = node.children[0] ?? null;
 
-          const spring = this._importJoint(node, child, setting, colliderGroupsForSpring);
+          const joint = this._importJoint(node, child, setting, colliderGroupsForSpring);
           if (center) {
-            spring.center = center;
+            joint.center = center;
           }
 
-          manager.addSpringBone(spring);
+          manager.addSpringBone(joint);
         });
       });
     });

--- a/packages/three-vrm-springbone/src/VRMSpringBoneLoaderPlugin.ts
+++ b/packages/three-vrm-springbone/src/VRMSpringBoneLoaderPlugin.ts
@@ -258,7 +258,7 @@ export class VRMSpringBoneLoaderPlugin implements GLTFLoaderPlugin {
           gravityDir.set(0.0, -1.0, 0.0);
         }
 
-      const center = schemaBoneGroup.center != null ? threeNodes[schemaBoneGroup.center] : undefined;
+        const center = schemaBoneGroup.center != null ? threeNodes[schemaBoneGroup.center] : undefined;
 
         const setting: Partial<VRMSpringBoneJointSettings> = {
           hitRadius: schemaBoneGroup.hitRadius,

--- a/packages/three-vrm-springbone/src/VRMSpringBoneManager.ts
+++ b/packages/three-vrm-springbone/src/VRMSpringBoneManager.ts
@@ -170,6 +170,12 @@ export class VRMSpringBoneManager {
       set.add(parent);
     }
 
+    springBone.colliderGroups.forEach((colliderGroup) => {
+      colliderGroup.colliders.forEach((collider) => {
+        set.add(collider);
+      });
+    });
+
     return set;
   }
 }

--- a/packages/types-vrmc-springbone-1.0/src/SpringBoneSpring.ts
+++ b/packages/types-vrmc-springbone-1.0/src/SpringBoneSpring.ts
@@ -19,6 +19,11 @@ export interface SpringBoneSpring {
    */
   colliderGroups?: number[];
 
+  /**
+   * An index of node which is used as a root of center space.
+   */
+  center?: number;
+
   extensions?: { [name: string]: any };
   extras?: any;
 }


### PR DESCRIPTION
### Description

- Re-introduce `center` to the serialized SpringBone fields.
    - See: https://github.com/vrm-c/vrm-specification/pull/374
- Fix behavior of SpringBone when `center` is applied:
    - Collision should be calculated in world space instead of center space
    - Colliders should be dependencies on a SpringBone
