### PR TITLE
docs:   Replace comment  "VRM0.X" to "VRM0.0"

### DIFF
--- a/packages/three-vrm-core/src/meta/VRMMetaLoaderPlugin.ts
+++ b/packages/three-vrm-core/src/meta/VRMMetaLoaderPlugin.ts
@@ -29,7 +29,7 @@ export class VRMMetaLoaderPlugin implements GLTFLoaderPlugin {
   public acceptLicenseUrls: string[];
 
   /**
-   * Whether it should accept VRM0.X meta or not.
+   * Whether it should accept VRM0.0 meta or not.
    * Note that it might load {@link VRM0Meta} instead of {@link VRM1Meta} when this is `true`.
    * `true` by default.
    */
@@ -142,7 +142,7 @@ export class VRMMetaLoaderPlugin implements GLTFLoaderPlugin {
 
     // throw an error if acceptV0Meta is false
     if (!this.acceptV0Meta) {
-      throw new Error('VRMMetaLoaderPlugin: Attempted to load VRM0.X meta but acceptV0Meta is false');
+      throw new Error('VRMMetaLoaderPlugin: Attempted to load VRM0.0 meta but acceptV0Meta is false');
     }
 
     // load thumbnail texture

--- a/packages/three-vrm-core/src/meta/VRMMetaLoaderPluginOptions.ts
+++ b/packages/three-vrm-core/src/meta/VRMMetaLoaderPluginOptions.ts
@@ -16,7 +16,7 @@ export interface VRMMetaLoaderPluginOptions {
   acceptLicenseUrls?: string[];
 
   /**
-   * Whether it should accept VRM0.X meta or not.
+   * Whether it should accept VRM0.0 meta or not.
    * Note that it might load {@link VRM0Meta} instead of {@link VRM1Meta} when this is `true`.
    * `true` by default.
    */


### PR DESCRIPTION
Description

VRM0系を表す単語をVRM0.0へ統一するためにDocsコメントの該当箇所を置換しました。

https://github.com/pixiv/three-vrm/pull/1029#discussion_r957938626
