### PR TITLE
Fix hips world position update

### DIFF
--- a/packages/three-vrm-core/src/humanoid/VRMHumanoidRig.ts
+++ b/packages/three-vrm-core/src/humanoid/VRMHumanoidRig.ts
@@ -132,7 +132,7 @@ export class VRMHumanoidRig extends VRMRig {
         // Move the mass center of the VRM
         if (boneName === 'hips') {
           const boneWorldPosition = rigBoneNode.getWorldPosition(_boneWorldPos);
-          boneNode.parent!.matrixWorld.multiplyMatrices(boneNode.parent!.parent!.matrixWorld, boneNode.parent!.matrix);
+          boneNode.parent!.updateWorldMatrix(true, false);
           const parentWorldMatrix = boneNode.parent!.matrixWorld;
           const localPosition = boneWorldPosition.applyMatrix4(parentWorldMatrix.invert());
           boneNode.position.copy(localPosition);

--- a/packages/three-vrm-core/src/humanoid/VRMHumanoidRig.ts
+++ b/packages/three-vrm-core/src/humanoid/VRMHumanoidRig.ts
@@ -6,6 +6,7 @@ import { VRMRig } from './VRMRig';
 
 const _v3A = new THREE.Vector3();
 const _quatA = new THREE.Quaternion();
+const _boneWorldPos = new THREE.Vector3();
 
 /**
  * A class represents the normalized Rig of a VRM.
@@ -130,7 +131,8 @@ export class VRMHumanoidRig extends VRMRig {
 
         // Move the mass center of the VRM
         if (boneName === 'hips') {
-          const boneWorldPosition = rigBoneNode.getWorldPosition(new THREE.Vector3());
+          const boneWorldPosition = rigBoneNode.getWorldPosition(_boneWorldPos);
+          boneNode.parent!.matrixWorld.multiplyMatrices(boneNode.parent!.parent!.matrixWorld, boneNode.parent!.matrix);
           const parentWorldMatrix = boneNode.parent!.matrixWorld;
           const localPosition = boneWorldPosition.applyMatrix4(parentWorldMatrix.invert());
           boneNode.position.copy(localPosition);


### PR DESCRIPTION
This PR is sponsored by Sougen 

Thanks for this great repo! :) 

I noticed an issue in the VRMHumanoidRig update method causing some tiny flicker in the VRM position.

Check this video to see the before/after
https://user-images.githubusercontent.com/7174039/192105285-aa55e9ec-3124-436e-8ef9-9d972bff54e1.mp4
Top VRM use my fix, bottom VRM is the current version. 
Both VRM are synchronised with the purple line position but as you can see, the bottom VRM is not at the correct position.
Updating the matrixWorld before using it fix this issue.

I also made a modification to avoid a needless instantiation.

Let me know if you need more info/edits.

