### PR TITLE
BREAKING change: VRMHumanoidの引数でautoUpdateHumanBonesの渡し方を変更

### DIFF
--- a/packages/three-vrm-core/src/humanoid/VRMHumanoid.ts
+++ b/packages/three-vrm-core/src/humanoid/VRMHumanoid.ts
@@ -87,8 +87,8 @@ export class VRMHumanoid {
    * @param humanBones A {@link VRMHumanBones} contains all the bones of the new humanoid
    * @param autoUpdateHumanBones Whether it copies pose from normalizedHumanBones to rawHumanBones on {@link update}. `true` by default.
    */
-  public constructor(humanBones: VRMHumanBones, autoUpdateHumanBones = true) {
-    this.autoUpdateHumanBones = autoUpdateHumanBones;
+  public constructor(humanBones: VRMHumanBones, options?: { autoUpdateHumanBones?: boolean }) {
+    this.autoUpdateHumanBones = options?.autoUpdateHumanBones ?? true;
     this._rawHumanBones = new VRMRig(humanBones);
     this._normalizedHumanBones = new VRMHumanoidRig(this._rawHumanBones);
   }
@@ -111,7 +111,7 @@ export class VRMHumanoid {
    * @returns Copied {@link VRMHumanoid}
    */
   public clone(): VRMHumanoid {
-    return new VRMHumanoid(this.humanBones, this.autoUpdateHumanBones).copy(this);
+    return new VRMHumanoid(this.humanBones, { autoUpdateHumanBones: this.autoUpdateHumanBones }).copy(this);
   }
 
   /**

--- a/packages/three-vrm-core/src/humanoid/VRMHumanoidLoaderPlugin.ts
+++ b/packages/three-vrm-core/src/humanoid/VRMHumanoidLoaderPlugin.ts
@@ -130,7 +130,9 @@ export class VRMHumanoidLoaderPlugin implements GLTFLoaderPlugin {
       );
     }
 
-    const humanoid = new VRMHumanoid(this._ensureRequiredBonesExist(humanBones), this.autoUpdateHumanBones);
+    const humanoid = new VRMHumanoid(this._ensureRequiredBonesExist(humanBones), {
+      autoUpdateHumanBones: this.autoUpdateHumanBones,
+    });
     gltf.scene.add(humanoid.normalizedHumanBonesRoot);
 
     if (this.helperRoot) {
@@ -193,7 +195,9 @@ export class VRMHumanoidLoaderPlugin implements GLTFLoaderPlugin {
       );
     }
 
-    const humanoid = new VRMHumanoid(this._ensureRequiredBonesExist(humanBones));
+    const humanoid = new VRMHumanoid(this._ensureRequiredBonesExist(humanBones), {
+      autoUpdateHumanBones: this.autoUpdateHumanBones,
+    });
     gltf.scene.add(humanoid.normalizedHumanBonesRoot);
 
     if (this.helperRoot) {


### PR DESCRIPTION

# Description
 VRMHumanoidの引数でautoUpdateHumanBonesの渡し方を変更します。

autoUpdateHumanBonesはオブジェクトのプロパティとして渡します。
デフォルト値は変わらず`true`です


- `new VRMHumanoid(humanBones, true)`
||
V
- `new VRMHumanoid(humanBones, { autoUpdateHumanBones: true })`