### PR TITLE
[1.0] Add Humanoid helper

### DIFF
--- a/packages/three-vrm-core/examples/humanoid.html
+++ b/packages/three-vrm-core/examples/humanoid.html
@@ -57,7 +57,7 @@
 
 			loader.register( ( parser ) => {
 
-				return new THREE_VRM_CORE.VRMCoreLoaderPlugin( parser );
+				return new THREE_VRM_CORE.VRMCoreLoaderPlugin( parser, { helperRoot: scene } );
 
 			} );
 

--- a/packages/three-vrm-core/src/VRMCoreLoaderPlugin.ts
+++ b/packages/three-vrm-core/src/VRMCoreLoaderPlugin.ts
@@ -28,7 +28,7 @@ export class VRMCoreLoaderPlugin implements GLTFLoaderPlugin {
 
     this.expressionPlugin = options?.expressionPlugin ?? new VRMExpressionLoaderPlugin(parser);
     this.firstPersonPlugin = options?.firstPersonPlugin ?? new VRMFirstPersonLoaderPlugin(parser);
-    this.humanoidPlugin = options?.humanoidPlugin ?? new VRMHumanoidLoaderPlugin(parser);
+    this.humanoidPlugin = options?.humanoidPlugin ?? new VRMHumanoidLoaderPlugin(parser, { helperRoot });
     this.lookAtPlugin = options?.lookAtPlugin ?? new VRMLookAtLoaderPlugin(parser, { helperRoot });
     this.metaPlugin = options?.metaPlugin ?? new VRMMetaLoaderPlugin(parser);
   }

--- a/packages/three-vrm-core/src/humanoid/VRMHumanoidLoaderPlugin.ts
+++ b/packages/three-vrm-core/src/humanoid/VRMHumanoidLoaderPlugin.ts
@@ -5,11 +5,20 @@ import { VRMHumanoid } from './VRMHumanoid';
 import type { VRMHumanBones } from './VRMHumanBones';
 import { VRMRequiredHumanBoneName } from './VRMRequiredHumanBoneName';
 import { GLTF as GLTFSchema } from '@gltf-transform/core';
+import { VRMHumanoidHelper } from './helpers/VRMHumanoidHelper';
+import { VRMHumanoidLoaderPluginOptions } from './VRMHumanoidLoaderPluginOptions';
 
 /**
  * A plugin of GLTFLoader that imports a {@link VRMHumanoid} from a VRM extension of a GLTF.
  */
 export class VRMHumanoidLoaderPlugin implements GLTFLoaderPlugin {
+  /**
+   * Specify an Object3D to add {@link VRMHumanoidHelper}.
+   * If not specified, helper will not be created.
+   * If `renderOrder` is set to the root, the helper will copy the same `renderOrder` .
+   */
+  public helperRoot?: THREE.Object3D;
+
   public readonly parser: GLTFParser;
 
   public get name(): string {
@@ -17,8 +26,10 @@ export class VRMHumanoidLoaderPlugin implements GLTFLoaderPlugin {
     return 'VRMHumanoidLoaderPlugin';
   }
 
-  public constructor(parser: GLTFParser) {
+  public constructor(parser: GLTFParser, options?: VRMHumanoidLoaderPluginOptions) {
     this.parser = parser;
+
+    this.helperRoot = options?.helperRoot;
   }
 
   public async afterRoot(gltf: GLTF): Promise<void> {
@@ -89,7 +100,15 @@ export class VRMHumanoidLoaderPlugin implements GLTFLoaderPlugin {
       );
     }
 
-    return new VRMHumanoid(this._ensureRequiredBonesExist(humanBones));
+    const humanoid = new VRMHumanoid(this._ensureRequiredBonesExist(humanBones));
+
+    if (this.helperRoot) {
+      const helper = new VRMHumanoidHelper(humanoid);
+      this.helperRoot.add(helper);
+      helper.renderOrder = this.helperRoot.renderOrder;
+    }
+
+    return humanoid;
   }
 
   private async _v0Import(gltf: GLTF): Promise<VRMHumanoid | null> {
@@ -139,7 +158,15 @@ export class VRMHumanoidLoaderPlugin implements GLTFLoaderPlugin {
       );
     }
 
-    return new VRMHumanoid(this._ensureRequiredBonesExist(humanBones));
+    const humanoid = new VRMHumanoid(this._ensureRequiredBonesExist(humanBones));
+
+    if (this.helperRoot) {
+      const helper = new VRMHumanoidHelper(humanoid);
+      this.helperRoot.add(helper);
+      helper.renderOrder = this.helperRoot.renderOrder;
+    }
+
+    return humanoid;
   }
 
   /**

--- a/packages/three-vrm-core/src/humanoid/VRMHumanoidLoaderPluginOptions.ts
+++ b/packages/three-vrm-core/src/humanoid/VRMHumanoidLoaderPluginOptions.ts
@@ -1,0 +1,8 @@
+export interface VRMHumanoidLoaderPluginOptions {
+  /**
+   * Specify an Object3D to add {@link VRMHumanoidHelper}.
+   * If not specified, helper will not be created.
+   * If `renderOrder` is set to the root, helpers will copy the same `renderOrder` .
+   */
+  helperRoot?: THREE.Object3D;
+}

--- a/packages/three-vrm-core/src/humanoid/helpers/VRMHumanoidHelper.ts
+++ b/packages/three-vrm-core/src/humanoid/helpers/VRMHumanoidHelper.ts
@@ -1,0 +1,55 @@
+import * as THREE from 'three';
+import { VRMHumanBone } from '../VRMHumanBone';
+import { VRMHumanoid } from '../VRMHumanoid';
+
+const _v3A = new THREE.Vector3();
+const _v3B = new THREE.Vector3();
+const _quatA = new THREE.Quaternion();
+
+export class VRMHumanoidHelper extends THREE.Group {
+  public readonly vrmHumanoid: VRMHumanoid;
+  private _boneAxesMap: Map<VRMHumanBone, THREE.AxesHelper>;
+
+  public constructor(humanoid: VRMHumanoid) {
+    super();
+
+    this.vrmHumanoid = humanoid;
+
+    this._boneAxesMap = new Map();
+
+    Object.values(humanoid.humanBones).forEach((bone) => {
+      if (bone) {
+        const helper = new THREE.AxesHelper(1.0);
+
+        helper.matrixAutoUpdate = false;
+
+        (helper.material as THREE.Material).depthTest = false;
+        (helper.material as THREE.Material).depthWrite = false;
+
+        this.add(helper);
+
+        this._boneAxesMap.set(bone, helper);
+      }
+    });
+  }
+
+  public dispose(): void {
+    Array.from(this._boneAxesMap.values()).forEach((axes) => {
+      axes.geometry.dispose();
+      (axes.material as THREE.Material).dispose();
+    });
+  }
+
+  public updateMatrixWorld(force: boolean): void {
+    Array.from(this._boneAxesMap.entries()).forEach(([bone, axes]) => {
+      bone.node.updateWorldMatrix(true, false);
+
+      bone.node.matrixWorld.decompose(_v3A, _quatA, _v3B);
+
+      const scale = _v3A.set(0.1, 0.1, 0.1).divide(_v3B);
+      axes.matrix.copy(bone.node.matrixWorld).scale(scale);
+    });
+
+    super.updateMatrixWorld(force);
+  }
+}

--- a/packages/three-vrm-core/src/humanoid/helpers/VRMHumanoidHelper.ts
+++ b/packages/three-vrm-core/src/humanoid/helpers/VRMHumanoidHelper.ts
@@ -18,18 +18,17 @@ export class VRMHumanoidHelper extends THREE.Group {
     this._boneAxesMap = new Map();
 
     Object.values(humanoid.humanBones).forEach((bone) => {
-      if (bone) {
-        const helper = new THREE.AxesHelper(1.0);
+      const helper = new THREE.AxesHelper(1.0);
 
-        helper.matrixAutoUpdate = false;
+      helper.matrixAutoUpdate = false;
 
-        (helper.material as THREE.Material).depthTest = false;
-        (helper.material as THREE.Material).depthWrite = false;
+      (helper.material as THREE.Material).depthTest = false;
+      (helper.material as THREE.Material).depthWrite = false;
 
-        this.add(helper);
+      this.add(helper);
 
-        this._boneAxesMap.set(bone, helper);
-      }
+      // TODO: type assertion is not needed in later versions of TypeScript
+      this._boneAxesMap.set(bone!, helper);
     });
   }
 

--- a/packages/three-vrm-core/src/humanoid/helpers/index.ts
+++ b/packages/three-vrm-core/src/humanoid/helpers/index.ts
@@ -1,0 +1,1 @@
+export { VRMHumanoidHelper } from './VRMHumanoidHelper';

--- a/packages/three-vrm-core/src/humanoid/index.ts
+++ b/packages/three-vrm-core/src/humanoid/index.ts
@@ -1,3 +1,5 @@
+export * from './helpers';
+
 export { VRMHumanBone } from './VRMHumanBone';
 export { VRMHumanBoneName } from './VRMHumanBoneName';
 export type { VRMHumanBones } from './VRMHumanBones';


### PR DESCRIPTION
### Description

This PR adds `VRMHumanoidHelper` which visualizes humanoid bones.

![image](https://user-images.githubusercontent.com/7824814/172755763-02239249-0e25-445b-8f56-ff298b84ed94.png)

This PR was originally done in #889 but since Humanoid Rig changes are going to be difficult I separated the humanoid helper changes into this PR.
