### PR TITLE
fix: mixamoのモーション仕様変更への対応

### DIFF
--- a/packages/three-vrm-core/examples/humanoidAnimation/loadMixamoAnimation.js
+++ b/packages/three-vrm-core/examples/humanoidAnimation/loadMixamoAnimation.js
@@ -54,7 +54,7 @@ function loadMixamoAnimation( url, vrm ) {
 							.multiply( restRotationInverse )
 							.toArray( flatQuaternion );
 
-						flatQuaternion.map( ( v, index )=> track.values[ index + i ] = v );
+						flatQuaternion.map( ( v, index ) => track.values[ index + i ] = v );
 
 					}
 

--- a/packages/three-vrm-core/examples/humanoidAnimation/loadMixamoAnimation.js
+++ b/packages/three-vrm-core/examples/humanoidAnimation/loadMixamoAnimation.js
@@ -18,8 +18,7 @@ function loadMixamoAnimation( url, vrm ) {
 
 		const restRotationInverse = new THREE.Quaternion();
 		const parentRestWorldRotation = new THREE.Quaternion();
-		const targetRotation = new THREE.Quaternion();
-		const retargetRotation = new THREE.Quaternion();
+		const _quatA = new THREE.Quaternion();
 
 		clip.tracks.forEach( ( track ) => {
 
@@ -45,16 +44,20 @@ function loadMixamoAnimation( url, vrm ) {
 
 						const flatQuaternion = track.values.slice( i, i + 4 );
 
-						targetRotation
-							.fromArray( flatQuaternion )
-							.premultiply( parentRestWorldRotation );
+						_quatA.fromArray( flatQuaternion );
 
-						retargetRotation
-							.copy( targetRotation )
-							.multiply( restRotationInverse )
-							.toArray( flatQuaternion );
+						// 親のレスト時ワールド回転 * トラックの回転 * レスト時ワールド回転の逆
+						_quatA
+							.premultiply( parentRestWorldRotation )
+							.multiply( restRotationInverse );
 
-						flatQuaternion.map( ( v, index ) => track.values[ index + i ] = v );
+						_quatA.toArray( flatQuaternion );
+
+						flatQuaternion.forEach( ( v, index ) => {
+
+							track.values[ index + i ] = v;
+
+						} );
 
 					}
 

--- a/packages/three-vrm-core/examples/humanoidAnimation/loadMixamoAnimation.js
+++ b/packages/three-vrm-core/examples/humanoidAnimation/loadMixamoAnimation.js
@@ -7,7 +7,7 @@
  * @param {VRM} vrm A target VRM
  * @returns {Promise<THREE.AnimationClip>} The converted AnimationClip
  */
-function loadMixamoAnimation( url, vrm ) {
+ function loadMixamoAnimation( url, vrm ) {
 
 	const loader = new THREE.FBXLoader(); // A loader which loads FBX
 	return loader.loadAsync( url ).then( ( asset ) => {
@@ -16,6 +16,11 @@ function loadMixamoAnimation( url, vrm ) {
 
 		const tracks = []; // KeyframeTracks compatible with VRM will be added here
 
+		const restRotationInverse = new THREE.Quaternion();
+		const parentRestWorldRotation = new THREE.Quaternion();
+		const targetRotation = new THREE.Quaternion();
+		const retargetRotation = new THREE.Quaternion();
+
 		clip.tracks.forEach( ( track ) => {
 
 			// Convert each tracks for VRM use, and push to `tracks`
@@ -23,12 +28,35 @@ function loadMixamoAnimation( url, vrm ) {
 			const mixamoRigName = trackSplitted[ 0 ];
 			const vrmBoneName = mixamoVRMRigMap[ mixamoRigName ];
 			const vrmNodeName = vrm.humanoid?.getNormalizedBoneNode( vrmBoneName )?.name;
+			const mixamoRigNode = asset.getObjectByName( mixamoRigName );
 
 			if ( vrmNodeName != null ) {
 
 				const propertyName = trackSplitted[ 1 ];
 
+				// Store rotations of rest-pose.
+				mixamoRigNode.getWorldQuaternion( restRotationInverse ).invert();
+				mixamoRigNode.parent.getWorldQuaternion( parentRestWorldRotation );
+
 				if ( track instanceof THREE.QuaternionKeyframeTrack ) {
+
+					// Retarget rotation of mixamoRig to NormalizedBone.
+					for ( let i = 0; i < track.values.length; i += 4 ) {
+
+						const flatQuaternion = track.values.slice( i, i + 4 );
+
+						targetRotation
+							.fromArray( flatQuaternion )
+							.premultiply( parentRestWorldRotation );
+
+						retargetRotation
+							.copy( targetRotation )
+							.multiply( restRotationInverse )
+							.toArray( flatQuaternion );
+
+						flatQuaternion.map( ( v, index )=> track.values[ index + i ] = v );
+
+					}
 
 					tracks.push(
 						new THREE.QuaternionKeyframeTrack(

--- a/packages/three-vrm-core/examples/humanoidAnimation/loadMixamoAnimation.js
+++ b/packages/three-vrm-core/examples/humanoidAnimation/loadMixamoAnimation.js
@@ -7,7 +7,7 @@
  * @param {VRM} vrm A target VRM
  * @returns {Promise<THREE.AnimationClip>} The converted AnimationClip
  */
- function loadMixamoAnimation( url, vrm ) {
+function loadMixamoAnimation( url, vrm ) {
 
 	const loader = new THREE.FBXLoader(); // A loader which loads FBX
 	return loader.loadAsync( url ).then( ( asset ) => {

--- a/packages/three-vrm/examples/humanoidAnimation/loadMixamoAnimation.js
+++ b/packages/three-vrm/examples/humanoidAnimation/loadMixamoAnimation.js
@@ -54,7 +54,7 @@ function loadMixamoAnimation( url, vrm ) {
 							.multiply( restRotationInverse )
 							.toArray( flatQuaternion );
 
-						flatQuaternion.map( ( v, index )=> track.values[ index + i ] = v );
+						flatQuaternion.map( ( v, index ) => track.values[ index + i ] = v );
 
 					}
 

--- a/packages/three-vrm/examples/humanoidAnimation/loadMixamoAnimation.js
+++ b/packages/three-vrm/examples/humanoidAnimation/loadMixamoAnimation.js
@@ -18,8 +18,7 @@ function loadMixamoAnimation( url, vrm ) {
 
 		const restRotationInverse = new THREE.Quaternion();
 		const parentRestWorldRotation = new THREE.Quaternion();
-		const targetRotation = new THREE.Quaternion();
-		const retargetRotation = new THREE.Quaternion();
+		const _quatA = new THREE.Quaternion();
 
 		clip.tracks.forEach( ( track ) => {
 
@@ -45,16 +44,20 @@ function loadMixamoAnimation( url, vrm ) {
 
 						const flatQuaternion = track.values.slice( i, i + 4 );
 
-						targetRotation
-							.fromArray( flatQuaternion )
-							.premultiply( parentRestWorldRotation );
+						_quatA.fromArray( flatQuaternion );
 
-						retargetRotation
-							.copy( targetRotation )
-							.multiply( restRotationInverse )
-							.toArray( flatQuaternion );
+						// 親のレスト時ワールド回転 * トラックの回転 * レスト時ワールド回転の逆
+						_quatA
+							.premultiply( parentRestWorldRotation )
+							.multiply( restRotationInverse );
 
-						flatQuaternion.map( ( v, index ) => track.values[ index + i ] = v );
+						_quatA.toArray( flatQuaternion );
+
+						flatQuaternion.forEach( ( v, index ) => {
+
+							track.values[ index + i ] = v;
+
+						} );
 
 					}
 


### PR DESCRIPTION
mixamoのモーションをNormalizedBone用に変換し、アニメーショントラックに格納する処理を追加

ローカル軸が正規化されていないrigにバインドされたアニメーションでもvrmに適用できるようになったため、
新旧どちらのFBXファイルにおいても同様にアニメーションの再生ができる。

https://github.com/pixiv/three-vrm/pull/889#issuecomment-1231434269