### PR TITLE
Adjust animation with reference to hips height

### DIFF
--- a/packages/three-vrm-core/examples/humanoidAnimation/loadMixamoAnimation.js
+++ b/packages/three-vrm-core/examples/humanoidAnimation/loadMixamoAnimation.js
@@ -19,6 +19,13 @@ function loadMixamoAnimation( url, vrm ) {
 		const restRotationInverse = new THREE.Quaternion();
 		const parentRestWorldRotation = new THREE.Quaternion();
 		const _quatA = new THREE.Quaternion();
+		const _vec3 = new THREE.Vector3();
+
+		const motionHipsHeight = asset.getObjectByName( 'mixamorigHips' ).position.y;
+		const vrmHipsY = vrm.humanoid?.getNormalizedBoneNode( 'hips' ).getWorldPosition( _vec3 ).y;
+		const vrmRootY = vrm.scene.getWorldPosition( _vec3 ).y;
+		const vrmHipsHeight = Math.abs( vrmHipsY - vrmRootY );
+		const hipsPositionScale = vrmHipsHeight / motionHipsHeight;
 
 		clip.tracks.forEach( ( track ) => {
 
@@ -71,10 +78,8 @@ function loadMixamoAnimation( url, vrm ) {
 
 				} else if ( track instanceof THREE.VectorKeyframeTrack ) {
 
-					let nodeName = vrmNodeName;
-					let value = track.values.map( ( v, i ) => ( vrm.meta?.metaVersion === '0' && i % 3 !== 1 ? - v : v ) * 0.01 );
-
-					tracks.push( new THREE.VectorKeyframeTrack( `${nodeName}.${propertyName}`, track.times, value ) );
+					const value = track.values.map( ( v, i ) => ( vrm.meta?.metaVersion === '0' && i % 3 !== 1 ? - v : v ) * hipsPositionScale );
+					tracks.push( new THREE.VectorKeyframeTrack( `${vrmNodeName}.${propertyName}`, track.times, value ) );
 
 				}
 

--- a/packages/three-vrm-core/examples/humanoidAnimation/loadMixamoAnimation.js
+++ b/packages/three-vrm-core/examples/humanoidAnimation/loadMixamoAnimation.js
@@ -21,6 +21,7 @@ function loadMixamoAnimation( url, vrm ) {
 		const _quatA = new THREE.Quaternion();
 		const _vec3 = new THREE.Vector3();
 
+		// Adjust with reference to hips height.
 		const motionHipsHeight = asset.getObjectByName( 'mixamorigHips' ).position.y;
 		const vrmHipsY = vrm.humanoid?.getNormalizedBoneNode( 'hips' ).getWorldPosition( _vec3 ).y;
 		const vrmRootY = vrm.scene.getWorldPosition( _vec3 ).y;

--- a/packages/three-vrm/examples/humanoidAnimation/loadMixamoAnimation.js
+++ b/packages/three-vrm/examples/humanoidAnimation/loadMixamoAnimation.js
@@ -19,6 +19,14 @@ function loadMixamoAnimation( url, vrm ) {
 		const restRotationInverse = new THREE.Quaternion();
 		const parentRestWorldRotation = new THREE.Quaternion();
 		const _quatA = new THREE.Quaternion();
+		const _vec3 = new THREE.Vector3();
+
+		// Adjust with reference to hips height.
+		const motionHipsHeight = asset.getObjectByName( 'mixamorigHips' ).position.y;
+		const vrmHipsY = vrm.humanoid?.getNormalizedBoneNode( 'hips' ).getWorldPosition( _vec3 ).y;
+		const vrmRootY = vrm.scene.getWorldPosition( _vec3 ).y;
+		const vrmHipsHeight = Math.abs( vrmHipsY - vrmRootY );
+		const hipsPositionScale = vrmHipsHeight / motionHipsHeight;
 
 		clip.tracks.forEach( ( track ) => {
 
@@ -71,10 +79,8 @@ function loadMixamoAnimation( url, vrm ) {
 
 				} else if ( track instanceof THREE.VectorKeyframeTrack ) {
 
-					let nodeName = vrmNodeName;
-					let value = track.values.map( ( v, i ) => ( vrm.meta?.metaVersion === '0' && i % 3 !== 1 ? - v : v ) * 0.01 );
-
-					tracks.push( new THREE.VectorKeyframeTrack( `${nodeName}.${propertyName}`, track.times, value ) );
+					const value = track.values.map( ( v, i ) => ( vrm.meta?.metaVersion === '0' && i % 3 !== 1 ? - v : v ) * hipsPositionScale );
+					tracks.push( new THREE.VectorKeyframeTrack( `${vrmNodeName}.${propertyName}`, track.times, value ) );
 
 				}
 


### PR DESCRIPTION
# Description

examples/humanoidAniamtion でVRMごとの身長差を考慮するように修正します

VRMのhipsの高さとmixamoのFBXのhipsのYの比によって、
hipsの位置のアニメーションの値を変更します。

これによって、足の長いVRMや短いVRMでも地面に足がついた状態でアニメーションするようになります。
