### PR TITLE
Fix: fix lookAt, rightEye did have wrong orientation

### DIFF
--- a/packages/three-vrm-core/src/lookAt/VRMLookAtBoneApplier.ts
+++ b/packages/three-vrm-core/src/lookAt/VRMLookAtBoneApplier.ts
@@ -105,7 +105,7 @@ export class VRMLookAtBoneApplier implements VRMLookAtApplier {
     this._restRightEyeParentWorldQuat = new THREE.Quaternion();
 
     const leftEye = this.humanoid.getRawBoneNode('leftEye');
-    const rightEye = this.humanoid.getRawBoneNode('leftEye');
+    const rightEye = this.humanoid.getRawBoneNode('rightEye');
 
     if (leftEye) {
       this._restQuatLeftEye.copy(leftEye.quaternion);

--- a/packages/three-vrm-core/src/lookAt/tests/VRMLookAtBoneApplier.test.ts
+++ b/packages/three-vrm-core/src/lookAt/tests/VRMLookAtBoneApplier.test.ts
@@ -95,7 +95,6 @@ describe('VRMLookAtBoneApplier', () => {
 
     humanoid = createHumanoid();
     scene.add(humanoid.getRawBoneNode('hips')!);
-    scene.add(humanoid.normalizedHumanBonesRoot);
 
     applier = createBoneApplier(humanoid);
   });
@@ -144,6 +143,36 @@ describe('VRMLookAtBoneApplier', () => {
       const expected = new THREE.Quaternion().setFromEuler(new THREE.Euler(DEG2RAD * 2.5, DEG2RAD * 2.5, 0.0, 'YXZ'));
 
       expect(normalizedRightEye.quaternion).toBeCloseToQuaternion(expected);
+    });
+
+    describe('when leftEye and rightEye have different rest orientations', () => {
+      beforeEach(() => {
+        scene = new THREE.Scene();
+
+        humanoid = createHumanoid();
+        scene.add(humanoid.getRawBoneNode('hips')!);
+        humanoid.getRawBoneNode('rightEye')!.quaternion.copy(QUAT_Y_CCW90);
+
+        applier = createBoneApplier(humanoid);
+      });
+
+      it('makes each eye look toward the specified angle', () => {
+        applier.applyYawPitch(15.0, 15.0);
+
+        const rawLeftEye = humanoid.getRawBoneNode('leftEye')!;
+        const rawRightEye = humanoid.getRawBoneNode('rightEye')!;
+
+        // saturate( angle / rangeMap.inputMaxValue ) * rangeMap.outputScale = saturate( 15 / 30 ) * 5 = 2.5
+        const expectedLeft = new THREE.Quaternion()
+          .setFromEuler(new THREE.Euler(DEG2RAD * 2.5, DEG2RAD * 2.5, 0.0, 'YXZ'))
+          .multiply(QUAT_Y_CW90);
+        const expectedRight = new THREE.Quaternion()
+          .setFromEuler(new THREE.Euler(DEG2RAD * 2.5, DEG2RAD * 2.5, 0.0, 'YXZ'))
+          .multiply(QUAT_Y_CCW90);
+
+        expect(rawLeftEye.quaternion).toBeCloseToQuaternion(expectedLeft);
+        expect(rawRightEye.quaternion).toBeCloseToQuaternion(expectedRight);
+      });
     });
   });
 


### PR DESCRIPTION
### Description

rightEye did have wrong orientation, fixed this.

It turns out that it's an easy mistake, See the diff of VRMLookAtBoneApplier.

Also added a test addressing this case.
