### PR TITLE
[1.0] MToon, let outlineLightingMix be affected from emission and rim lighting

### DIFF
--- a/packages/three-vrm-materials-mtoon/src/shaders/mtoon.frag
+++ b/packages/three-vrm-materials-mtoon/src/shaders/mtoon.frag
@@ -658,15 +658,6 @@ void main() {
 
   vec3 col = reflectedLight.directDiffuse + reflectedLight.indirectDiffuse;
 
-  #if defined( OUTLINE )
-    gl_FragColor = vec4(
-      outlineColorFactor.rgb * mix( vec3( 1.0 ), col, outlineLightingMixFactor ),
-      diffuseColor.a
-    );
-    postCorrection();
-    return;
-  #endif
-
   #ifdef DEBUG_LITSHADERATE
     gl_FragColor = vec4( col, diffuseColor.a );
     postCorrection();
@@ -717,6 +708,10 @@ void main() {
   // #include <envmap_fragment>
 
   // -- Almost done! -----------------------------------------------------------
+  #if defined( OUTLINE )
+    col = outlineColorFactor.rgb * mix( vec3( 1.0 ), col, outlineLightingMixFactor );
+  #endif
+
   gl_FragColor = vec4( col, diffuseColor.a );
   postCorrection();
 }


### PR DESCRIPTION
Depends on https://github.com/vrm-c/vrm-specification/pull/392

### Description

This PR changes how MToon's outlineLightingMix interacts with surface rendering results.

it used to be affected by direct lighting and indirect lighting, now it also receives emission and rim lighting.

Based on this change of vrm-spec: https://github.com/vrm-c/vrm-specification/pull/392
