### PR TITLE
[1.0] Giving `helperRoot` to `VRMLoaderPlugin` now automatically enables `VRMHumanoidHelper`

### DIFF
--- a/packages/three-vrm/src/VRMLoaderPlugin.ts
+++ b/packages/three-vrm/src/VRMLoaderPlugin.ts
@@ -40,7 +40,7 @@ export class VRMLoaderPlugin implements GLTFLoaderPlugin {
 
     this.expressionPlugin = options?.expressionPlugin ?? new VRMExpressionLoaderPlugin(parser);
     this.firstPersonPlugin = options?.firstPersonPlugin ?? new VRMFirstPersonLoaderPlugin(parser);
-    this.humanoidPlugin = options?.humanoidPlugin ?? new VRMHumanoidLoaderPlugin(parser);
+    this.humanoidPlugin = options?.humanoidPlugin ?? new VRMHumanoidLoaderPlugin(parser, { helperRoot });
     this.lookAtPlugin = options?.lookAtPlugin ?? new VRMLookAtLoaderPlugin(parser, { helperRoot });
     this.metaPlugin = options?.metaPlugin ?? new VRMMetaLoaderPlugin(parser);
     this.mtoonMaterialPlugin = options?.mtoonMaterialPlugin ?? new MToonMaterialLoaderPlugin(parser);


### PR DESCRIPTION
### Description

The name of the PR tells it
