### PR TITLE
BREAKING change: VRM now requires meta and humanoid to instantiate

### DIFF
--- a/packages/three-vrm-core/src/VRMCore.ts
+++ b/packages/three-vrm-core/src/VRMCore.ts
@@ -17,12 +17,18 @@ export class VRMCore {
   public readonly scene: THREE.Group;
 
   /**
+   * Contains meta fields of the VRM.
+   * You might want to refer these license fields before use your VRMs.
+   */
+  public readonly meta: VRMMeta;
+
+  /**
    * Contains {@link VRMHumanoid} of the VRM.
    * You can control each bones using {@link VRMHumanoid.getBoneNode}.
    *
    * @TODO Add a link to VRM spec
    */
-  public readonly humanoid?: VRMHumanoid;
+  public readonly humanoid: VRMHumanoid;
 
   /**
    * Contains {@link VRMExpressionManager} of the VRM.
@@ -43,23 +49,17 @@ export class VRMCore {
   public readonly lookAt?: VRMLookAt;
 
   /**
-   * Contains meta fields of the VRM.
-   * You might want to refer these license fields before use your VRMs.
-   */
-  public readonly meta?: VRMMeta;
-
-  /**
    * Create a new VRM instance.
    *
    * @param params [[VRMParameters]] that represents components of the VRM
    */
   public constructor(params: VRMCoreParameters) {
     this.scene = params.scene;
+    this.meta = params.meta;
     this.humanoid = params.humanoid;
     this.expressionManager = params.expressionManager;
     this.firstPerson = params.firstPerson;
     this.lookAt = params.lookAt;
-    this.meta = params.meta;
   }
 
   /**
@@ -70,9 +70,7 @@ export class VRMCore {
    * @param delta deltaTime
    */
   public update(delta: number): void {
-    if (this.humanoid) {
-      this.humanoid.update();
-    }
+    this.humanoid.update();
 
     if (this.lookAt) {
       this.lookAt.update(delta);

--- a/packages/three-vrm-core/src/VRMCoreLoaderPlugin.ts
+++ b/packages/three-vrm-core/src/VRMCoreLoaderPlugin.ts
@@ -6,6 +6,8 @@ import { VRMFirstPersonLoaderPlugin } from './firstPerson/VRMFirstPersonLoaderPl
 import { VRMHumanoidLoaderPlugin } from './humanoid/VRMHumanoidLoaderPlugin';
 import { VRMMetaLoaderPlugin } from './meta/VRMMetaLoaderPlugin';
 import { VRMLookAtLoaderPlugin } from './lookAt/VRMLookAtLoaderPlugin';
+import type { VRMHumanoid } from './humanoid';
+import type { VRMMeta } from './meta';
 
 export class VRMCoreLoaderPlugin implements GLTFLoaderPlugin {
   public get name(): string {
@@ -42,14 +44,22 @@ export class VRMCoreLoaderPlugin implements GLTFLoaderPlugin {
     await this.lookAtPlugin.afterRoot(gltf);
     await this.firstPersonPlugin.afterRoot(gltf);
 
-    const vrmCore = new VRMCore({
-      scene: gltf.scene,
-      expressionManager: gltf.userData.vrmExpressionManager,
-      firstPerson: gltf.userData.vrmFirstPerson,
-      humanoid: gltf.userData.vrmHumanoid,
-      lookAt: gltf.userData.vrmLookAt,
-      meta: gltf.userData.vrmMeta,
-    });
-    gltf.userData.vrmCore = vrmCore;
+    const meta = gltf.userData.vrmMeta as VRMMeta | null;
+    const humanoid = gltf.userData.vrmHumanoid as VRMHumanoid | null;
+
+    // meta and humanoid are required to be a VRM.
+    // Don't create VRM if they are null
+    if (meta && humanoid) {
+      const vrmCore = new VRMCore({
+        scene: gltf.scene,
+        expressionManager: gltf.userData.vrmExpressionManager,
+        firstPerson: gltf.userData.vrmFirstPerson,
+        humanoid,
+        lookAt: gltf.userData.vrmLookAt,
+        meta,
+      });
+
+      gltf.userData.vrmCore = vrmCore;
+    }
   }
 }

--- a/packages/three-vrm-core/src/VRMCoreParameters.ts
+++ b/packages/three-vrm-core/src/VRMCoreParameters.ts
@@ -9,9 +9,9 @@ import type { VRMMeta } from './meta/VRMMeta';
  */
 export interface VRMCoreParameters {
   scene: THREE.Group;
-  humanoid?: VRMHumanoid;
+  meta: VRMMeta;
+  humanoid: VRMHumanoid;
   expressionManager?: VRMExpressionManager;
   firstPerson?: VRMFirstPerson;
   lookAt?: VRMLookAt;
-  meta?: VRMMeta;
 }

--- a/packages/three-vrm/src/VRMLoaderPlugin.ts
+++ b/packages/three-vrm/src/VRMLoaderPlugin.ts
@@ -3,8 +3,10 @@ import { GLTF, GLTFLoaderPlugin, GLTFParser } from 'three/examples/jsm/loaders/G
 import {
   VRMExpressionLoaderPlugin,
   VRMFirstPersonLoaderPlugin,
+  VRMHumanoid,
   VRMHumanoidLoaderPlugin,
   VRMLookAtLoaderPlugin,
+  VRMMeta,
   VRMMetaLoaderPlugin,
 } from '@pixiv/three-vrm-core';
 import { MToonMaterialLoaderPlugin } from '@pixiv/three-vrm-materials-mtoon';
@@ -98,17 +100,25 @@ export class VRMLoaderPlugin implements GLTFLoaderPlugin {
     await this.nodeConstraintPlugin.afterRoot(gltf);
     await this.mtoonMaterialPlugin.afterRoot(gltf);
 
-    const vrm = new VRM({
-      scene: gltf.scene,
-      expressionManager: gltf.userData.vrmExpressionManager,
-      firstPerson: gltf.userData.vrmFirstPerson,
-      humanoid: gltf.userData.vrmHumanoid,
-      lookAt: gltf.userData.vrmLookAt,
-      meta: gltf.userData.vrmMeta,
-      materials: gltf.userData.vrmMToonMaterials,
-      springBoneManager: gltf.userData.vrmSpringBoneManager,
-      nodeConstraintManager: gltf.userData.vrmNodeConstraintManager,
-    });
-    gltf.userData.vrm = vrm;
+    const meta = gltf.userData.vrmMeta as VRMMeta | null;
+    const humanoid = gltf.userData.vrmHumanoid as VRMHumanoid | null;
+
+    // meta and humanoid are required to be a VRM.
+    // Don't create VRM if they are null
+    if (meta && humanoid) {
+      const vrm = new VRM({
+        scene: gltf.scene,
+        expressionManager: gltf.userData.vrmExpressionManager,
+        firstPerson: gltf.userData.vrmFirstPerson,
+        humanoid,
+        lookAt: gltf.userData.vrmLookAt,
+        meta,
+        materials: gltf.userData.vrmMToonMaterials,
+        springBoneManager: gltf.userData.vrmSpringBoneManager,
+        nodeConstraintManager: gltf.userData.vrmNodeConstraintManager,
+      });
+
+      gltf.userData.vrm = vrm;
+    }
   }
 }


### PR DESCRIPTION
### Description

VRM now requires meta and humanoid to instantiate

If loader could not find valid meta and humanoid, it does not create VRM object

this also fixes the bug where it loads a empty VRM class when the loaded glTF is not a VRM

VRM.meta and VRM.humanoid are no longer optional!
