### PR TITLE
[1.0] Support the new MaterialColorBind type `matcapColor`

### DIFF
--- a/packages/three-vrm-core/src/expressions/VRMExpressionMaterialColorBind.ts
+++ b/packages/three-vrm-core/src/expressions/VRMExpressionMaterialColorBind.ts
@@ -25,6 +25,7 @@ export class VRMExpressionMaterialColorBind implements VRMExpressionBind {
       color: 'color',
       emissionColor: 'emissive',
       outlineColor: 'outlineColorFactor',
+      matcapColor: 'matcapFactor',
       rimColor: 'parametricRimColorFactor',
       shadeColor: 'shadeColorFactor',
     },

--- a/packages/three-vrm-core/src/expressions/VRMExpressionMaterialColorType.ts
+++ b/packages/three-vrm-core/src/expressions/VRMExpressionMaterialColorType.ts
@@ -4,6 +4,7 @@ export const VRMExpressionMaterialColorType = {
   Color: 'color',
   EmissionColor: 'emissionColor',
   ShadeColor: 'shadeColor',
+  MatcapColor: 'matcapColor',
   RimColor: 'rimColor',
   OutlineColor: 'outlineColor',
 } as const;

--- a/packages/types-vrmc-vrm-1.0/src/ExpressionMaterialColorType.ts
+++ b/packages/types-vrmc-vrm-1.0/src/ExpressionMaterialColorType.ts
@@ -1,1 +1,1 @@
-export type ExpressionMaterialColorType = 'color' | 'emissionColor' | 'shadeColor' | 'rimColor' | 'outlineColor';
+export type ExpressionMaterialColorType = 'color' | 'emissionColor' | 'shadeColor' | 'matcapColor' | 'rimColor' | 'outlineColor';

--- a/packages/types-vrmc-vrm-1.0/src/ExpressionMaterialColorType.ts
+++ b/packages/types-vrmc-vrm-1.0/src/ExpressionMaterialColorType.ts
@@ -1,1 +1,7 @@
-export type ExpressionMaterialColorType = 'color' | 'emissionColor' | 'shadeColor' | 'matcapColor' | 'rimColor' | 'outlineColor';
+export type ExpressionMaterialColorType =
+  | 'color'
+  | 'emissionColor'
+  | 'shadeColor'
+  | 'matcapColor'
+  | 'rimColor'
+  | 'outlineColor';


### PR DESCRIPTION
~~Depends on https://github.com/vrm-c/vrm-specification/pull/394~~

### Description

Support the new MaterialColorBind type `matcapColor` which was introduced in the spec.

See: https://github.com/vrm-c/vrm-specification/pull/394

### Points need review

- [ ] Is this working correctly?
- [ ] Any leftover?
