### PR TITLE
Bump Three.js to r146

### DIFF
--- a/packages/three-vrm-core/examples/expressions.html
+++ b/packages/three-vrm-core/examples/expressions.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.144.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm-core.js"></script>
 		<script>
 			/* global THREE_VRM_CORE*/

--- a/packages/three-vrm-core/examples/firstPerson.html
+++ b/packages/three-vrm-core/examples/firstPerson.html
@@ -24,9 +24,9 @@
 
 	<body>
 		<span id="info"></span>
-		<script src="https://unpkg.com/three@0.144.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm-core.js"></script>
 		<script>
 			/* global THREE_VRM_CORE*/

--- a/packages/three-vrm-core/examples/humanoid.html
+++ b/packages/three-vrm-core/examples/humanoid.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.144.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm-core.js"></script>
 		<script>
 			/* global THREE_VRM_CORE*/

--- a/packages/three-vrm-core/examples/humanoidAnimation/index.html
+++ b/packages/three-vrm-core/examples/humanoidAnimation/index.html
@@ -30,11 +30,11 @@
 			drag and drop <a href="https://www.mixamo.com/" target="_blank" rel="noopener noreferrer">mixamo</a> animation (.fbx)
 		</div>
 
-		<script src="https://unpkg.com/three@0.144.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
 		<script src="https://cdn.jsdelivr.net/npm/fflate/umd/index.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/controls/OrbitControls.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/loaders/FBXLoader.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/FBXLoader.js"></script>
 		<script src="../../lib/three-vrm-core.js"></script>
 		<script src="mixamoRigMap.js"></script>
 		<script src="loadMixamoAnimation.js"></script>

--- a/packages/three-vrm-core/examples/lookAt.html
+++ b/packages/three-vrm-core/examples/lookAt.html
@@ -24,9 +24,9 @@
 
 	<body>
 		<span id="info"></span>
-		<script src="https://unpkg.com/three@0.144.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm-core.js"></script>
 		<script>
 			/* global THREE_VRM_CORE*/

--- a/packages/three-vrm-core/examples/meta.html
+++ b/packages/three-vrm-core/examples/meta.html
@@ -31,9 +31,9 @@
 	<body>
 		<span id="meta"></span>
 		<img id="thumbnail" alt="thumbnail" />
-		<script src="https://unpkg.com/three@0.144.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm-core.js"></script>
 		<script>
 			/* global THREE_VRM_CORE*/

--- a/packages/three-vrm-core/package.json
+++ b/packages/three-vrm-core/package.json
@@ -50,12 +50,12 @@
     "@pixiv/types-vrmc-vrm-1.0": "1.0.0"
   },
   "devDependencies": {
-    "@types/three": "^0.144.0",
+    "@types/three": "^0.146.0",
     "lint-staged": "13.0.3",
-    "three": "^0.144.0"
+    "three": "^0.146.0"
   },
   "peerDependencies": {
-    "@types/three": "^0.144.0",
-    "three": "^0.144.0"
+    "@types/three": "^0.146.0",
+    "three": "^0.146.0"
   }
 }

--- a/packages/three-vrm-materials-hdr-emissive-multiplier/examples/loader-plugin.html
+++ b/packages/three-vrm-materials-hdr-emissive-multiplier/examples/loader-plugin.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.144.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm-materials-hdr-emissive-multiplier.js"></script>
 		<script>
 			/*  global THREE_VRM_MATERIALS_HDR_EMISSIVE_MULTIPLIER */

--- a/packages/three-vrm-materials-hdr-emissive-multiplier/package.json
+++ b/packages/three-vrm-materials-hdr-emissive-multiplier/package.json
@@ -44,11 +44,11 @@
     "@pixiv/types-vrmc-materials-hdr-emissive-multiplier-1.0": "1.0.0"
   },
   "devDependencies": {
-    "@types/three": "^0.144.0",
-    "three": "^0.144.0"
+    "@types/three": "^0.146.0",
+    "three": "^0.146.0"
   },
   "peerDependencies": {
-    "@types/three": "^0.144.0",
-    "three": "^0.144.0"
+    "@types/three": "^0.146.0",
+    "three": "^0.146.0"
   }
 }

--- a/packages/three-vrm-materials-mtoon/examples/emissive-strength.html
+++ b/packages/three-vrm-materials-mtoon/examples/emissive-strength.html
@@ -19,15 +19,15 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.144.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/controls/OrbitControls.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/shaders/CopyShader.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/shaders/LuminosityHighPassShader.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/postprocessing/EffectComposer.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/postprocessing/ShaderPass.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/postprocessing/RenderPass.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/postprocessing/UnrealBloomPass.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/shaders/CopyShader.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/shaders/LuminosityHighPassShader.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/postprocessing/EffectComposer.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/postprocessing/ShaderPass.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/postprocessing/RenderPass.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/postprocessing/UnrealBloomPass.js"></script>
 		<script src="../lib/three-vrm-materials-mtoon.js"></script>
 		<script>
 			/* global THREE_VRM_MATERIALS_MTOON */

--- a/packages/three-vrm-materials-mtoon/examples/loader-plugin.html
+++ b/packages/three-vrm-materials-mtoon/examples/loader-plugin.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.144.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm-materials-mtoon.js"></script>
 		<script>
 			/* global THREE_VRM_MATERIALS_MTOON */

--- a/packages/three-vrm-materials-mtoon/package.json
+++ b/packages/three-vrm-materials-mtoon/package.json
@@ -45,11 +45,11 @@
     "@pixiv/types-vrmc-materials-mtoon-1.0": "1.0.0"
   },
   "devDependencies": {
-    "@types/three": "^0.144.0",
-    "three": "^0.144.0"
+    "@types/three": "^0.146.0",
+    "three": "^0.146.0"
   },
   "peerDependencies": {
-    "@types/three": "^0.144.0",
-    "three": "^0.144.0"
+    "@types/three": "^0.146.0",
+    "three": "^0.146.0"
   }
 }

--- a/packages/three-vrm-materials-v0compat/package.json
+++ b/packages/three-vrm-materials-v0compat/package.json
@@ -44,12 +44,12 @@
     "@pixiv/types-vrmc-materials-mtoon-1.0": "1.0.0"
   },
   "devDependencies": {
-    "@types/three": "^0.144.0",
+    "@types/three": "^0.146.0",
     "lint-staged": "13.0.3",
-    "three": "^0.144.0"
+    "three": "^0.146.0"
   },
   "peerDependencies": {
-    "@types/three": "^0.144.0",
-    "three": "^0.144.0"
+    "@types/three": "^0.146.0",
+    "three": "^0.146.0"
   }
 }

--- a/packages/three-vrm-node-constraint/examples/aim.html
+++ b/packages/three-vrm-node-constraint/examples/aim.html
@@ -19,8 +19,8 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.144.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="https://unpkg.com/tweakpane@3.0"></script>
 		<script src="https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1"></script>
 		<script src="../lib/three-vrm-node-constraint.js"></script>

--- a/packages/three-vrm-node-constraint/examples/importer.html
+++ b/packages/three-vrm-node-constraint/examples/importer.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.144.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="https://unpkg.com/tweakpane@3.0"></script>
 		<script src="https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1"></script>
 		<script src="../lib/three-vrm-node-constraint.js"></script>

--- a/packages/three-vrm-node-constraint/examples/roll.html
+++ b/packages/three-vrm-node-constraint/examples/roll.html
@@ -19,8 +19,8 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.144.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="https://unpkg.com/tweakpane@3.0"></script>
 		<script src="https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1"></script>
 		<script src="../lib/three-vrm-node-constraint.js"></script>

--- a/packages/three-vrm-node-constraint/examples/rotation.html
+++ b/packages/three-vrm-node-constraint/examples/rotation.html
@@ -19,8 +19,8 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.144.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="https://unpkg.com/tweakpane@3.0"></script>
 		<script src="https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1"></script>
 		<script src="../lib/three-vrm-node-constraint.js"></script>

--- a/packages/three-vrm-node-constraint/examples/upper-arm.html
+++ b/packages/three-vrm-node-constraint/examples/upper-arm.html
@@ -19,8 +19,8 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.144.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="https://unpkg.com/tweakpane@3.0"></script>
 		<script src="https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1"></script>
 		<script src="../lib/three-vrm-node-constraint.js"></script>

--- a/packages/three-vrm-node-constraint/package.json
+++ b/packages/three-vrm-node-constraint/package.json
@@ -45,12 +45,12 @@
     "@pixiv/types-vrmc-node-constraint-1.0": "1.0.0"
   },
   "devDependencies": {
-    "@types/three": "^0.144.0",
+    "@types/three": "^0.146.0",
     "lint-staged": "13.0.3",
-    "three": "^0.144.0"
+    "three": "^0.146.0"
   },
   "peerDependencies": {
-    "@types/three": "^0.144.0",
-    "three": "^0.144.0"
+    "@types/three": "^0.146.0",
+    "three": "^0.146.0"
   }
 }

--- a/packages/three-vrm-springbone/examples/collider.html
+++ b/packages/three-vrm-springbone/examples/collider.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.144.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm-springbone.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm-springbone/examples/loader-plugin.html
+++ b/packages/three-vrm-springbone/examples/loader-plugin.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.144.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm-springbone.js"></script>
 		<script>
 			/* global THREE_VRM_SPRINGBONE */

--- a/packages/three-vrm-springbone/examples/multiple.html
+++ b/packages/three-vrm-springbone/examples/multiple.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.144.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm-springbone.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm-springbone/examples/single.html
+++ b/packages/three-vrm-springbone/examples/single.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.144.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm-springbone.js"></script>
 		<script>
 			// renderer

--- a/packages/three-vrm-springbone/package.json
+++ b/packages/three-vrm-springbone/package.json
@@ -47,9 +47,9 @@
   },
   "devDependencies": {
     "lint-staged": "13.0.3",
-    "three": "^0.144.0"
+    "three": "^0.146.0"
   },
   "peerDependencies": {
-    "three": "^0.144.0"
+    "three": "^0.146.0"
   }
 }

--- a/packages/three-vrm/examples/animations.html
+++ b/packages/three-vrm/examples/animations.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.144.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			/* global THREE_VRM */

--- a/packages/three-vrm/examples/basic.html
+++ b/packages/three-vrm/examples/basic.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.144.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			/* global THREE_VRM */

--- a/packages/three-vrm/examples/bones.html
+++ b/packages/three-vrm/examples/bones.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.144.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			/* global THREE_VRM */

--- a/packages/three-vrm/examples/debug.html
+++ b/packages/three-vrm/examples/debug.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.144.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			/* global THREE_VRM */

--- a/packages/three-vrm/examples/dnd.html
+++ b/packages/three-vrm/examples/dnd.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.144.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			/* global THREE_VRM */

--- a/packages/three-vrm/examples/expressions.html
+++ b/packages/three-vrm/examples/expressions.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.144.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			/* global THREE_VRM */

--- a/packages/three-vrm/examples/firstperson.html
+++ b/packages/three-vrm/examples/firstperson.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.144.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			/* global THREE_VRM */

--- a/packages/three-vrm/examples/humanoidAnimation/index.html
+++ b/packages/three-vrm/examples/humanoidAnimation/index.html
@@ -30,11 +30,11 @@
 			drag and drop <a href="https://www.mixamo.com/" target="_blank" rel="noopener noreferrer">mixamo</a> animation (.fbx)
 		</div>
 
-		<script src="https://unpkg.com/three@0.144.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
 		<script src="https://cdn.jsdelivr.net/npm/fflate/umd/index.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/controls/OrbitControls.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/loaders/FBXLoader.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/FBXLoader.js"></script>
 		<script src="../../lib/three-vrm.js"></script>
 		<script src="mixamoRigMap.js"></script>
 		<script src="loadMixamoAnimation.js"></script>

--- a/packages/three-vrm/examples/lookat-advanced.html
+++ b/packages/three-vrm/examples/lookat-advanced.html
@@ -21,9 +21,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.144.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			/* global THREE_VRM */

--- a/packages/three-vrm/examples/lookat.html
+++ b/packages/three-vrm/examples/lookat.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.144.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			/* global THREE_VRM */

--- a/packages/three-vrm/examples/materials-debug.html
+++ b/packages/three-vrm/examples/materials-debug.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.144.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			/* global THREE_VRM */

--- a/packages/three-vrm/examples/meta.html
+++ b/packages/three-vrm/examples/meta.html
@@ -31,9 +31,9 @@
 	<body>
 		<span id="meta"></span>
 		<img id="thumbnail" alt="thumbnail" />
-		<script src="https://unpkg.com/three@0.144.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			/* global THREE_VRM */

--- a/packages/three-vrm/examples/mouse.html
+++ b/packages/three-vrm/examples/mouse.html
@@ -19,9 +19,9 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.144.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.144.0/examples/js/controls/OrbitControls.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/GLTFLoader.js"></script>
+		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
 		<script src="../lib/three-vrm.js"></script>
 		<script>
 			/* global THREE_VRM */

--- a/packages/three-vrm/package.json
+++ b/packages/three-vrm/package.json
@@ -55,12 +55,12 @@
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^13.0.0",
-    "@types/three": "^0.144.0",
+    "@types/three": "^0.146.0",
     "lint-staged": "13.0.3",
-    "three": "^0.144.0"
+    "three": "^0.146.0"
   },
   "peerDependencies": {
-    "@types/three": "^0.144.0",
-    "three": "^0.144.0"
+    "@types/three": "^0.146.0",
+    "three": "^0.146.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1739,10 +1739,10 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
 
-"@types/three@^0.144.0":
-  version "0.144.0"
-  resolved "https://registry.yarnpkg.com/@types/three/-/three-0.144.0.tgz#a154f40122dbc3668c5424a5373f3965c6564557"
-  integrity sha512-psvEs6q5rLN50jUYZ3D4pZMfxTbdt3A243blt0my7/NcL6chaCZpHe2csbCtx0SOD9fI/XnF3wnVUAYZGqCSYg==
+"@types/three@^0.146.0":
+  version "0.146.0"
+  resolved "https://registry.yarnpkg.com/@types/three/-/three-0.146.0.tgz#83813ba0d2fff6bdc6d7fda3a77993a932bba45f"
+  integrity sha512-75AgysUrIvTCB054eQa2pDVFurfeFW8CrMQjpzjt3yHBfuuknoSvvsESd/3EhQxPrz9si3+P0wiDUVsWUlljfA==
   dependencies:
     "@types/webxr" "*"
 
@@ -7258,10 +7258,10 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
-three@^0.144.0:
-  version "0.144.0"
-  resolved "https://registry.yarnpkg.com/three/-/three-0.144.0.tgz#2818517169f8ff94eea5f664f6ff1fcdcd436cc8"
-  integrity sha512-R8AXPuqfjfRJKkYoTQcTK7A6i3AdO9++2n8ubya/GTU+fEHhYKu1ZooRSCPkx69jbnzT7dD/xEo6eROQTt2lJw==
+three@^0.146.0:
+  version "0.146.0"
+  resolved "https://registry.yarnpkg.com/three/-/three-0.146.0.tgz#fd80f0d128ab4bb821a02191ae241e4e6326f17a"
+  integrity sha512-1lvNfLezN6OJ9NaFAhfX4sm5e9YCzHtaRgZ1+B4C+Hv6TibRMsuBAM5/wVKzxjpYIlMymvgsHEFrrigEfXnb2A==
 
 throat@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
# Bump
`three` 0.144.0 -> 0.146.0
`@types/three` 0.144.0 -> 0.146.0


# Ref

r145
- https://github.com/mrdoob/three.js/releases/tag/r145

r146
- https://github.com/mrdoob/three.js/releases/tag/r146