### PR TITLE
fix: Fix v0compat matcap behavior

### DIFF
--- a/packages/three-vrm-materials-v0compat/src/VRMMaterialsV0CompatPlugin.ts
+++ b/packages/three-vrm-materials-v0compat/src/VRMMaterialsV0CompatPlugin.ts
@@ -156,6 +156,7 @@ export class VRMMaterialsV0CompatPlugin implements GLTFLoaderPlugin {
     const giEqualizationFactor = giIntensityFactor ? 1.0 - giIntensityFactor : undefined;
 
     const matcapTextureIndex = materialProperties.textureProperties?.['_SphereAdd'];
+    const matcapFactor = matcapTextureIndex != null ? [1.0, 1.0, 1.0] : undefined;
     const matcapTexture =
       matcapTextureIndex != null
         ? {
@@ -233,6 +234,7 @@ export class VRMMaterialsV0CompatPlugin implements GLTFLoaderPlugin {
       shadingShiftFactor,
       shadingToonyFactor,
       giEqualizationFactor,
+      matcapFactor,
       matcapTexture,
       rimLightingMixFactor,
       rimMultiplyTexture,


### PR DESCRIPTION
### Description

Fix v0compat matcap behavior.

Currently, matcaps are completely disabled for VRM0.0 models because of lack of this change.

matcapFactor must be explicitly defined as `[1, 1, 1]` because the default value is `[0, 0, 0]`.
