### PR TITLE
/packages/three-vrm/README.mdにdocsへのリンクを追加

### DIFF
--- a/packages/three-vrm/README.md
+++ b/packages/three-vrm/README.md
@@ -8,7 +8,9 @@ Use [VRM](https://vrm.dev/) on [three.js](https://threejs.org/)
 
 [Examples](https://pixiv.github.io/three-vrm/packages/three-vrm/examples)
 
-[Documentation](https://pixiv.github.io/three-vrm/packages/three-vrm/docs)
+[Documentation](/docs/README.md)
+
+[API Reference](https://pixiv.github.io/three-vrm/packages/three-vrm/docs)
 
 ## How to Use
 


### PR DESCRIPTION
# Description

/packages/three-vrm/README.md内のドキュメントへのリンクを変更しました。

マイグレーションガイドなどのドキュメントを/docs下へ配置し、
これまでのDocumentationはAPIリファレンスと呼ぶことにします。



このPRはhttps://github.com/pixiv/three-vrm/pull/1037#issuecomment-1237914052 についての対応です。
> 合わせて /packages/three-vrm/README.md も更新お願いします。ルートのREADMEと同じ内容で大丈夫です。

