### PR TITLE
ドキュメントの公開場所とマイグレーションガイドを追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,11 @@ Use [VRM](https://vrm.dev/) on [three.js](https://threejs.org/)
 
 [Examples](https://pixiv.github.io/three-vrm/packages/three-vrm/examples)
 
-[Documentation](https://pixiv.github.io/three-vrm/packages/three-vrm/docs)
+[Documentation](docs/README.md)
+
+- > TODO: Fix URL
+
+[API Reference](https://pixiv.github.io/three-vrm/packages/three-vrm/docs)
 
 ## How to Use
 
@@ -19,8 +23,8 @@ You will need:
 - [Three.js build](https://github.com/mrdoob/three.js/blob/master/build/three.js)
 - [GLTFLoader](https://github.com/mrdoob/three.js/blob/master/examples/js/loaders/GLTFLoader.js)
 - [A build of @pixiv/three-vrm](https://unpkg.com/browse/@pixiv/three-vrm/lib/)
-	- `.module` ones are ESM, otherwise it's UMD and injects its modules into global `THREE`
-	- `.min` ones are minified (for production), otherwise it's not minified and it comes with source maps
+  - `.module` ones are ESM, otherwise it's UMD and injects its modules into global `THREE`
+  - `.min` ones are minified (for production), otherwise it's not minified and it comes with source maps
 
 Code like this:
 
@@ -30,43 +34,37 @@ Code like this:
 <script src="three-vrm.js"></script>
 
 <script>
-const scene = new THREE.Scene();
+  const scene = new THREE.Scene();
 
-const loader = new THREE.GLTFLoader();
+  const loader = new THREE.GLTFLoader();
 
-// Install GLTFLoader plugin
-loader.register( ( parser ) => {
+  // Install GLTFLoader plugin
+  loader.register((parser) => {
+    return new THREE_VRM.VRMLoaderPlugin(parser);
+  });
 
-	return new THREE_VRM.VRMLoaderPlugin( parser );
+  loader.load(
+    // URL of the VRM you want to load
+    '/models/three-vrm-girl.vrm',
 
-} );
+    // called when the resource is loaded
+    (gltf) => {
+      // retrieve a VRM instance from gltf
+      const vrm = gltf.userData.vrm;
 
-loader.load(
+      // add the loaded vrm to the scene
+      scene.add(vrm.scene);
 
-	// URL of the VRM you want to load
-	'/models/three-vrm-girl.vrm',
+      // deal with vrm features
+      console.log(vrm);
+    },
 
-	// called when the resource is loaded
-	( gltf ) => {
+    // called while loading is progressing
+    (progress) => console.log('Loading model...', 100.0 * (progress.loaded / progress.total), '%'),
 
-		// retrieve a VRM instance from gltf
-		const vrm = gltf.userData.vrm;
-
-		// add the loaded vrm to the scene
-		scene.add( vrm.scene );
-
-		// deal with vrm features
-		console.log( vrm );
-
-	},
-
-	// called while loading is progressing
-	( progress ) => console.log( 'Loading model...', 100.0 * ( progress.loaded / progress.total ), '%' ),
-
-	// called when loading has errors
-	( error ) => console.error( error )
-
-);
+    // called when loading has errors
+    (error) => console.error(error),
+  );
 </script>
 ```
 
@@ -90,37 +88,31 @@ const scene = new THREE.Scene();
 const loader = new GLTFLoader();
 
 // Install GLTFLoader plugin
-loader.register( ( parser ) => {
-
-	return new VRMLoaderPlugin( parser );
-
-} );
+loader.register((parser) => {
+  return new VRMLoaderPlugin(parser);
+});
 
 loader.load(
+  // URL of the VRM you want to load
+  '/models/three-vrm-girl.vrm',
 
-	// URL of the VRM you want to load
-	'/models/three-vrm-girl.vrm',
+  // called when the resource is loaded
+  (gltf) => {
+    // retrieve a VRM instance from gltf
+    const vrm = gltf.userData.vrm;
 
-	// called when the resource is loaded
-	( gltf ) => {
+    // add the loaded vrm to the scene
+    scene.add(vrm.scene);
 
-		// retrieve a VRM instance from gltf
-		const vrm = gltf.userData.vrm;
+    // deal with vrm features
+    console.log(vrm);
+  },
 
-		// add the loaded vrm to the scene
-		scene.add( vrm.scene );
+  // called while loading is progressing
+  (progress) => console.log('Loading model...', 100.0 * (progress.loaded / progress.total), '%'),
 
-		// deal with vrm features
-		console.log( vrm );
-
-	},
-
-	// called while loading is progressing
-	( progress ) => console.log( 'Loading model...', 100.0 * ( progress.loaded / progress.total ), '%' ),
-
-	// called when loading has errors
-	( error ) => console.error( error )
-
+  // called when loading has errors
+  (error) => console.error(error),
 );
 ```
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,5 @@
+# Documentation
+
+## Developer Guide
+
+- [v1.0 - Migration guide](migration-guide-1.0.md)

--- a/docs/migration-guide-1.0.md
+++ b/docs/migration-guide-1.0.md
@@ -2,8 +2,6 @@
 
 `v0.6.x` -> `v1.0.0-beta.19`
 
-> test
-
 ## Overall
 
 ### It’s now a Loader Plugin

--- a/docs/migration-guide-1.0.md
+++ b/docs/migration-guide-1.0.md
@@ -1,0 +1,224 @@
+# three-vrm v1.0 - migration guide
+
+`v1.0.0-beta.19`
+
+## Overall
+
+### It’s now a Loader Plugin
+
+three-vrm v1 is implemented as a Loader Plugin of GLTFLoader.
+
+Both `VRM.from` and `VRMImporter` are removed.
+
+You are going to use the new `VRMLoaderPlugin` with the GLTFLoader instead.
+
+See the example code below:
+
+```jsx
+const loader = new THREE.GLTFLoader();
+
+loader.register((parser) => new VRMLoaderPlugin(parser)); // here we are installing VRMLoaderPlugin
+
+return loader.loadAsync(modelUrl).then((gltf) => {
+  const vrm = gltf.userData.vrm; // `VRM` is loaded inside `gltf.userData.vrm`
+
+  VRMUtils.rotateVRM0(vrm); // rotate the vrm around y axis if the vrm is VRM0.0
+
+  return vrm;
+});
+```
+
+### Linear Workflows
+
+In VRM1.0, linear workflow is explicitly recommended, [as GLTFLoader recommends](https://threejs.org/docs/#examples/en/loaders/GLTFLoader).
+
+You should enable the linear workflow.
+
+```jsx
+renderer.outputEncoding = THREE.sRGBEncoding;
+```
+
+### VRMUtils.rotateVRM0
+
+I have already used this in the example above but there is a utility function called `VRMUtils.rotateVRM0`.
+
+In VRM1.0, the facing direction of the model has been changed from Y- to Y+.
+
+`VRMUtils.rotateVRM0` rotates the VRM model if the VRM is VRM0.0 and faces backward.
+
+Use this function to make your app compatible with both VRM0.0 and VRM1.0.
+
+```tsx
+VRMUtils.rotateVRM0(eitherVRM0or1);
+```
+
+### VRMUtils.deepDispose
+
+We have removed `vrm.dispose` since it does not contain any VRM-specific disposal procedures.
+
+We still have our utility function `VRMUtils.deepDispose`.
+
+Call this before you unload your VRM scene.
+
+```tsx
+VRMUtils.deepDispose(vrm.scene);
+```
+
+### Helper / Debug
+
+`VRMDebug` has been removed.
+
+You can give `helperRoot` to the options of `VRMLoaderPlugin` instead to enable helpers for VRM components.
+
+We currently have helpers for humanoid, lookAt, springBone, and constraints.
+
+```tsx
+const helperRoot = new THREE.Group();
+helperRoot.renderOrder = 10000;
+scene.add(helperRoot);
+
+loader.register((parser) => {
+  // assigning `helperRoot` to options will make helpers appear
+  return new THREE_VRM.VRMLoaderPlugin(parser, { helperRoot });
+});
+```
+
+### VRMSchema
+
+`VRMSchema` has been removed.
+
+Instead, we have a new package `@pixiv/types-vrm-0.0`, which provides the type definition of the VRM0.0 schema.
+
+Also, there are type definition packages of VRM1.0 schema such as `@pixiv/types-vrmc-vrm-1.0`.
+
+```tsx
+import type * as V1VRMSchema from '@pixiv/types-vrmc-vrm-1.0';
+
+const extension = json.extensions?.['VRMC_vrm'] as V1VRMSchema.VRMCVRM | undefined;
+```
+
+### GLTFSchema
+
+`GLTFSchema` has been removed.
+
+If you are already referring to GLTF schema in your code, we recommend using type definitions provided from `@gltf-transform/core`.
+
+```tsx
+import { GLTF as GLTFSchema } from '@gltf-transform/core';
+
+const json = gltf.parser.json as GLTFSchema.IGLTF;
+```
+
+## Meta
+
+### VRM1Meta
+
+In VRM1.0, the structure of `meta` has been reworked.
+
+We also have an interface `VRM0Meta` which is compatible with VRM0.0.
+
+`VRM.meta` might have either `VRM1Meta` or `VRM0Meta`.
+
+`VRM0Meta` and `VRM1Meta` have a member `.metaVersion` to distinguish each other.
+
+```tsx
+// vrm.meta: VRM0Meta | VRM1Meta
+
+if (vrm.meta.metaVersion === '0') {
+  // vrm.meta: VRM0Meta
+} else if (vrm.meta.metaVersion === '1') {
+  // vrm.meta: VRM1Meta
+}
+```
+
+### thumbnailImage and VRMUtils.extractThumbnailBlob
+
+In VRM1.0, `meta.texture` is `meta.thumbnailImage` instead, and it is an image instead of a texture.
+
+We have removed `VRMUtils.extractThumbnailBlob` for now due to this change (plus it's buggy).
+
+If public demand is high enough, we will consider having a utility function that handles both VRM0.0 and VRM1.0 and return an appropriate thumbnail image.
+
+## Humanoid
+
+### Normalized Human Bones
+
+From VRM1.0, VRM models can have “non-normalized” orientations for each human bone.
+
+Due to this change, we introduce a feature to access “normalized” human bones to maintain compatibility between models with different bone orientations.
+
+Normalized human bones have identity orientation (`[0, 0, 0; 1]` in quaternion) in its rest pose.
+
+Almost all members of `VRMHumanoid` existed in v0.x were deprecated.
+
+We now have members to access raw (original) human bones and normalized human bones instead.
+
+For example, you can get a `THREE.Object3D` of a human bone by either `VRMHumanoid.getRawBoneNode` or `VRMHumanoid.getNormalizedBoneNode`.
+
+Normalized human bones are proxy objects of raw human bones.
+
+Operations applied to normalized human bones are automatically synced to raw human bones upon `VRM.update` or `VRMHumanoid.update`.
+
+If you don’t need this behavior, set `VRMHumanoid.autoUpdateHumanBones` to `false`.
+
+See the example: `TODO`
+
+See the documentation: `TODO`
+
+### VRMSchema.HumanoidBoneName
+
+There is a union type/const called `VRMHumanBoneName` instead.
+
+### VRMHumanoid.getBones / VRMHumanoid.getBoneNodes
+
+In VRM1.0, VRMs no longer can multiple nodes for a single bone at once.
+
+Due to this change, we have removed `VRMHumanoid.getBones` and `VRMHumanoid.getBoneNodes`.
+
+## Expressions (previously BlendShapeProxy)
+
+### Renamed, BlendShapeProxy → Expressions
+
+In VRM1.0, BlendShapeProxy is renamed to Expressions.
+
+Due to this change, we also renamed our BlendShapeProxy APIs to Expressions.
+
+`VRM.blendShapeProxy` should be renamed to `VRM.expressionManager`, for example.
+
+### VRMSchema.BlendShapePresetName
+
+There is a union type/const called `VRMExpressionPresetName` instead.
+
+The first argument of `VRMExpressionManager.setValue()` is no longer enum; you can use string instead.
+
+```tsx
+vrm.expressionManager.setValue('happy', 1.0); // 😄
+```
+
+## FirstPerson
+
+### VRMFirstPerson.firstPersonBone
+
+In VRM1.0, FirstPersonBone is removed. You should use the head of Humanoid instead.
+
+### VRMFirstPerson.firstPersonBoneOffset
+
+`VRMFirstPerson.firstPersonBoneOffset` is removed.
+
+You might want to use `VRMLookAt.offsetFromHeadBone` instead.
+
+## MToonMaterial
+
+### The interface must have been largely changed
+
+MToon has been largely reworked from the VRM0.0 one.
+
+Think like the VRM1.0 MToon is basically a totally different material.
+
+See the documentation: `TODO`
+
+### v0CompatShade
+
+In VRM1.0, how MToon renders shade parts of materials has been changed.
+
+If you want to use the old MToon behavior, change `MToonMaterial.v0CompatShade` to `true`.

--- a/docs/migration-guide-1.0.md
+++ b/docs/migration-guide-1.0.md
@@ -1,6 +1,8 @@
-# three-vrm v1.0 - migration guide
+# Migration Guide `v0.6.x` -> `v1.0.0-beta.19`
 
-`v1.0.0-beta.19`
+`v0.6.x` -> `v1.0.0-beta.19`
+
+> test
 
 ## Overall
 


### PR DESCRIPTION
マイグレーションガイドなどのドキュメント置き場として/docsを追加しました。

# Description

ドキュメントの公開方法について検討を行いましたが、いったんマークダウンファイルをこのリポジトリ内の/docsディレクトリで管理することにしました。

変更点
- Document用のREADME
  - https://github.com/pixiv/three-vrm/tree/docs/migration-guide/docs
- v0.6 -> v1.0へのマイグレーションガイド
  - https://github.com/pixiv/three-vrm/blob/docs/migration-guide/docs/migration-guide-1.0.md
- TypeDocから生成したドキュメントへの動線の名前を変更
  - リンク名変更 Documentation -> API Reference
  - https://github.com/pixiv/three-vrm/tree/docs/migration-guide#pixivthree-vrm
