### PR TITLE
examplesでgetBoneNodeを使用している箇所をNormalizedに変更

### DIFF
--- a/packages/three-vrm-core/src/VRMCore.ts
+++ b/packages/three-vrm-core/src/VRMCore.ts
@@ -24,7 +24,7 @@ export class VRMCore {
 
   /**
    * Contains {@link VRMHumanoid} of the VRM.
-   * You can control each bones using {@link VRMHumanoid.getBoneNode}.
+   * You can control each bones using {@link VRMHumanoid.getNormalizedBoneNode} or {@link VRMHumanoid.getRawBoneNode}.
    *
    * @TODO Add a link to VRM spec
    */

--- a/packages/three-vrm/examples/animations.html
+++ b/packages/three-vrm/examples/animations.html
@@ -97,7 +97,7 @@
 				quatB.setFromEuler( new THREE.Euler( 0.0, 0.0, 0.25 * Math.PI ) );
 
 				const armTrack = new THREE.QuaternionKeyframeTrack(
-					vrm.humanoid.getBoneNode( THREE_VRM.VRMHumanBoneName.LeftUpperArm ).name + '.quaternion', // name
+					vrm.humanoid.getNormalizedBoneNode( THREE_VRM.VRMHumanBoneName.LeftUpperArm ).name + '.quaternion', // name
 					[ 0.0, 0.5, 1.0 ], // times
 					[ ...quatA.toArray(), ...quatB.toArray(), ...quatA.toArray() ] // values
 				);

--- a/packages/three-vrm/examples/bones.html
+++ b/packages/three-vrm/examples/bones.html
@@ -104,9 +104,9 @@
 
 					// tweak bones
 					const s = 0.25 * Math.PI * Math.sin( Math.PI * clock.elapsedTime );
-					currentVrm.humanoid.getBoneNode( THREE_VRM.VRMHumanBoneName.Neck ).rotation.y = s;
-					currentVrm.humanoid.getBoneNode( THREE_VRM.VRMHumanBoneName.LeftUpperArm ).rotation.z = s;
-					currentVrm.humanoid.getBoneNode( THREE_VRM.VRMHumanBoneName.RightUpperArm ).rotation.x = s;
+					currentVrm.humanoid.getNormalizedBoneNode( THREE_VRM.VRMHumanBoneName.Neck ).rotation.y = s;
+					currentVrm.humanoid.getNormalizedBoneNode( THREE_VRM.VRMHumanBoneName.LeftUpperArm ).rotation.z = s;
+					currentVrm.humanoid.getNormalizedBoneNode( THREE_VRM.VRMHumanBoneName.RightUpperArm ).rotation.x = s;
 
 					// update vrm
 					currentVrm.update( deltaTime );

--- a/packages/three-vrm/examples/mouse.html
+++ b/packages/three-vrm/examples/mouse.html
@@ -113,7 +113,7 @@
 					const px = ( 2.0 * event.clientX - window.innerWidth ) / window.innerHeight * range;
 					const py = -( 2.0 * event.clientY - window.innerHeight ) / window.innerHeight * range;
 
-					currentVrm.humanoid.getBoneNode( THREE_VRM.VRMHumanBoneName.Hips ).position.set( px, py, 0.0 );
+					currentVrm.humanoid.getNormalizedBoneNode( THREE_VRM.VRMHumanBoneName.Hips ).position.set( px, py, 0.0 );
 
 				}
 


### PR DESCRIPTION
# Description 

examplesでgetBoneNodeを使用している箇所をNormalizedに変更します。
- getBoneNode => getNormalizedBoneNode

getBone/getBoneNodeは非推奨となりました。
また、VRM1.0の仕様変更からexamplesでの今回の該当箇所ではgetNormalizedBoneを使用する方が望ましいため変更しました。