### PR TITLE
prepare for 1.0 release

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Code like this:
 
   loader.load(
     // URL of the VRM you want to load
-    '/models/three-vrm-girl.vrm',
+    '/models/VRM1_Constraint_Twist_Sample.vrm',
 
     // called when the resource is loaded
     (gltf) => {
@@ -94,7 +94,7 @@ loader.register((parser) => {
 
 loader.load(
   // URL of the VRM you want to load
-  '/models/three-vrm-girl.vrm',
+  '/models/VRM1_Constraint_Twist_Sample.vrm',
 
   // called when the resource is loaded
   (gltf) => {

--- a/packages/three-vrm-core/examples/models/cube.gltf
+++ b/packages/three-vrm-core/examples/models/cube.gltf
@@ -429,7 +429,7 @@
   ],
   "extensions": {
     "VRMC_vrm": {
-      "specVersion": "1.0-beta",
+      "specVersion": "1.0",
       "meta": {
         "name": "Cube",
         "version": "1.0.0",

--- a/packages/three-vrm-core/src/expressions/VRMExpressionLoaderPlugin.ts
+++ b/packages/three-vrm-core/src/expressions/VRMExpressionLoaderPlugin.ts
@@ -14,6 +14,11 @@ import { VRMExpressionTextureTransformBind } from './VRMExpressionTextureTransfo
 import { GLTF as GLTFSchema } from '@gltf-transform/core';
 
 /**
+ * Possible spec versions it recognizes.
+ */
+const POSSIBLE_SPEC_VERSIONS = new Set(['1.0', '1.0-beta']);
+
+/**
  * A plugin of GLTFLoader that imports a {@link VRMExpressionManager} from a VRM extension of a GLTF.
  */
 export class VRMExpressionLoaderPlugin implements GLTFLoaderPlugin {
@@ -88,7 +93,8 @@ export class VRMExpressionLoaderPlugin implements GLTFLoaderPlugin {
     }
 
     const specVersion = extension.specVersion;
-    if (specVersion !== '1.0-beta') {
+    if (!POSSIBLE_SPEC_VERSIONS.has(specVersion)) {
+      console.warn(`VRMExpressionLoaderPlugin: Unknown VRMC_vrm specVersion "${specVersion}"`);
       return null;
     }
 

--- a/packages/three-vrm-core/src/firstPerson/VRMFirstPersonLoaderPlugin.ts
+++ b/packages/three-vrm-core/src/firstPerson/VRMFirstPersonLoaderPlugin.ts
@@ -9,6 +9,11 @@ import type { VRMFirstPersonMeshAnnotationType } from './VRMFirstPersonMeshAnnot
 import { GLTF as GLTFSchema } from '@gltf-transform/core';
 
 /**
+ * Possible spec versions it recognizes.
+ */
+const POSSIBLE_SPEC_VERSIONS = new Set(['1.0', '1.0-beta']);
+
+/**
  * A plugin of GLTFLoader that imports a {@link VRMFirstPerson} from a VRM extension of a GLTF.
  */
 export class VRMFirstPersonLoaderPlugin implements GLTFLoaderPlugin {
@@ -79,7 +84,8 @@ export class VRMFirstPersonLoaderPlugin implements GLTFLoaderPlugin {
     }
 
     const specVersion = extension.specVersion;
-    if (specVersion !== '1.0-beta') {
+    if (!POSSIBLE_SPEC_VERSIONS.has(specVersion)) {
+      console.warn(`VRMFirstPersonLoaderPlugin: Unknown VRMC_vrm specVersion "${specVersion}"`);
       return null;
     }
 

--- a/packages/three-vrm-core/src/humanoid/VRMHumanBoneName.ts
+++ b/packages/three-vrm-core/src/humanoid/VRMHumanBoneName.ts
@@ -3,7 +3,7 @@
 /**
  * The names of {@link VRMHumanoid} bone names.
  *
- * Ref: https://github.com/vrm-c/vrm-specification/blob/master/specification/VRMC_vrm-1.0-beta/humanoid.md
+ * Ref: https://github.com/vrm-c/vrm-specification/blob/master/specification/VRMC_vrm-1.0/humanoid.md
  */
 export const VRMHumanBoneName = {
   Hips: 'hips',

--- a/packages/three-vrm-core/src/humanoid/VRMHumanBoneParentMap.ts
+++ b/packages/three-vrm-core/src/humanoid/VRMHumanBoneParentMap.ts
@@ -5,7 +5,7 @@ import { VRMHumanBoneName } from './VRMHumanBoneName';
 /**
  * An object that maps from {@link VRMHumanBoneName} to its parent {@link VRMHumanBoneName}.
  *
- * Ref: https://github.com/vrm-c/vrm-specification/blob/master/specification/VRMC_vrm-1.0-beta/humanoid.md
+ * Ref: https://github.com/vrm-c/vrm-specification/blob/master/specification/VRMC_vrm-1.0/humanoid.md
  */
 export const VRMHumanBoneParentMap: { [bone in VRMHumanBoneName]: VRMHumanBoneName | null } = {
   hips: null,

--- a/packages/three-vrm-core/src/humanoid/VRMHumanoidLoaderPlugin.ts
+++ b/packages/three-vrm-core/src/humanoid/VRMHumanoidLoaderPlugin.ts
@@ -9,6 +9,11 @@ import { VRMHumanoidHelper } from './helpers/VRMHumanoidHelper';
 import { VRMHumanoidLoaderPluginOptions } from './VRMHumanoidLoaderPluginOptions';
 
 /**
+ * Possible spec versions it recognizes.
+ */
+const POSSIBLE_SPEC_VERSIONS = new Set(['1.0', '1.0-beta']);
+
+/**
  * A map from old thumb bone names to new thumb bone names
  */
 const thumbBoneNameMap: { [key: string]: V1VRMSchema.HumanoidHumanBoneName | undefined } = {
@@ -83,7 +88,8 @@ export class VRMHumanoidLoaderPlugin implements GLTFLoaderPlugin {
     }
 
     const specVersion = extension.specVersion;
-    if (specVersion !== '1.0-beta') {
+    if (!POSSIBLE_SPEC_VERSIONS.has(specVersion)) {
+      console.warn(`VRMHumanoidLoaderPlugin: Unknown VRMC_vrm specVersion "${specVersion}"`);
       return null;
     }
 

--- a/packages/three-vrm-core/src/lookAt/VRMLookAtLoaderPlugin.ts
+++ b/packages/three-vrm-core/src/lookAt/VRMLookAtLoaderPlugin.ts
@@ -13,6 +13,11 @@ import { VRMLookAtRangeMap } from './VRMLookAtRangeMap';
 import { GLTF as GLTFSchema } from '@gltf-transform/core';
 
 /**
+ * Possible spec versions it recognizes.
+ */
+const POSSIBLE_SPEC_VERSIONS = new Set(['1.0', '1.0-beta']);
+
+/**
  * A plugin of GLTFLoader that imports a {@link VRMLookAt} from a VRM extension of a GLTF.
  */
 export class VRMLookAtLoaderPlugin implements GLTFLoaderPlugin {
@@ -44,9 +49,7 @@ export class VRMLookAtLoaderPlugin implements GLTFLoaderPlugin {
     if (vrmHumanoid === null) {
       return;
     } else if (vrmHumanoid === undefined) {
-      throw new Error(
-        'VRMFirstPersonLoaderPlugin: vrmHumanoid is undefined. VRMHumanoidLoaderPlugin have to be used first',
-      );
+      throw new Error('VRMLookAtLoaderPlugin: vrmHumanoid is undefined. VRMHumanoidLoaderPlugin have to be used first');
     }
 
     const vrmExpressionManager = gltf.userData.vrmExpressionManager as VRMExpressionManager | undefined;
@@ -55,7 +58,7 @@ export class VRMLookAtLoaderPlugin implements GLTFLoaderPlugin {
       return;
     } else if (vrmExpressionManager === undefined) {
       throw new Error(
-        'VRMFirstPersonLoaderPlugin: vrmExpressionManager is undefined. VRMExpressionLoaderPlugin have to be used first',
+        'VRMLookAtLoaderPlugin: vrmExpressionManager is undefined. VRMExpressionLoaderPlugin have to be used first',
       );
     }
 
@@ -110,7 +113,8 @@ export class VRMLookAtLoaderPlugin implements GLTFLoaderPlugin {
     }
 
     const specVersion = extension.specVersion;
-    if (specVersion !== '1.0-beta') {
+    if (!POSSIBLE_SPEC_VERSIONS.has(specVersion)) {
+      console.warn(`VRMLookAtLoaderPlugin: Unknown VRMC_vrm specVersion "${specVersion}"`);
       return null;
     }
 

--- a/packages/three-vrm-core/src/meta/VRMMetaLoaderPlugin.ts
+++ b/packages/three-vrm-core/src/meta/VRMMetaLoaderPlugin.ts
@@ -10,6 +10,11 @@ import { resolveURL } from '../utils/resolveURL';
 import { GLTF as GLTFSchema } from '@gltf-transform/core';
 
 /**
+ * Possible spec versions it recognizes.
+ */
+const POSSIBLE_SPEC_VERSIONS = new Set(['1.0', '1.0-beta']);
+
+/**
  * A plugin of GLTFLoader that imports a {@link VRM1Meta} from a VRM extension of a GLTF.
  */
 export class VRMMetaLoaderPlugin implements GLTFLoaderPlugin {
@@ -81,7 +86,8 @@ export class VRMMetaLoaderPlugin implements GLTFLoaderPlugin {
     }
 
     const specVersion = extension.specVersion;
-    if (specVersion !== '1.0-beta') {
+    if (!POSSIBLE_SPEC_VERSIONS.has(specVersion)) {
+      console.warn(`VRMMetaLoaderPlugin: Unknown VRMC_vrm specVersion "${specVersion}"`);
       return null;
     }
 

--- a/packages/three-vrm-materials-mtoon/examples/models/cube.gltf
+++ b/packages/three-vrm-materials-mtoon/examples/models/cube.gltf
@@ -167,7 +167,7 @@
       "doubleSided": false,
       "extensions": {
         "VRMC_materials_mtoon": {
-          "specVersion": "1.0-beta",
+          "specVersion": "1.0",
           "transparentWithZWrite": false,
           "renderQueueOffsetNumber": 0,
           "shadeColorFactor": [ 0.9, 0.5, 0.4 ],

--- a/packages/three-vrm-materials-mtoon/examples/models/khr-materials-emissive-strength-test.gltf
+++ b/packages/three-vrm-materials-mtoon/examples/models/khr-materials-emissive-strength-test.gltf
@@ -134,7 +134,7 @@
       },
       "extensions": {
         "VRMC_materials_mtoon": {
-          "specVersion": "1.0-beta",
+          "specVersion": "1.0",
           "shadeColorFactor": [
             0.5,
             0.25,
@@ -160,7 +160,7 @@
       ],
       "extensions": {
         "VRMC_materials_mtoon": {
-          "specVersion": "1.0-beta",
+          "specVersion": "1.0",
           "shadeColorFactor": [
             0,
             0,
@@ -189,7 +189,7 @@
           "emissiveStrength": 10
         },
         "VRMC_materials_mtoon": {
-          "specVersion": "1.0-beta",
+          "specVersion": "1.0",
           "shadeColorFactor": [
             0,
             0,

--- a/packages/three-vrm-materials-mtoon/src/MToonMaterialLoaderPlugin.ts
+++ b/packages/three-vrm-materials-mtoon/src/MToonMaterialLoaderPlugin.ts
@@ -9,6 +9,11 @@ import { MToonMaterialLoaderPluginOptions } from './MToonMaterialLoaderPluginOpt
 import type { MToonMaterialDebugMode } from './MToonMaterialDebugMode';
 import { GLTF as GLTFSchema } from '@gltf-transform/core';
 
+/**
+ * Possible spec versions it recognizes.
+ */
+const POSSIBLE_SPEC_VERSIONS = new Set(['1.0', '1.0-beta']);
+
 export class MToonMaterialLoaderPlugin implements GLTFLoaderPlugin {
   public static EXTENSION_NAME = 'VRMC_materials_mtoon';
 
@@ -162,7 +167,10 @@ export class MToonMaterialLoaderPlugin implements GLTFLoaderPlugin {
     }
 
     const specVersion = extension.specVersion;
-    if (specVersion !== '1.0-beta') {
+    if (!POSSIBLE_SPEC_VERSIONS.has(specVersion)) {
+      console.warn(
+        `MToonMaterialLoaderPlugin: Unknown ${MToonMaterialLoaderPlugin.EXTENSION_NAME} specVersion "${specVersion}"`,
+      );
       return undefined;
     }
 

--- a/packages/three-vrm-materials-v0compat/src/VRMMaterialsV0CompatPlugin.ts
+++ b/packages/three-vrm-materials-v0compat/src/VRMMaterialsV0CompatPlugin.ts
@@ -225,7 +225,7 @@ export class VRMMaterialsV0CompatPlugin implements GLTFLoaderPlugin {
     const uvAnimationRotationSpeedFactor = materialProperties.floatProperties?.['_UvAnimRotation'];
 
     const mtoonExtension: V1MToonSchema.VRMCMaterialsMToon = {
-      specVersion: '1.0-beta',
+      specVersion: '1.0',
       transparentWithZWrite,
       renderQueueOffsetNumber,
       shadeColorFactor,
@@ -299,7 +299,7 @@ export class VRMMaterialsV0CompatPlugin implements GLTFLoaderPlugin {
 
     // use mtoon instead of unlit, since there might be VRM0.0 specific features that are not supported by gltf
     const mtoonExtension: V1MToonSchema.VRMCMaterialsMToon = {
-      specVersion: '1.0-beta',
+      specVersion: '1.0',
       transparentWithZWrite: isTransparentZWrite,
       renderQueueOffsetNumber,
       shadeColorFactor: baseColorFactor,

--- a/packages/three-vrm-node-constraint/examples/models/cubes.gltf
+++ b/packages/three-vrm-node-constraint/examples/models/cubes.gltf
@@ -318,7 +318,7 @@
       "mesh": 1,
       "extensions": {
         "VRMC_node_constraint": {
-          "specVersion": "1.0-beta",
+          "specVersion": "1.0",
           "constraint": {
             "roll": {
               "source": 0,
@@ -351,7 +351,7 @@
       "mesh": 2,
       "extensions": {
         "VRMC_node_constraint": {
-          "specVersion": "1.0-beta",
+          "specVersion": "1.0",
           "constraint": {
             "rotation": {
               "source": 0,

--- a/packages/three-vrm-node-constraint/src/VRMNodeConstraintLoaderPlugin.ts
+++ b/packages/three-vrm-node-constraint/src/VRMNodeConstraintLoaderPlugin.ts
@@ -9,6 +9,11 @@ import { GLTF as GLTFSchema } from '@gltf-transform/core';
 import { VRMAimConstraint } from './VRMAimConstraint';
 import { VRMRollConstraint } from './VRMRollConstraint';
 
+/**
+ * Possible spec versions it recognizes.
+ */
+const POSSIBLE_SPEC_VERSIONS = new Set(['1.0', '1.0-beta']);
+
 export class VRMNodeConstraintLoaderPlugin implements GLTFLoaderPlugin {
   public static readonly EXTENSION_NAME = 'VRMC_node_constraint';
 
@@ -67,7 +72,10 @@ export class VRMNodeConstraintLoaderPlugin implements GLTFLoaderPlugin {
       }
 
       const specVersion = extension.specVersion;
-      if (specVersion !== '1.0-beta') {
+      if (!POSSIBLE_SPEC_VERSIONS.has(specVersion)) {
+        console.warn(
+          `VRMNodeConstraintLoaderPlugin: Unknown ${VRMNodeConstraintLoaderPlugin.EXTENSION_NAME} specVersion "${specVersion}"`,
+        );
         return;
       }
 

--- a/packages/three-vrm-springbone/examples/models/cubes.gltf
+++ b/packages/three-vrm-springbone/examples/models/cubes.gltf
@@ -269,7 +269,7 @@
   ],
   "extensions": {
     "VRMC_springBone": {
-      "specVersion": "1.0-beta",
+      "specVersion": "1.0",
       "colliders": [
         {
           "node": 5,

--- a/packages/three-vrm-springbone/src/VRMSpringBoneJoint.ts
+++ b/packages/three-vrm-springbone/src/VRMSpringBoneJoint.ts
@@ -177,7 +177,7 @@ export class VRMSpringBoneJoint {
       this._initialLocalChildPosition.copy(this.child.position);
     } else {
       // vrm0 requires a 7cm fixed bone length for the final node in a chain
-      // See: https://github.com/vrm-c/vrm-specification/tree/master/specification/VRMC_springBone-1.0-beta#about-spring-configuration
+      // See: https://github.com/vrm-c/vrm-specification/tree/master/specification/VRMC_springBone-1.0#about-spring-configuration
       this._initialLocalChildPosition.copy(this.bone.position).normalize().multiplyScalar(0.07);
     }
 

--- a/packages/three-vrm-springbone/src/VRMSpringBoneLoaderPlugin.ts
+++ b/packages/three-vrm-springbone/src/VRMSpringBoneLoaderPlugin.ts
@@ -13,6 +13,11 @@ import { VRMSpringBoneManager } from './VRMSpringBoneManager';
 import type { VRMSpringBoneJointSettings } from './VRMSpringBoneJointSettings';
 import { GLTF as GLTFSchema } from '@gltf-transform/core';
 
+/**
+ * Possible spec versions it recognizes.
+ */
+const POSSIBLE_SPEC_VERSIONS = new Set(['1.0', '1.0-beta']);
+
 export class VRMSpringBoneLoaderPlugin implements GLTFLoaderPlugin {
   public static readonly EXTENSION_NAME = 'VRMC_springBone';
 
@@ -88,7 +93,10 @@ export class VRMSpringBoneLoaderPlugin implements GLTFLoaderPlugin {
     }
 
     const specVersion = extension.specVersion;
-    if (specVersion !== '1.0-beta') {
+    if (!POSSIBLE_SPEC_VERSIONS.has(specVersion)) {
+      console.warn(
+        `VRMSpringBoneLoaderPlugin: Unknown ${VRMSpringBoneLoaderPlugin.EXTENSION_NAME} specVersion "${specVersion}"`,
+      );
       return null;
     }
 

--- a/packages/three-vrm/README.md
+++ b/packages/three-vrm/README.md
@@ -46,7 +46,7 @@ loader.register( ( parser ) => {
 loader.load(
 
 	// URL of the VRM you want to load
-	'/models/three-vrm-girl.vrm',
+	'/models/VRM1_Constraint_Twist_Sample.vrm',
 
 	// called when the resource is loaded
 	( gltf ) => {
@@ -101,7 +101,7 @@ loader.register( ( parser ) => {
 loader.load(
 
 	// URL of the VRM you want to load
-	'/models/three-vrm-girl.vrm',
+	'/models/VRM1_Constraint_Twist_Sample.vrm',
 
 	// called when the resource is loaded
 	( gltf ) => {

--- a/packages/three-vrm/examples/animations.html
+++ b/packages/three-vrm/examples/animations.html
@@ -64,7 +64,7 @@
 
 			loader.load(
 
-				'./models/three-vrm-girl.vrm',
+				'./models/VRM1_Constraint_Twist_Sample.vrm',
 
 				( gltf ) => {
 

--- a/packages/three-vrm/examples/basic.html
+++ b/packages/three-vrm/examples/basic.html
@@ -64,7 +64,7 @@
 			loader.load(
 
 				// URL of the VRM you want to load
-				'./models/three-vrm-girl.vrm',
+				'./models/VRM1_Constraint_Twist_Sample.vrm',
 
 				// called when the resource is loaded
 				( gltf ) => {

--- a/packages/three-vrm/examples/bones.html
+++ b/packages/three-vrm/examples/bones.html
@@ -63,7 +63,7 @@
 
 			loader.load(
 
-				'./models/three-vrm-girl.vrm',
+				'./models/VRM1_Constraint_Twist_Sample.vrm',
 
 				( gltf ) => {
 

--- a/packages/three-vrm/examples/debug.html
+++ b/packages/three-vrm/examples/debug.html
@@ -70,7 +70,7 @@
 			loader.load(
 
 				// URL of the VRM you want to load
-				'./models/three-vrm-girl.vrm',
+				'./models/VRM1_Constraint_Twist_Sample.vrm',
 
 				// called when the resource is loaded
 				( gltf ) => {

--- a/packages/three-vrm/examples/dnd.html
+++ b/packages/three-vrm/examples/dnd.html
@@ -100,7 +100,7 @@
 
 			}
 
-			load( './models/three-vrm-girl.vrm' );
+			load( './models/VRM1_Constraint_Twist_Sample.vrm' );
 
 			// helpers
 			const gridHelper = new THREE.GridHelper( 10, 10 );

--- a/packages/three-vrm/examples/expressions.html
+++ b/packages/three-vrm/examples/expressions.html
@@ -63,7 +63,7 @@
 
 			loader.load(
 
-				'./models/three-vrm-girl.vrm',
+				'./models/VRM1_Constraint_Twist_Sample.vrm',
 
 				( gltf ) => {
 

--- a/packages/three-vrm/examples/firstperson.html
+++ b/packages/three-vrm/examples/firstperson.html
@@ -63,7 +63,7 @@
 
 			loader.load(
 
-				'./models/three-vrm-girl.vrm',
+				'./models/VRM1_Constraint_Twist_Sample.vrm',
 
 				( gltf ) => {
 

--- a/packages/three-vrm/examples/humanoidAnimation/main.js
+++ b/packages/three-vrm/examples/humanoidAnimation/main.js
@@ -25,7 +25,7 @@ const light = new THREE.DirectionalLight( 0xffffff );
 light.position.set( 1.0, 1.0, 1.0 ).normalize();
 scene.add( light );
 
-const defaultModelUrl = '../models/three-vrm-girl.vrm';
+const defaultModelUrl = '../models/VRM1_Constraint_Twist_Sample.vrm';
 
 // gltf and vrm
 let currentVrm = undefined;

--- a/packages/three-vrm/examples/lookat-advanced.html
+++ b/packages/three-vrm/examples/lookat-advanced.html
@@ -134,7 +134,7 @@
 
 			loader.load(
 
-				'./models/three-vrm-girl.vrm',
+				'./models/VRM1_Constraint_Twist_Sample.vrm',
 
 				( gltf ) => {
 

--- a/packages/three-vrm/examples/lookat.html
+++ b/packages/three-vrm/examples/lookat.html
@@ -67,7 +67,7 @@
 
 			loader.load(
 
-				'./models/three-vrm-girl.vrm',
+				'./models/VRM1_Constraint_Twist_Sample.vrm',
 
 				( gltf ) => {
 

--- a/packages/three-vrm/examples/materials-debug.html
+++ b/packages/three-vrm/examples/materials-debug.html
@@ -63,7 +63,7 @@
 
 			loader.load(
 
-				'./models/three-vrm-girl.vrm',
+				'./models/VRM1_Constraint_Twist_Sample.vrm',
 
 				( gltf ) => {
 

--- a/packages/three-vrm/examples/meta.html
+++ b/packages/three-vrm/examples/meta.html
@@ -76,7 +76,7 @@
 			loader.load(
 
 				// URL of the VRM you want to load
-				'./models/three-vrm-girl.vrm',
+				'./models/VRM1_Constraint_Twist_Sample.vrm',
 
 				// called when the resource is loaded
 				( gltf ) => {

--- a/packages/three-vrm/examples/mouse.html
+++ b/packages/three-vrm/examples/mouse.html
@@ -59,7 +59,7 @@
 
 			loader.load(
 
-				'./models/three-vrm-girl.vrm',
+				'./models/VRM1_Constraint_Twist_Sample.vrm',
 
 				( gltf ) => {
 

--- a/packages/types-vrmc-materials-mtoon-1.0/README.md
+++ b/packages/types-vrmc-materials-mtoon-1.0/README.md
@@ -2,7 +2,7 @@
 
 Type definitions of VRMC_materials_mtoon 1.0 schema.
 
-https://github.com/vrm-c/vrm-specification/tree/master/specification/VRMC_materials_mtoon-1.0-beta
+https://github.com/vrm-c/vrm-specification/tree/master/specification/VRMC_materials_mtoon-1.0
 
 There should not be any implementation in this package. Just type definitions of the schema.
 

--- a/packages/types-vrmc-materials-mtoon-1.0/src/VRMCMaterialsMToon.ts
+++ b/packages/types-vrmc-materials-mtoon-1.0/src/VRMCMaterialsMToon.ts
@@ -6,7 +6,7 @@ export interface VRMCMaterialsMToon {
   /**
    * Specification version of VRMC_materials_mtoon
    */
-  specVersion: '1.0-beta';
+  specVersion: '1.0' | '1.0-beta';
 
   /**
    * enable depth buffer when renderMode is transparent

--- a/packages/types-vrmc-node-constraint-1.0/README.md
+++ b/packages/types-vrmc-node-constraint-1.0/README.md
@@ -2,7 +2,7 @@
 
 Type definitions of VRMC_node_constraint 1.0 schema.
 
-https://github.com/vrm-c/vrm-specification/tree/master/specification/VRMC_node_constraint-1.0_beta
+https://github.com/vrm-c/vrm-specification/tree/master/specification/VRMC_node_constraint-1.0
 
 There should not be any implementation in this package. Just type definitions of the schema.
 

--- a/packages/types-vrmc-node-constraint-1.0/src/VRMCNodeConstraint.ts
+++ b/packages/types-vrmc-node-constraint-1.0/src/VRMCNodeConstraint.ts
@@ -7,7 +7,7 @@ export interface VRMCNodeConstraint {
   /**
    * Specification version of VRMC_node_constraint
    */
-  specVersion: '1.0-beta';
+  specVersion: '1.0' | '1.0-beta';
 
   constraint: Constraint;
 

--- a/packages/types-vrmc-springbone-1.0/README.md
+++ b/packages/types-vrmc-springbone-1.0/README.md
@@ -2,7 +2,7 @@
 
 Type definitions of VRMC_springBone 1.0 schema.
 
-https://github.com/vrm-c/vrm-specification/tree/master/specification/VRMC_springBone-1.0_beta
+https://github.com/vrm-c/vrm-specification/tree/master/specification/VRMC_springBone-1.0
 
 There should not be any implementation in this package. Just type definitions of the schema.
 

--- a/packages/types-vrmc-springbone-1.0/src/VRMCSpringBone.ts
+++ b/packages/types-vrmc-springbone-1.0/src/VRMCSpringBone.ts
@@ -9,7 +9,7 @@ export interface VRMCSpringBone {
   /**
    * Specification version of VRMC_springBone
    */
-  specVersion: '1.0-beta';
+  specVersion: '1.0' | '1.0-beta';
 
   /**
    * An array of colliders.

--- a/packages/types-vrmc-vrm-1.0/README.md
+++ b/packages/types-vrmc-vrm-1.0/README.md
@@ -2,7 +2,7 @@
 
 Type definitions of VRM_vrm 1.0 schema.
 
-https://github.com/vrm-c/vrm-specification/tree/master/specification/VRMC_vrm-1.0-beta
+https://github.com/vrm-c/vrm-specification/tree/master/specification/VRMC_vrm-1.0
 
 There should not be any implementation in this package. Just type definitions of the schema.
 

--- a/packages/types-vrmc-vrm-1.0/src/VRMCVRM.ts
+++ b/packages/types-vrmc-vrm-1.0/src/VRMCVRM.ts
@@ -8,7 +8,7 @@ export interface VRMCVRM {
   /**
    * Specification version of VRMC_vrm
    */
-  specVersion: '1.0-beta';
+  specVersion: '1.0' | '1.0-beta';
 
   /**
    * Meta informations of the VRM model


### PR DESCRIPTION
### Description

Done these jobs preparing for 1.0 release:

- Loaders, it now supports both `1.0` and `1.0-beta`
- Samples: Replace `three-vrm-girl` with `VRM1_Constraint_Twist_Sample`
- Samples: Bump specVersion of extensions to `1.0`
- Docs, comments: update URLs

I will do the bump of three-vrm itself later (would not be included in this PR).
