### PR TITLE
examples: ESM examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,18 +39,32 @@ You will need:
 Code like this:
 
 ```html
-<script src="three.js"></script>
-<script src="GLTFLoader.js"></script>
-<script src="three-vrm.js"></script>
+<!-- About import maps, see the Three.js official docs: -->
+<!-- https://threejs.org/docs/#manual/en/introduction/Installation -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
 
-<script>
+<script type="importmap">
+  {
+    "imports": {
+      "three": "https://unpkg.com/three@0.146/build/three.module.js",
+      "three/addons/": "https://unpkg.com/three@0.146/examples/jsm/",
+      "@pixiv/three-vrm": "three-vrm.module.js"
+    }
+  }
+</script>
+
+<script type="module">
+  import * as THREE from 'three';
+  import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+  import { VRMLoaderPlugin } from '@pixiv/three-vrm';
+
   const scene = new THREE.Scene();
 
-  const loader = new THREE.GLTFLoader();
+  const loader = new GLTFLoader();
 
   // Install GLTFLoader plugin
   loader.register((parser) => {
-    return new THREE_VRM.VRMLoaderPlugin(parser);
+    return new VRMLoaderPlugin(parser);
   });
 
   loader.load(

--- a/packages/three-vrm-core/examples/expressions.html
+++ b/packages/three-vrm-core/examples/expressions.html
@@ -19,12 +19,26 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
-		<script src="../lib/three-vrm-core.js"></script>
-		<script>
-			/* global THREE_VRM_CORE*/
+		<!-- Import maps polyfill -->
+		<!-- Remove this when import maps will be widely supported -->
+		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+		<script type="importmap">
+			{
+				"imports": {
+					"three": "https://unpkg.com/three@0.146/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.146/examples/jsm/",
+					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
+				}
+			}
+		</script>
+
+		<script type="module">
+			import * as THREE from 'three';
+			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+			import { VRMCoreLoaderPlugin } from '@pixiv/three-vrm-core';
+
 			// renderer
 			const renderer = new THREE.WebGLRenderer();
 			renderer.setSize( window.innerWidth, window.innerHeight );
@@ -37,7 +51,7 @@
 			camera.position.set( 0.0, 1.0, 5.0 );
 
 			// camera controls
-			const controls = new THREE.OrbitControls( camera, renderer.domElement );
+			const controls = new OrbitControls( camera, renderer.domElement );
 			controls.screenSpacePanning = true;
 			controls.target.set( 0.0, 1.0, 0.0 );
 			controls.update();
@@ -53,12 +67,12 @@
 			// gltf and vrm
 			let currentGltf = undefined;
 
-			const loader = new THREE.GLTFLoader();
+			const loader = new GLTFLoader();
 			loader.crossOrigin = 'anonymous';
 
 			loader.register( ( parser ) => {
 
-				return new THREE_VRM_CORE.VRMCoreLoaderPlugin( parser );
+				return new VRMCoreLoaderPlugin( parser );
 
 			} );
 

--- a/packages/three-vrm-core/examples/firstPerson.html
+++ b/packages/three-vrm-core/examples/firstPerson.html
@@ -24,12 +24,27 @@
 
 	<body>
 		<span id="info"></span>
-		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
-		<script src="../lib/three-vrm-core.js"></script>
-		<script>
-			/* global THREE_VRM_CORE*/
+
+		<!-- Import maps polyfill -->
+		<!-- Remove this when import maps will be widely supported -->
+		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+		<script type="importmap">
+			{
+				"imports": {
+					"three": "https://unpkg.com/three@0.146/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.146/examples/jsm/",
+					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
+				}
+			}
+		</script>
+
+		<script type="module">
+			import * as THREE from 'three';
+			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+			import { VRMCoreLoaderPlugin } from '@pixiv/three-vrm-core';
+
 			// renderer
 			const renderer = new THREE.WebGLRenderer();
 			renderer.setSize( window.innerWidth, window.innerHeight );
@@ -42,7 +57,7 @@
 			camera.position.set( 0.0, 1.0, 5.0 );
 
 			// camera controls
-			const controls = new THREE.OrbitControls( camera, renderer.domElement );
+			const controls = new OrbitControls( camera, renderer.domElement );
 			controls.screenSpacePanning = true;
 			controls.target.set( 0.0, 1.0, 0.0 );
 			controls.update();
@@ -58,12 +73,12 @@
 			// gltf and vrm
 			let currentGltf = undefined;
 
-			const loader = new THREE.GLTFLoader();
+			const loader = new GLTFLoader();
 			loader.crossOrigin = 'anonymous';
 
 			loader.register( ( parser ) => {
 
-				return new THREE_VRM_CORE.VRMCoreLoaderPlugin( parser );
+				return new VRMCoreLoaderPlugin( parser );
 
 			} );
 

--- a/packages/three-vrm-core/examples/humanoid.html
+++ b/packages/three-vrm-core/examples/humanoid.html
@@ -19,12 +19,26 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
-		<script src="../lib/three-vrm-core.js"></script>
-		<script>
-			/* global THREE_VRM_CORE*/
+		<!-- Import maps polyfill -->
+		<!-- Remove this when import maps will be widely supported -->
+		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+		<script type="importmap">
+			{
+				"imports": {
+					"three": "https://unpkg.com/three@0.146/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.146/examples/jsm/",
+					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
+				}
+			}
+		</script>
+
+		<script type="module">
+			import * as THREE from 'three';
+			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+			import { VRMCoreLoaderPlugin } from '@pixiv/three-vrm-core';
+
 			// renderer
 			const renderer = new THREE.WebGLRenderer();
 			renderer.setSize( window.innerWidth, window.innerHeight );
@@ -37,7 +51,7 @@
 			camera.position.set( 0.0, 1.0, 5.0 );
 
 			// camera controls
-			const controls = new THREE.OrbitControls( camera, renderer.domElement );
+			const controls = new OrbitControls( camera, renderer.domElement );
 			controls.screenSpacePanning = true;
 			controls.target.set( 0.0, 1.0, 0.0 );
 			controls.update();
@@ -53,12 +67,12 @@
 			// gltf and vrm
 			let currentGltf = undefined;
 
-			const loader = new THREE.GLTFLoader();
+			const loader = new GLTFLoader();
 			loader.crossOrigin = 'anonymous';
 
 			loader.register( ( parser ) => {
 
-				return new THREE_VRM_CORE.VRMCoreLoaderPlugin( parser, { helperRoot: scene, autoUpdateHumanBones: true } );
+				return new VRMCoreLoaderPlugin( parser, { helperRoot: scene, autoUpdateHumanBones: true } );
 
 			} );
 

--- a/packages/three-vrm-core/examples/humanoidAnimation/index.html
+++ b/packages/three-vrm-core/examples/humanoidAnimation/index.html
@@ -30,14 +30,21 @@
 			drag and drop <a href="https://www.mixamo.com/" target="_blank" rel="noopener noreferrer">mixamo</a> animation (.fbx)
 		</div>
 
-		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
-		<script src="https://cdn.jsdelivr.net/npm/fflate/umd/index.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/FBXLoader.js"></script>
-		<script src="../../lib/three-vrm-core.js"></script>
-		<script src="mixamoRigMap.js"></script>
-		<script src="loadMixamoAnimation.js"></script>
-		<script src="main.js""></script>
+		<!-- Import maps polyfill -->
+		<!-- Remove this when import maps will be widely supported -->
+		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+		<script type="importmap">
+			{
+				"imports": {
+					"fflate": "https://unpkg.com/fflate@0.7.4/esm/browser.js",
+					"three": "https://unpkg.com/three@0.146/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.146/examples/jsm/",
+					"@pixiv/three-vrm-core": "../../lib/three-vrm-core.module.js"
+				}
+			}
+		</script>
+
+		<script src="main.js" type="module"></script>
 	</body>
 </html>

--- a/packages/three-vrm-core/examples/humanoidAnimation/loadMixamoAnimation.js
+++ b/packages/three-vrm-core/examples/humanoidAnimation/loadMixamoAnimation.js
@@ -1,4 +1,6 @@
-/* global THREE, mixamoVRMRigMap */
+import * as THREE from 'three';
+import { FBXLoader } from 'three/addons/loaders/FBXLoader.js';
+import { mixamoVRMRigMap } from './mixamoVRMRigMap.js';
 
 /**
  * Load Mixamo animation, convert for three-vrm use, and return it.
@@ -7,9 +9,9 @@
  * @param {VRM} vrm A target VRM
  * @returns {Promise<THREE.AnimationClip>} The converted AnimationClip
  */
-function loadMixamoAnimation( url, vrm ) {
+export function loadMixamoAnimation( url, vrm ) {
 
-	const loader = new THREE.FBXLoader(); // A loader which loads FBX
+	const loader = new FBXLoader(); // A loader which loads FBX
 	return loader.loadAsync( url ).then( ( asset ) => {
 
 		const clip = THREE.AnimationClip.findByName( asset.animations, 'mixamo.com' ); // extract the AnimationClip

--- a/packages/three-vrm-core/examples/humanoidAnimation/main.js
+++ b/packages/three-vrm-core/examples/humanoidAnimation/main.js
@@ -1,4 +1,8 @@
-/* global THREE, THREE_VRM_CORE, loadMixamoAnimation */
+import * as THREE from 'three';
+import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+import { VRMCoreLoaderPlugin } from '@pixiv/three-vrm-core';
+import { loadMixamoAnimation } from './loadMixamoAnimation.js';
 
 // renderer
 const renderer = new THREE.WebGLRenderer();
@@ -12,7 +16,7 @@ const camera = new THREE.PerspectiveCamera( 30.0, window.innerWidth / window.inn
 camera.position.set( 0.0, 1.0, 5.0 );
 
 // camera controls
-const controls = new THREE.OrbitControls( camera, renderer.domElement );
+const controls = new OrbitControls( camera, renderer.domElement );
 controls.screenSpacePanning = true;
 controls.target.set( 0.0, 1.0, 0.0 );
 controls.update();
@@ -38,14 +42,14 @@ scene.add( helperRoot );
 
 function loadVRM( modelUrl ) {
 
-	const loader = new THREE.GLTFLoader();
+	const loader = new GLTFLoader();
 	loader.crossOrigin = 'anonymous';
 
 	helperRoot.clear();
 
 	loader.register( ( parser ) => {
 
-		return new THREE_VRM_CORE.VRMCoreLoaderPlugin( parser, { helperRoot: helperRoot, autoUpdateHumanBones: true } );
+		return new VRMCoreLoaderPlugin( parser, { helperRoot: helperRoot, autoUpdateHumanBones: true } );
 
 	} );
 

--- a/packages/three-vrm-core/examples/humanoidAnimation/mixamoVRMRigMap.js
+++ b/packages/three-vrm-core/examples/humanoidAnimation/mixamoVRMRigMap.js
@@ -1,7 +1,7 @@
 /**
  * A map from Mixamo rig name to VRM Humanoid bone name
  */
-const mixamoVRMRigMap = {
+export const mixamoVRMRigMap = {
 	mixamorigHips: 'hips',
 	mixamorigSpine: 'spine',
 	mixamorigSpine1: 'chest',

--- a/packages/three-vrm-core/examples/lookAt.html
+++ b/packages/three-vrm-core/examples/lookAt.html
@@ -24,12 +24,27 @@
 
 	<body>
 		<span id="info"></span>
-		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
-		<script src="../lib/three-vrm-core.js"></script>
-		<script>
-			/* global THREE_VRM_CORE*/
+
+		<!-- Import maps polyfill -->
+		<!-- Remove this when import maps will be widely supported -->
+		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+		<script type="importmap">
+			{
+				"imports": {
+					"three": "https://unpkg.com/three@0.146/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.146/examples/jsm/",
+					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
+				}
+			}
+		</script>
+
+		<script type="module">
+			import * as THREE from 'three';
+			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+			import { VRMCoreLoaderPlugin } from '@pixiv/three-vrm-core';
+
 			// renderer
 			const renderer = new THREE.WebGLRenderer();
 			renderer.setSize( window.innerWidth, window.innerHeight );
@@ -42,7 +57,7 @@
 			camera.position.set( 0.0, 1.0, 5.0 );
 
 			// camera controls
-			const controls = new THREE.OrbitControls( camera, renderer.domElement );
+			const controls = new OrbitControls( camera, renderer.domElement );
 			controls.screenSpacePanning = true;
 			controls.target.set( 0.0, 1.0, 0.0 );
 			controls.update();
@@ -63,12 +78,12 @@
 			// gltf and vrm
 			let currentGltf = undefined;
 
-			const loader = new THREE.GLTFLoader();
+			const loader = new GLTFLoader();
 			loader.crossOrigin = 'anonymous';
 
 			loader.register( ( parser ) => {
 
-				return new THREE_VRM_CORE.VRMCoreLoaderPlugin( parser, { helperRoot: scene, autoUpdateHumanBones: true } );
+				return new VRMCoreLoaderPlugin( parser, { helperRoot: scene, autoUpdateHumanBones: true } );
 
 			} );
 

--- a/packages/three-vrm-core/examples/meta.html
+++ b/packages/three-vrm-core/examples/meta.html
@@ -31,12 +31,27 @@
 	<body>
 		<span id="meta"></span>
 		<img id="thumbnail" alt="thumbnail" />
-		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
-		<script src="../lib/three-vrm-core.js"></script>
-		<script>
-			/* global THREE_VRM_CORE*/
+
+		<!-- Import maps polyfill -->
+		<!-- Remove this when import maps will be widely supported -->
+		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+		<script type="importmap">
+			{
+				"imports": {
+					"three": "https://unpkg.com/three@0.146/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.146/examples/jsm/",
+					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
+				}
+			}
+		</script>
+
+		<script type="module">
+			import * as THREE from 'three';
+			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+			import { VRMCoreLoaderPlugin } from '@pixiv/three-vrm-core';
+
 			// renderer
 			const renderer = new THREE.WebGLRenderer();
 			renderer.setSize( window.innerWidth, window.innerHeight );
@@ -49,7 +64,7 @@
 			camera.position.set( 0.0, 1.0, 5.0 );
 
 			// camera controls
-			const controls = new THREE.OrbitControls( camera, renderer.domElement );
+			const controls = new OrbitControls( camera, renderer.domElement );
 			controls.screenSpacePanning = true;
 			controls.target.set( 0.0, 1.0, 0.0 );
 			controls.update();
@@ -64,12 +79,12 @@
 
 			// gltf and vrm
 			let currentGltf = undefined;
-			const loader = new THREE.GLTFLoader();
+			const loader = new GLTFLoader();
 			loader.crossOrigin = 'anonymous';
 
 			loader.register( ( parser ) => {
 
-				return new THREE_VRM_CORE.VRMCoreLoaderPlugin( parser );
+				return new VRMCoreLoaderPlugin( parser );
 
 			} );
 

--- a/packages/three-vrm-materials-hdr-emissive-multiplier/examples/loader-plugin.html
+++ b/packages/three-vrm-materials-hdr-emissive-multiplier/examples/loader-plugin.html
@@ -19,12 +19,26 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
-		<script src="../lib/three-vrm-materials-hdr-emissive-multiplier.js"></script>
-		<script>
-			/*  global THREE_VRM_MATERIALS_HDR_EMISSIVE_MULTIPLIER */
+		<!-- Import maps polyfill -->
+		<!-- Remove this when import maps will be widely supported -->
+		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+		<script type="importmap">
+			{
+				"imports": {
+					"three": "https://unpkg.com/three@0.146/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.146/examples/jsm/",
+					"@pixiv/three-vrm-materials-hdr-emissive-multiplier": "../lib/three-vrm-materials-hdr-emissive-multiplier.module.js"
+				}
+			}
+		</script>
+
+		<script type="module">
+			import * as THREE from 'three';
+			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+			import { VRMMaterialsHDREmissiveMultiplierLoaderPlugin } from '@pixiv/three-vrm-materials-hdr-emissive-multiplier';
+
 			// renderer
 			const renderer = new THREE.WebGLRenderer();
 			renderer.outputEncoding = THREE.sRGBEncoding;
@@ -37,7 +51,7 @@
 			camera.position.set( 0.0, 0.0, 10.0 );
 
 			// camera controls
-			const controls = new THREE.OrbitControls( camera, renderer.domElement );
+			const controls = new OrbitControls( camera, renderer.domElement );
 			controls.screenSpacePanning = true;
 			controls.target.set( 0.0, 0.0, 0.0 );
 			controls.update();
@@ -52,11 +66,11 @@
 			// gltf and vrm
 			let currentGltf = null;
 
-			const loader = new THREE.GLTFLoader();
+			const loader = new GLTFLoader();
 
 			loader.register( ( parser ) => {
 
-				const plugin = new THREE_VRM_MATERIALS_HDR_EMISSIVE_MULTIPLIER.VRMMaterialsHDREmissiveMultiplierLoaderPlugin( parser );
+				const plugin = new VRMMaterialsHDREmissiveMultiplierLoaderPlugin( parser );
 				return plugin;
 
 			} );

--- a/packages/three-vrm-materials-mtoon/examples/emissive-strength.html
+++ b/packages/three-vrm-materials-mtoon/examples/emissive-strength.html
@@ -19,17 +19,27 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/shaders/CopyShader.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/shaders/LuminosityHighPassShader.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/postprocessing/EffectComposer.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/postprocessing/ShaderPass.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/postprocessing/RenderPass.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/postprocessing/UnrealBloomPass.js"></script>
-		<script src="../lib/three-vrm-materials-mtoon.js"></script>
-		<script>
+		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+		<script type="importmap">
+			{
+				"imports": {
+					"three": "https://unpkg.com/three@0.146/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.146/examples/jsm/",
+					"@pixiv/three-vrm-materials-mtoon": "../lib/three-vrm-materials-mtoon.module.js"
+				}
+			}
+		</script>
+
+		<script type="module">
+			import * as THREE from 'three';
+			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+			import { EffectComposer } from 'three/addons/postprocessing/EffectComposer.js';
+			import { RenderPass } from 'three/addons/postprocessing/RenderPass.js';
+			import { UnrealBloomPass } from 'three/addons/postprocessing/UnrealBloomPass.js';
+			import { MToonMaterialLoaderPlugin } from '@pixiv/three-vrm-materials-mtoon';
+
 			/* global THREE_VRM_MATERIALS_MTOON */
 			// renderer
 			const renderer = new THREE.WebGLRenderer();
@@ -44,7 +54,7 @@
 			camera.position.set( 0.0, 0.0, 10.0 );
 
 			// camera controls
-			const controls = new THREE.OrbitControls( camera, renderer.domElement );
+			const controls = new OrbitControls( camera, renderer.domElement );
 			controls.screenSpacePanning = true;
 			controls.target.set( 0.0, 0.0, 0.0 );
 			controls.update();
@@ -59,11 +69,11 @@
 			// gltf and vrm
 			let currentGltf = null;
 
-			const loader = new THREE.GLTFLoader();
+			const loader = new GLTFLoader();
 
 			loader.register( ( parser ) => {
 
-				const plugin = new THREE_VRM_MATERIALS_MTOON.MToonMaterialLoaderPlugin( parser );
+				const plugin = new MToonMaterialLoaderPlugin( parser );
 				return plugin;
 
 			} );
@@ -103,12 +113,12 @@
 			scene.add( axesHelper );
 
 			// composer
-			const composer = new THREE.EffectComposer( renderer );
+			const composer = new EffectComposer( renderer );
 
-			const renderPass = new THREE.RenderPass( scene, camera );
+			const renderPass = new RenderPass( scene, camera );
 			composer.addPass( renderPass );
 
-			const bloomPass = new THREE.UnrealBloomPass(
+			const bloomPass = new UnrealBloomPass(
 
 				// resolution
 				new THREE.Vector2( window.innerWidth, window.innerHeight ),

--- a/packages/three-vrm-materials-mtoon/examples/loader-plugin.html
+++ b/packages/three-vrm-materials-mtoon/examples/loader-plugin.html
@@ -19,12 +19,26 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
-		<script src="../lib/three-vrm-materials-mtoon.js"></script>
-		<script>
-			/* global THREE_VRM_MATERIALS_MTOON */
+		<!-- Import maps polyfill -->
+		<!-- Remove this when import maps will be widely supported -->
+		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+		<script type="importmap">
+			{
+				"imports": {
+					"three": "https://unpkg.com/three@0.146/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.146/examples/jsm/",
+					"@pixiv/three-vrm-materials-mtoon": "../lib/three-vrm-materials-mtoon.module.js"
+				}
+			}
+		</script>
+
+		<script type="module">
+			import * as THREE from 'three';
+			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+			import { MToonMaterialLoaderPlugin } from '@pixiv/three-vrm-materials-mtoon';
+
 			// renderer
 			const renderer = new THREE.WebGLRenderer();
 			renderer.outputEncoding = THREE.sRGBEncoding;
@@ -37,7 +51,7 @@
 			camera.position.set( 0.0, 0.0, 10.0 );
 
 			// camera controls
-			const controls = new THREE.OrbitControls( camera, renderer.domElement );
+			const controls = new OrbitControls( camera, renderer.domElement );
 			controls.screenSpacePanning = true;
 			controls.target.set( 0.0, 0.0, 0.0 );
 			controls.update();
@@ -52,11 +66,11 @@
 			// gltf and vrm
 			let currentGltf = null;
 
-			const loader = new THREE.GLTFLoader();
+			const loader = new GLTFLoader();
 
 			loader.register( ( parser ) => {
 
-				const plugin = new THREE_VRM_MATERIALS_MTOON.MToonMaterialLoaderPlugin( parser );
+				const plugin = new MToonMaterialLoaderPlugin( parser );
 				return plugin;
 
 			} );

--- a/packages/three-vrm-node-constraint/examples/aim.html
+++ b/packages/three-vrm-node-constraint/examples/aim.html
@@ -19,13 +19,25 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
-		<script src="https://unpkg.com/tweakpane@3.0"></script>
-		<script src="https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1"></script>
-		<script src="../lib/three-vrm-node-constraint.js"></script>
-		<script>
-			/* global Tweakpane, TweakpaneRotationInputPlugin, THREE_VRM_NODE_CONSTRAINT */
+		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+		<script type="importmap">
+			{
+			  "imports": {
+				"three": "https://unpkg.com/three@0.146.0/build/three.module.js",
+				"three/addons/": "https://unpkg.com/three@0.146.0/examples/jsm/",
+				"tweakpane": "https://unpkg.com/tweakpane@3.0",
+				"tweakpane-plugin-rotation": "https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1",
+				"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"
+			  }
+			}
+		</script>
+		<script type="module">
+			import * as THREE from 'three';
+			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+			import 'tweakpane';
+			import 'tweakpane-plugin-rotation';
+			import { VRMNodeConstraintManager, VRMAimConstraint, VRMNodeConstraintHelper } from '@pixiv/three-vrm-node-constraint';
+			/* global Tweakpane, TweakpaneRotationInputPlugin */
 			// gui
 			const guiParams = {
 
@@ -72,7 +84,7 @@
 			camera.position.set( 0.0, 1.0, 10.0 );
 
 			// camera controls
-			const controls = new THREE.OrbitControls( camera, renderer.domElement );
+			const controls = new OrbitControls( camera, renderer.domElement );
 			controls.screenSpacePanning = true;
 			controls.target.set( 0.0, 1.0, 0.0 );
 			controls.update();
@@ -111,20 +123,20 @@
 			scene.add( axesHelper );
 
 			// constraints
-			const constraintManager = new THREE_VRM_NODE_CONSTRAINT.VRMNodeConstraintManager( {
+			const constraintManager = new VRMNodeConstraintManager( {
 
 				autoRemoveCircularDependency: true
 
 			} );
 
-			const constraint = new THREE_VRM_NODE_CONSTRAINT.VRMAimConstraint( aim, lowerArm );
+			const constraint = new VRMAimConstraint( aim, lowerArm );
 			constraint.aimAxis = 'PositiveY';
 			constraintManager.addConstraint( constraint );
 
 			// constraint helpers
 			Array.from( constraintManager.constraints ).forEach( ( constraint ) => {
 
-				const helper = new THREE_VRM_NODE_CONSTRAINT.VRMNodeConstraintHelper( constraint );
+				const helper = new VRMNodeConstraintHelper( constraint );
 				scene.add( helper );
 
 			} );

--- a/packages/three-vrm-node-constraint/examples/aim.html
+++ b/packages/three-vrm-node-constraint/examples/aim.html
@@ -23,11 +23,11 @@
 		<script type="importmap">
 			{
 			  "imports": {
-				"three": "https://unpkg.com/three@0.146.0/build/three.module.js",
-				"three/addons/": "https://unpkg.com/three@0.146.0/examples/jsm/",
-				"tweakpane": "https://unpkg.com/tweakpane@3.0",
-				"tweakpane-plugin-rotation": "https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1",
-				"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"
+					"three": "https://unpkg.com/three@0.146.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.146.0/examples/jsm/",
+					"tweakpane": "https://unpkg.com/tweakpane@3.0",
+					"tweakpane-plugin-rotation": "https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1",
+					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"
 			  }
 			}
 		</script>

--- a/packages/three-vrm-node-constraint/examples/importer.html
+++ b/packages/three-vrm-node-constraint/examples/importer.html
@@ -23,11 +23,11 @@
 		<script type="importmap">
 			{
 			  "imports": {
-				"three": "https://unpkg.com/three@0.146.0/build/three.module.js",
-				"three/addons/": "https://unpkg.com/three@0.146.0/examples/jsm/",
-				"tweakpane": "https://unpkg.com/tweakpane@3.0",
-				"tweakpane-plugin-rotation": "https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1",
-				"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"
+					"three": "https://unpkg.com/three@0.146.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.146.0/examples/jsm/",
+					"tweakpane": "https://unpkg.com/tweakpane@3.0",
+					"tweakpane-plugin-rotation": "https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1",
+					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"
 			  }
 			}
 		</script>

--- a/packages/three-vrm-node-constraint/examples/importer.html
+++ b/packages/three-vrm-node-constraint/examples/importer.html
@@ -19,14 +19,26 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
-		<script src="https://unpkg.com/tweakpane@3.0"></script>
-		<script src="https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1"></script>
-		<script src="../lib/three-vrm-node-constraint.js"></script>
-		<script>
-			/* global Tweakpane, TweakpaneRotationInputPlugin, THREE_VRM_NODE_CONSTRAINT */
+		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+		<script type="importmap">
+			{
+			  "imports": {
+				"three": "https://unpkg.com/three@0.146.0/build/three.module.js",
+				"three/addons/": "https://unpkg.com/three@0.146.0/examples/jsm/",
+				"tweakpane": "https://unpkg.com/tweakpane@3.0",
+				"tweakpane-plugin-rotation": "https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1",
+				"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"
+			  }
+			}
+		</script>
+		<script type="module">
+			import * as THREE from 'three';
+			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+			import 'tweakpane';
+			import 'tweakpane-plugin-rotation';
+			import { VRMNodeConstraintLoaderPlugin } from '@pixiv/three-vrm-node-constraint';
+			/* global Tweakpane, TweakpaneRotationInputPlugin */
 			// gui
 			const guiParams = {
 
@@ -56,7 +68,7 @@
 			camera.position.set( 0.0, 0.0, 10.0 );
 
 			// camera controls
-			const controls = new THREE.OrbitControls( camera, renderer.domElement );
+			const controls = new OrbitControls( camera, renderer.domElement );
 			controls.screenSpacePanning = true;
 			controls.target.set( 0.0, 0.0, 0.0 );
 			controls.update();
@@ -72,7 +84,7 @@
 			// gltf and vrm
 			let currentGltf = null;
 
-			const loader = new THREE.GLTFLoader();
+			const loader = new GLTFLoader();
 
 			const pluginOptions = {
 
@@ -82,7 +94,7 @@
 
 			loader.register( ( parser ) => {
 
-				return new THREE_VRM_NODE_CONSTRAINT.VRMNodeConstraintLoaderPlugin( parser, pluginOptions );
+				return new VRMNodeConstraintLoaderPlugin( parser, pluginOptions );
 
 			} );
 

--- a/packages/three-vrm-node-constraint/examples/roll.html
+++ b/packages/three-vrm-node-constraint/examples/roll.html
@@ -23,11 +23,11 @@
 		<script type="importmap">
 			{
 			  "imports": {
-				"three": "https://unpkg.com/three@0.146.0/build/three.module.js",
-				"three/addons/": "https://unpkg.com/three@0.146.0/examples/jsm/",
-				"tweakpane": "https://unpkg.com/tweakpane@3.0",
-				"tweakpane-plugin-rotation": "https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1",
-				"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"
+					"three": "https://unpkg.com/three@0.146.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.146.0/examples/jsm/",
+					"tweakpane": "https://unpkg.com/tweakpane@3.0",
+					"tweakpane-plugin-rotation": "https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1",
+					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"
 			  }
 			}
 		</script>

--- a/packages/three-vrm-node-constraint/examples/roll.html
+++ b/packages/three-vrm-node-constraint/examples/roll.html
@@ -19,13 +19,26 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
-		<script src="https://unpkg.com/tweakpane@3.0"></script>
-		<script src="https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1"></script>
-		<script src="../lib/three-vrm-node-constraint.js"></script>
-		<script>
-			/* global Tweakpane, TweakpaneRotationInputPlugin, THREE_VRM_NODE_CONSTRAINT */
+		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+		<script type="importmap">
+			{
+			  "imports": {
+				"three": "https://unpkg.com/three@0.146.0/build/three.module.js",
+				"three/addons/": "https://unpkg.com/three@0.146.0/examples/jsm/",
+				"tweakpane": "https://unpkg.com/tweakpane@3.0",
+				"tweakpane-plugin-rotation": "https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1",
+				"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"
+			  }
+			}
+		</script>
+		<script type="module">
+			import * as THREE from 'three';
+			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+			import 'tweakpane';
+			import 'tweakpane-plugin-rotation';
+			import { VRMNodeConstraintManager, VRMRollConstraint, VRMNodeConstraintHelper } from '@pixiv/three-vrm-node-constraint';
+			
+			/* global Tweakpane, TweakpaneRotationInputPlugin */
 			// gui
 			const guiParams = {
 
@@ -72,7 +85,7 @@
 			camera.position.set( 0.0, 1.0, 10.0 );
 
 			// camera controls
-			const controls = new THREE.OrbitControls( camera, renderer.domElement );
+			const controls = new OrbitControls( camera, renderer.domElement );
 			controls.screenSpacePanning = true;
 			controls.target.set( 0.0, 1.0, 0.0 );
 			controls.update();
@@ -111,20 +124,20 @@
 			scene.add( axesHelper );
 
 			// constraints
-			const constraintManager = new THREE_VRM_NODE_CONSTRAINT.VRMNodeConstraintManager( {
+			const constraintManager = new VRMNodeConstraintManager( {
 
 				autoRemoveCircularDependency: true
 
 			} );
 
-			const constraint = new THREE_VRM_NODE_CONSTRAINT.VRMRollConstraint( roll, hand );
+			const constraint = new VRMRollConstraint( roll, hand );
 			constraint.rollAxis = 'Y';
 			constraintManager.addConstraint( constraint );
 
 			// constraint helpers
 			Array.from( constraintManager.constraints ).forEach( ( constraint ) => {
 
-				const helper = new THREE_VRM_NODE_CONSTRAINT.VRMNodeConstraintHelper( constraint );
+				const helper = new VRMNodeConstraintHelper( constraint );
 				scene.add( helper );
 
 			} );

--- a/packages/three-vrm-node-constraint/examples/rotation.html
+++ b/packages/three-vrm-node-constraint/examples/rotation.html
@@ -23,11 +23,11 @@
 		<script type="importmap">
 			{
 			  "imports": {
-				"three": "https://unpkg.com/three@0.146.0/build/three.module.js",
-				"three/addons/": "https://unpkg.com/three@0.146.0/examples/jsm/",
-				"tweakpane": "https://unpkg.com/tweakpane@3.0",
-				"tweakpane-plugin-rotation": "https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1",
-				"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"
+					"three": "https://unpkg.com/three@0.146.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.146.0/examples/jsm/",
+					"tweakpane": "https://unpkg.com/tweakpane@3.0",
+					"tweakpane-plugin-rotation": "https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1",
+					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"
 			  }
 			}
 		</script>

--- a/packages/three-vrm-node-constraint/examples/rotation.html
+++ b/packages/three-vrm-node-constraint/examples/rotation.html
@@ -19,13 +19,25 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
-		<script src="https://unpkg.com/tweakpane@3.0"></script>
-		<script src="https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1"></script>
-		<script src="../lib/three-vrm-node-constraint.js"></script>
-		<script>
-			/* global Tweakpane, TweakpaneRotationInputPlugin, THREE_VRM_NODE_CONSTRAINT */
+		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+		<script type="importmap">
+			{
+			  "imports": {
+				"three": "https://unpkg.com/three@0.146.0/build/three.module.js",
+				"three/addons/": "https://unpkg.com/three@0.146.0/examples/jsm/",
+				"tweakpane": "https://unpkg.com/tweakpane@3.0",
+				"tweakpane-plugin-rotation": "https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1",
+				"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"
+			  }
+			}
+		</script>
+		<script type="module">
+			import * as THREE from 'three';
+			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+			import 'tweakpane';
+			import 'tweakpane-plugin-rotation';
+			import { VRMNodeConstraintManager, VRMRotationConstraint, VRMNodeConstraintHelper } from '@pixiv/three-vrm-node-constraint';
+			/* global Tweakpane, TweakpaneRotationInputPlugin */
 			// gui
 			const guiParams = {
 
@@ -63,7 +75,7 @@
 			camera.position.set( 0.0, 1.0, 10.0 );
 
 			// camera controls
-			const controls = new THREE.OrbitControls( camera, renderer.domElement );
+			const controls = new OrbitControls( camera, renderer.domElement );
 			controls.screenSpacePanning = true;
 			controls.target.set( 0.0, 1.0, 0.0 );
 			controls.update();
@@ -98,19 +110,19 @@
 			scene.add( axesHelper );
 
 			// constraints
-			const constraintManager = new THREE_VRM_NODE_CONSTRAINT.VRMNodeConstraintManager( {
+			const constraintManager = new VRMNodeConstraintManager( {
 
 				autoRemoveCircularDependency: true
 
 			} );
 
-			const constraint = new THREE_VRM_NODE_CONSTRAINT.VRMRotationConstraint( destination, source );
+			const constraint = new VRMRotationConstraint( destination, source );
 			constraintManager.addConstraint( constraint );
 
 			// constraint helpers
 			Array.from( constraintManager.constraints ).forEach( ( constraint ) => {
 
-				const helper = new THREE_VRM_NODE_CONSTRAINT.VRMNodeConstraintHelper( constraint );
+				const helper = new VRMNodeConstraintHelper( constraint );
 				scene.add( helper );
 
 			} );

--- a/packages/three-vrm-node-constraint/examples/upper-arm.html
+++ b/packages/three-vrm-node-constraint/examples/upper-arm.html
@@ -19,13 +19,25 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
-		<script src="https://unpkg.com/tweakpane@3.0"></script>
-		<script src="https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1"></script>
-		<script src="../lib/three-vrm-node-constraint.js"></script>
-		<script>
-			/* global Tweakpane, TweakpaneRotationInputPlugin, THREE_VRM_NODE_CONSTRAINT */
+		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+		<script type="importmap">
+			{
+			  "imports": {
+				"three": "https://unpkg.com/three@0.146.0/build/three.module.js",
+				"three/addons/": "https://unpkg.com/three@0.146.0/examples/jsm/",
+				"tweakpane": "https://unpkg.com/tweakpane@3.0",
+				"tweakpane-plugin-rotation": "https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1",
+				"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"
+			  }
+			}
+		</script>
+		<script type="module">
+			import * as THREE from 'three';
+			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+			import 'tweakpane';
+			import 'tweakpane-plugin-rotation';
+			import { VRMNodeConstraintManager, VRMAimConstraint, VRMRollConstraint, VRMNodeConstraintHelper } from '@pixiv/three-vrm-node-constraint';
+			/* global Tweakpane, TweakpaneRotationInputPlugin */
 			// gui
 			const guiParams = {
 
@@ -64,7 +76,7 @@
 			camera.position.set( 0.0, 1.0, 10.0 );
 
 			// camera controls
-			const controls = new THREE.OrbitControls( camera, renderer.domElement );
+			const controls = new OrbitControls( camera, renderer.domElement );
 			controls.screenSpacePanning = true;
 			controls.target.set( 0.0, 1.0, 0.0 );
 			controls.update();
@@ -111,17 +123,17 @@
 			scene.add( axesHelper );
 
 			// constraints
-			const constraintManager = new THREE_VRM_NODE_CONSTRAINT.VRMNodeConstraintManager( {
+			const constraintManager = new VRMNodeConstraintManager( {
 
 				autoRemoveCircularDependency: true
 
 			} );
 
-			const aimConstraint = new THREE_VRM_NODE_CONSTRAINT.VRMAimConstraint( twistParent, lowerArm );
+			const aimConstraint = new VRMAimConstraint( twistParent, lowerArm );
 			aimConstraint.aimAxis = '+Y';
 			constraintManager.addConstraint( aimConstraint );
 
-			const rollConstraint = new THREE_VRM_NODE_CONSTRAINT.VRMRollConstraint( twist2, upperArm );
+			const rollConstraint = new VRMRollConstraint( twist2, upperArm );
 			rollConstraint.rollAxis = 'Y';
 			rollConstraint.weight = 0.5;
 			constraintManager.addConstraint( rollConstraint );
@@ -129,7 +141,7 @@
 			// constraint helpers
 			Array.from( constraintManager.constraints ).forEach( ( constraint ) => {
 
-				const helper = new THREE_VRM_NODE_CONSTRAINT.VRMNodeConstraintHelper( constraint );
+				const helper = new VRMNodeConstraintHelper( constraint );
 				scene.add( helper );
 
 			} );

--- a/packages/three-vrm-node-constraint/examples/upper-arm.html
+++ b/packages/three-vrm-node-constraint/examples/upper-arm.html
@@ -23,11 +23,11 @@
 		<script type="importmap">
 			{
 			  "imports": {
-				"three": "https://unpkg.com/three@0.146.0/build/three.module.js",
-				"three/addons/": "https://unpkg.com/three@0.146.0/examples/jsm/",
-				"tweakpane": "https://unpkg.com/tweakpane@3.0",
-				"tweakpane-plugin-rotation": "https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1",
-				"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"
+					"three": "https://unpkg.com/three@0.146.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.146.0/examples/jsm/",
+					"tweakpane": "https://unpkg.com/tweakpane@3.0",
+					"tweakpane-plugin-rotation": "https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1",
+					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"
 			  }
 			}
 		</script>

--- a/packages/three-vrm-springbone/examples/collider.html
+++ b/packages/three-vrm-springbone/examples/collider.html
@@ -25,7 +25,7 @@
 			  "imports": {
 				"three": "https://unpkg.com/three@0.146.0/build/three.module.js",
 				"three/addons/": "https://unpkg.com/three@0.146.0/examples/jsm/",
-				"@pixiv/three-vrm": "../lib/three-vrm-springbone.module.js"
+				"@pixiv/three-vrm-springbone": "../lib/three-vrm-springbone.module.js"
 			  }
 			}
 		</script>
@@ -40,7 +40,7 @@
 				VRMSpringBoneManager,
 				VRMSpringBoneJoint,
 				VRMSpringBoneJointHelper
-			} from '@pixiv/three-vrm';
+			} from '@pixiv/three-vrm-springbone';
 			
 			// renderer
 			const renderer = new THREE.WebGLRenderer();

--- a/packages/three-vrm-springbone/examples/collider.html
+++ b/packages/three-vrm-springbone/examples/collider.html
@@ -19,11 +19,29 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
-		<script src="../lib/three-vrm-springbone.js"></script>
-		<script>
+		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+		<script type="importmap">
+			{
+			  "imports": {
+				"three": "https://unpkg.com/three@0.146.0/build/three.module.js",
+				"three/addons/": "https://unpkg.com/three@0.146.0/examples/jsm/",
+				"@pixiv/three-vrm": "../lib/three-vrm-springbone.module.js"
+			  }
+			}
+		</script>
+		<script type="module">
+			import * as THREE from 'three';
+			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+			import {
+				VRMSpringBoneColliderShapeCapsule,
+				VRMSpringBoneCollider,
+				VRMSpringBoneColliderHelper,
+				VRMSpringBoneManager,
+				VRMSpringBoneJoint,
+				VRMSpringBoneJointHelper
+			} from '@pixiv/three-vrm';
+			
 			// renderer
 			const renderer = new THREE.WebGLRenderer();
 			renderer.setSize( window.innerWidth, window.innerHeight );
@@ -35,7 +53,7 @@
 			camera.position.set( 0.0, 0.0, 5.0 );
 
 			// camera controls
-			const controls = new THREE.OrbitControls( camera, renderer.domElement );
+			const controls = new OrbitControls( camera, renderer.domElement );
 			controls.screenSpacePanning = true;
 			controls.target.set( 0.0, 0.0, 0.0 );
 			controls.update();
@@ -79,7 +97,7 @@
 			// collider
 			const colliders = [];
 
-			const colliderShape = new THREE.VRMSpringBoneColliderShapeCapsule( {
+			const colliderShape = new VRMSpringBoneColliderShapeCapsule( {
 
 				radius: 0.2,
 				offset: new THREE.Vector3( - 0.5, - 0.5, 1.0 ),
@@ -87,21 +105,21 @@
 
 			} );
 
-			const collider = new THREE.VRMSpringBoneCollider( colliderShape );
+			const collider = new VRMSpringBoneCollider( colliderShape );
 			scene.add( collider );
 
 			colliders.push( collider );
 
 			// collider helper
-			const colliderHelper = new THREE.VRMSpringBoneColliderHelper( collider );
+			const colliderHelper = new VRMSpringBoneColliderHelper( collider );
 			scene.add( colliderHelper );
 
 			// spring bone
-			const springBoneManager = new THREE.VRMSpringBoneManager();
+			const springBoneManager = new VRMSpringBoneManager();
 
 			for ( let i = 1; i < 4; i ++ ) {
 
-				const springBone = new THREE.VRMSpringBoneJoint( cubes[ i ], cubes[ i + 1 ], { hitRadius: 0.01 } );
+				const springBone = new VRMSpringBoneJoint( cubes[ i ], cubes[ i + 1 ], { hitRadius: 0.01 } );
 				springBone.colliderGroups = [ { colliders } ];
 				springBoneManager.addSpringBone( springBone );
 
@@ -110,7 +128,7 @@
 			// helpers
 			springBoneManager.springBones.forEach( ( bone ) => {
 
-				const helper = new THREE.VRMSpringBoneJointHelper( bone );
+				const helper = new VRMSpringBoneJointHelper( bone );
 				scene.add( helper );
 
 			} );

--- a/packages/three-vrm-springbone/examples/loader-plugin.html
+++ b/packages/three-vrm-springbone/examples/loader-plugin.html
@@ -19,12 +19,22 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
-		<script src="../lib/three-vrm-springbone.js"></script>
-		<script>
-			/* global THREE_VRM_SPRINGBONE */
+		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+		<script type="importmap">
+			{
+			  "imports": {
+				"three": "https://unpkg.com/three@0.146.0/build/three.module.js",
+				"three/addons/": "https://unpkg.com/three@0.146.0/examples/jsm/",
+				"@pixiv/three-vrm": "../lib/three-vrm-springbone.module.js"
+			  }
+			}
+		</script>
+		<script type="module">
+			import * as THREE from 'three';
+			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+			import { VRMSpringBoneLoaderPlugin } from "@pixiv/three-vrm";
+
 			// renderer
 			const renderer = new THREE.WebGLRenderer();
 			renderer.setSize( window.innerWidth, window.innerHeight );
@@ -36,7 +46,7 @@
 			camera.position.set( 0.0, 1.0, 5.0 );
 
 			// camera controls
-			const controls = new THREE.OrbitControls( camera, renderer.domElement );
+			const controls = new OrbitControls( camera, renderer.domElement );
 			controls.screenSpacePanning = true;
 			controls.target.set( 0.0, 1.0, 0.0 );
 			controls.update();
@@ -53,7 +63,7 @@
 			let currentGltf = null;
 			let currentSpringBoneManager = null;
 
-			const loader = new THREE.GLTFLoader();
+			const loader = new GLTFLoader();
 
 			const loaderPluginOptions = {
 
@@ -64,7 +74,7 @@
 
 			loader.register( ( parser ) => {
 
-				return new THREE_VRM_SPRINGBONE.VRMSpringBoneLoaderPlugin( parser, loaderPluginOptions );
+				return new VRMSpringBoneLoaderPlugin( parser, loaderPluginOptions );
 
 			} );
 

--- a/packages/three-vrm-springbone/examples/loader-plugin.html
+++ b/packages/three-vrm-springbone/examples/loader-plugin.html
@@ -25,7 +25,7 @@
 			  "imports": {
 				"three": "https://unpkg.com/three@0.146.0/build/three.module.js",
 				"three/addons/": "https://unpkg.com/three@0.146.0/examples/jsm/",
-				"@pixiv/three-vrm": "../lib/three-vrm-springbone.module.js"
+				"@pixiv/three-vrm-springbone": "../lib/three-vrm-springbone.module.js"
 			  }
 			}
 		</script>
@@ -33,7 +33,7 @@
 			import * as THREE from 'three';
 			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
-			import { VRMSpringBoneLoaderPlugin } from "@pixiv/three-vrm";
+			import { VRMSpringBoneLoaderPlugin } from "@pixiv/three-vrm-springbone";
 
 			// renderer
 			const renderer = new THREE.WebGLRenderer();

--- a/packages/three-vrm-springbone/examples/multiple.html
+++ b/packages/three-vrm-springbone/examples/multiple.html
@@ -25,7 +25,7 @@
 			  "imports": {
 				"three": "https://unpkg.com/three@0.146.0/build/three.module.js",
 				"three/addons/": "https://unpkg.com/three@0.146.0/examples/jsm/",
-				"@pixiv/three-vrm": "../lib/three-vrm-springbone.module.js"
+				"@pixiv/three-vrm-springbone": "../lib/three-vrm-springbone.module.js"
 			  }
 			}
 		</script>
@@ -33,7 +33,7 @@
 			import * as THREE from 'three';
 			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
-			import { VRMSpringBoneManager, VRMSpringBoneJoint, VRMSpringBoneJointHelper } from '@pixiv/three-vrm';
+			import { VRMSpringBoneManager, VRMSpringBoneJoint, VRMSpringBoneJointHelper } from '@pixiv/three-vrm-springbone';
 			// renderer
 			const renderer = new THREE.WebGLRenderer();
 			renderer.setSize( window.innerWidth, window.innerHeight );

--- a/packages/three-vrm-springbone/examples/multiple.html
+++ b/packages/three-vrm-springbone/examples/multiple.html
@@ -19,11 +19,21 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
-		<script src="../lib/three-vrm-springbone.js"></script>
-		<script>
+		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+		<script type="importmap">
+			{
+			  "imports": {
+				"three": "https://unpkg.com/three@0.146.0/build/three.module.js",
+				"three/addons/": "https://unpkg.com/three@0.146.0/examples/jsm/",
+				"@pixiv/three-vrm": "../lib/three-vrm-springbone.module.js"
+			  }
+			}
+		</script>
+		<script type="module">
+			import * as THREE from 'three';
+			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+			import { VRMSpringBoneManager, VRMSpringBoneJoint, VRMSpringBoneJointHelper } from '@pixiv/three-vrm';
 			// renderer
 			const renderer = new THREE.WebGLRenderer();
 			renderer.setSize( window.innerWidth, window.innerHeight );
@@ -35,7 +45,7 @@
 			camera.position.set( 0.0, 0.0, 5.0 );
 
 			// camera controls
-			const controls = new THREE.OrbitControls( camera, renderer.domElement );
+			const controls = new OrbitControls( camera, renderer.domElement );
 			controls.screenSpacePanning = true;
 			controls.target.set( 0.0, 0.0, 0.0 );
 			controls.update();
@@ -74,11 +84,11 @@
 			scene.add( axesHelper );
 
 			// spring bones
-			const springBoneManager = new THREE.VRMSpringBoneManager();
+			const springBoneManager = new VRMSpringBoneManager();
 
 			for ( let i = 1; i < 4; i ++ ) {
 
-				const springBone = new THREE.VRMSpringBoneJoint( cubes[ i ], cubes[ i + 1 ], { hitRadius: 0.01 } );
+				const springBone = new VRMSpringBoneJoint( cubes[ i ], cubes[ i + 1 ], { hitRadius: 0.01 } );
 				springBoneManager.addSpringBone( springBone );
 
 			}
@@ -86,7 +96,7 @@
 			// helpers
 			springBoneManager.springBones.forEach( ( bone ) => {
 
-				const helper = new THREE.VRMSpringBoneJointHelper( bone );
+				const helper = new VRMSpringBoneJointHelper( bone );
 				scene.add( helper );
 
 			} );

--- a/packages/three-vrm-springbone/examples/single.html
+++ b/packages/three-vrm-springbone/examples/single.html
@@ -25,7 +25,7 @@
 			  "imports": {
 				"three": "https://unpkg.com/three@0.146.0/build/three.module.js",
 				"three/addons/": "https://unpkg.com/three@0.146.0/examples/jsm/",
-				"@pixiv/three-vrm": "../lib/three-vrm-springbone.module.js"
+				"@pixiv/three-vrm-springbone": "../lib/three-vrm-springbone.module.js"
 			  }
 			}
 		</script>
@@ -33,7 +33,7 @@
 			import * as THREE from 'three';
 			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
-			import { VRMSpringBoneManager, VRMSpringBoneJoint, VRMSpringBoneJointHelper } from '@pixiv/three-vrm';
+			import { VRMSpringBoneManager, VRMSpringBoneJoint, VRMSpringBoneJointHelper } from '@pixiv/three-vrm-springbone';
 			// renderer
 			const renderer = new THREE.WebGLRenderer();
 			renderer.setSize( window.innerWidth, window.innerHeight );

--- a/packages/three-vrm-springbone/examples/single.html
+++ b/packages/three-vrm-springbone/examples/single.html
@@ -19,11 +19,21 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
-		<script src="../lib/three-vrm-springbone.js"></script>
-		<script>
+		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+		<script type="importmap">
+			{
+			  "imports": {
+				"three": "https://unpkg.com/three@0.146.0/build/three.module.js",
+				"three/addons/": "https://unpkg.com/three@0.146.0/examples/jsm/",
+				"@pixiv/three-vrm": "../lib/three-vrm-springbone.module.js"
+			  }
+			}
+		</script>
+		<script type="module">
+			import * as THREE from 'three';
+			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+			import { VRMSpringBoneManager, VRMSpringBoneJoint, VRMSpringBoneJointHelper } from '@pixiv/three-vrm';
 			// renderer
 			const renderer = new THREE.WebGLRenderer();
 			renderer.setSize( window.innerWidth, window.innerHeight );
@@ -35,7 +45,7 @@
 			camera.position.set( 0.0, 0.0, 5.0 );
 
 			// camera controls
-			const controls = new THREE.OrbitControls( camera, renderer.domElement );
+			const controls = new OrbitControls( camera, renderer.domElement );
 			controls.screenSpacePanning = true;
 			controls.target.set( 0.0, 0.0, 0.0 );
 			controls.update();
@@ -75,13 +85,13 @@
 			scene.add( axesHelper );
 
 			// spring bones
-			const springBoneManager = new THREE.VRMSpringBoneManager();
+			const springBoneManager = new VRMSpringBoneManager();
 
-			const springBone = new THREE.VRMSpringBoneJoint( cubeB, cubeC, { hitRadius: 0.01 } );
+			const springBone = new VRMSpringBoneJoint( cubeB, cubeC, { hitRadius: 0.01 } );
 			springBoneManager.addSpringBone( springBone );
 
 			// helper
-			const springBoneHelper = new THREE.VRMSpringBoneJointHelper( springBone );
+			const springBoneHelper = new VRMSpringBoneJointHelper( springBone );
 			scene.add( springBoneHelper );
 
 			// init spring bones

--- a/packages/three-vrm/README.md
+++ b/packages/three-vrm/README.md
@@ -39,18 +39,32 @@ You will need:
 Code like this:
 
 ```html
-<script src="three.js"></script>
-<script src="GLTFLoader.js"></script>
-<script src="three-vrm.js"></script>
+<!-- About import maps, see the Three.js official docs: -->
+<!-- https://threejs.org/docs/#manual/en/introduction/Installation -->
+<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
 
-<script>
+<script type="importmap">
+  {
+    "imports": {
+      "three": "https://unpkg.com/three@0.146/build/three.module.js",
+      "three/addons/": "https://unpkg.com/three@0.146/examples/jsm/",
+      "@pixiv/three-vrm": "three-vrm.module.js"
+    }
+  }
+</script>
+
+<script type="module">
+  import * as THREE from 'three';
+  import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+  import { VRMLoaderPlugin } from '@pixiv/three-vrm';
+
   const scene = new THREE.Scene();
 
-  const loader = new THREE.GLTFLoader();
+  const loader = new GLTFLoader();
 
   // Install GLTFLoader plugin
   loader.register((parser) => {
-    return new THREE_VRM.VRMLoaderPlugin(parser);
+    return new VRMLoaderPlugin(parser);
   });
 
   loader.load(

--- a/packages/three-vrm/examples/animations.html
+++ b/packages/three-vrm/examples/animations.html
@@ -19,12 +19,26 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
-		<script src="../lib/three-vrm.js"></script>
-		<script>
-			/* global THREE_VRM */
+		<!-- Import maps polyfill -->
+		<!-- Remove this when import maps will be widely supported -->
+		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+		<script type="importmap">
+			{
+				"imports": {
+					"three": "https://unpkg.com/three@0.146/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.146/examples/jsm/",
+					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
+				}
+			}
+		</script>
+
+		<script type="module">
+			import * as THREE from 'three';
+			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+			import { VRMLoaderPlugin, VRMUtils } from '@pixiv/three-vrm';
+
 			// renderer
 			const renderer = new THREE.WebGLRenderer();
 			renderer.outputEncoding = THREE.sRGBEncoding;
@@ -37,7 +51,7 @@
 			camera.position.set( 0.0, 1.0, 5.0 );
 
 			// camera controls
-			const controls = new THREE.OrbitControls( camera, renderer.domElement );
+			const controls = new OrbitControls( camera, renderer.domElement );
 			controls.screenSpacePanning = true;
 			controls.target.set( 0.0, 1.0, 0.0 );
 			controls.update();
@@ -53,12 +67,12 @@
 			// gltf and vrm
 			let currentVrm = undefined;
 			let currentMixer = undefined;
-			const loader = new THREE.GLTFLoader();
+			const loader = new GLTFLoader();
 			loader.crossOrigin = 'anonymous';
 
 			loader.register( ( parser ) => {
 
-				return new THREE_VRM.VRMLoaderPlugin( parser );
+				return new VRMLoaderPlugin( parser );
 
 			} );
 
@@ -71,14 +85,14 @@
 					const vrm = gltf.userData.vrm;
 
 					// calling these functions greatly improves the performance
-					THREE_VRM.VRMUtils.removeUnnecessaryVertices( gltf.scene );
-					THREE_VRM.VRMUtils.removeUnnecessaryJoints( gltf.scene );
+					VRMUtils.removeUnnecessaryVertices( gltf.scene );
+					VRMUtils.removeUnnecessaryJoints( gltf.scene );
 
 					// Disable frustum culling
 					vrm.scene.traverse( ( obj ) => {
 
 						obj.frustumCulled = false;
-			
+
 					} );
 
 					scene.add( vrm.scene );
@@ -104,18 +118,18 @@
 				quatB.setFromEuler( new THREE.Euler( 0.0, 0.0, 0.25 * Math.PI ) );
 
 				const armTrack = new THREE.QuaternionKeyframeTrack(
-					vrm.humanoid.getNormalizedBoneNode( THREE_VRM.VRMHumanBoneName.LeftUpperArm ).name + '.quaternion', // name
+					vrm.humanoid.getNormalizedBoneNode( 'leftUpperArm' ).name + '.quaternion', // name
 					[ 0.0, 0.5, 1.0 ], // times
 					[ ...quatA.toArray(), ...quatB.toArray(), ...quatA.toArray() ] // values
 				);
 
 				const blinkTrack = new THREE.NumberKeyframeTrack(
-					vrm.expressionManager.getExpressionTrackName( THREE_VRM.VRMExpressionPresetName.Blink ), // name
+					vrm.expressionManager.getExpressionTrackName( 'blink' ), // name
 					[ 0.0, 0.5, 1.0 ], // times
 					[ 0.0, 1.0, 0.0 ] // values
 				);
 
-				const clip = new THREE.AnimationClip( 'blink', 1.0, [ armTrack, blinkTrack ] );
+				const clip = new THREE.AnimationClip( 'Animation', 1.0, [ armTrack, blinkTrack ] );
 				const action = currentMixer.clipAction( clip );
 				action.play();
 

--- a/packages/three-vrm/examples/basic.html
+++ b/packages/three-vrm/examples/basic.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.147/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.147/examples/jsm/",
+					"three": "https://unpkg.com/three@0.146/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.146/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/basic.html
+++ b/packages/three-vrm/examples/basic.html
@@ -19,12 +19,26 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
-		<script src="../lib/three-vrm.js"></script>
-		<script>
-			/* global THREE_VRM */
+		<!-- Import maps polyfill -->
+		<!-- Remove this when import maps will be widely supported -->
+		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+		<script type="importmap">
+			{
+				"imports": {
+					"three": "https://unpkg.com/three@0.147/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.147/examples/jsm/",
+					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
+				}
+			}
+		</script>
+
+		<script type="module">
+			import * as THREE from 'three';
+			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+			import { VRMLoaderPlugin, VRMUtils } from '@pixiv/three-vrm';
+
 			// renderer
 			const renderer = new THREE.WebGLRenderer();
 			renderer.outputEncoding = THREE.sRGBEncoding;
@@ -37,7 +51,7 @@
 			camera.position.set( 0.0, 1.0, 5.0 );
 
 			// camera controls
-			const controls = new THREE.OrbitControls( camera, renderer.domElement );
+			const controls = new OrbitControls( camera, renderer.domElement );
 			controls.screenSpacePanning = true;
 			controls.target.set( 0.0, 1.0, 0.0 );
 			controls.update();
@@ -52,12 +66,12 @@
 
 			// gltf and vrm
 			let currentVrm = undefined;
-			const loader = new THREE.GLTFLoader();
+			const loader = new GLTFLoader();
 			loader.crossOrigin = 'anonymous';
 
 			loader.register( ( parser ) => {
 
-				return new THREE_VRM.VRMLoaderPlugin( parser );
+				return new VRMLoaderPlugin( parser );
 
 			} );
 
@@ -72,8 +86,8 @@
 					const vrm = gltf.userData.vrm;
 
 					// calling these functions greatly improves the performance
-					THREE_VRM.VRMUtils.removeUnnecessaryVertices( gltf.scene );
-					THREE_VRM.VRMUtils.removeUnnecessaryJoints( gltf.scene );
+					VRMUtils.removeUnnecessaryVertices( gltf.scene );
+					VRMUtils.removeUnnecessaryJoints( gltf.scene );
 
 					// Disable frustum culling
 					vrm.scene.traverse( ( obj ) => {

--- a/packages/three-vrm/examples/bones.html
+++ b/packages/three-vrm/examples/bones.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.147/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.147/examples/jsm/",
+					"three": "https://unpkg.com/three@0.146/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.146/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/bones.html
+++ b/packages/three-vrm/examples/bones.html
@@ -19,12 +19,26 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
-		<script src="../lib/three-vrm.js"></script>
-		<script>
-			/* global THREE_VRM */
+		<!-- Import maps polyfill -->
+		<!-- Remove this when import maps will be widely supported -->
+		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+		<script type="importmap">
+			{
+				"imports": {
+					"three": "https://unpkg.com/three@0.147/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.147/examples/jsm/",
+					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
+				}
+			}
+		</script>
+
+		<script type="module">
+			import * as THREE from 'three';
+			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+			import { VRMLoaderPlugin, VRMUtils } from '@pixiv/three-vrm';
+
 			// renderer
 			const renderer = new THREE.WebGLRenderer();
 			renderer.outputEncoding = THREE.sRGBEncoding;
@@ -37,7 +51,7 @@
 			camera.position.set( 0.0, 1.0, 5.0 );
 
 			// camera controls
-			const controls = new THREE.OrbitControls( camera, renderer.domElement );
+			const controls = new OrbitControls( camera, renderer.domElement );
 			controls.screenSpacePanning = true;
 			controls.target.set( 0.0, 1.0, 0.0 );
 			controls.update();
@@ -52,12 +66,12 @@
 
 			// gltf and vrm
 			let currentVrm = undefined;
-			const loader = new THREE.GLTFLoader();
+			const loader = new GLTFLoader();
 			loader.crossOrigin = 'anonymous';
 
 			loader.register( ( parser ) => {
 
-				return new THREE_VRM.VRMLoaderPlugin( parser );
+				return new VRMLoaderPlugin( parser );
 
 			} );
 
@@ -70,16 +84,16 @@
 					const vrm = gltf.userData.vrm;
 
 					// calling these functions greatly improves the performance
-					THREE_VRM.VRMUtils.removeUnnecessaryVertices( gltf.scene );
-					THREE_VRM.VRMUtils.removeUnnecessaryJoints( gltf.scene );
-			
+					VRMUtils.removeUnnecessaryVertices( gltf.scene );
+					VRMUtils.removeUnnecessaryJoints( gltf.scene );
+
 					// Disable frustum culling
 					vrm.scene.traverse( ( obj ) => {
 
 						obj.frustumCulled = false;
 
 					} );
-			
+
 					scene.add( vrm.scene );
 					currentVrm = vrm;
 					console.log( vrm );
@@ -112,9 +126,9 @@
 
 					// tweak bones
 					const s = 0.25 * Math.PI * Math.sin( Math.PI * clock.elapsedTime );
-					currentVrm.humanoid.getNormalizedBoneNode( THREE_VRM.VRMHumanBoneName.Neck ).rotation.y = s;
-					currentVrm.humanoid.getNormalizedBoneNode( THREE_VRM.VRMHumanBoneName.LeftUpperArm ).rotation.z = s;
-					currentVrm.humanoid.getNormalizedBoneNode( THREE_VRM.VRMHumanBoneName.RightUpperArm ).rotation.x = s;
+					currentVrm.humanoid.getNormalizedBoneNode( 'neck' ).rotation.y = s;
+					currentVrm.humanoid.getNormalizedBoneNode( 'leftUpperArm' ).rotation.z = s;
+					currentVrm.humanoid.getNormalizedBoneNode( 'rightUpperArm' ).rotation.x = s;
 
 					// update vrm
 					currentVrm.update( deltaTime );

--- a/packages/three-vrm/examples/debug.html
+++ b/packages/three-vrm/examples/debug.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.147/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.147/examples/jsm/",
+					"three": "https://unpkg.com/three@0.146/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.146/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/debug.html
+++ b/packages/three-vrm/examples/debug.html
@@ -19,12 +19,26 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
-		<script src="../lib/three-vrm.js"></script>
-		<script>
-			/* global THREE_VRM */
+		<!-- Import maps polyfill -->
+		<!-- Remove this when import maps will be widely supported -->
+		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+		<script type="importmap">
+			{
+				"imports": {
+					"three": "https://unpkg.com/three@0.147/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.147/examples/jsm/",
+					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
+				}
+			}
+		</script>
+
+		<script type="module">
+			import * as THREE from 'three';
+			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+			import { VRMLoaderPlugin, VRMUtils } from '@pixiv/three-vrm';
+
 			// renderer
 			const renderer = new THREE.WebGLRenderer();
 			renderer.outputEncoding = THREE.sRGBEncoding;
@@ -37,7 +51,7 @@
 			camera.position.set( 0.0, 1.0, 5.0 );
 
 			// camera controls
-			const controls = new THREE.OrbitControls( camera, renderer.domElement );
+			const controls = new OrbitControls( camera, renderer.domElement );
 			controls.screenSpacePanning = true;
 			controls.target.set( 0.0, 1.0, 0.0 );
 			controls.update();
@@ -57,13 +71,13 @@
 
 			// gltf and vrm
 			let currentVrm = undefined;
-			const loader = new THREE.GLTFLoader();
+			const loader = new GLTFLoader();
 			loader.crossOrigin = 'anonymous';
 
 			loader.register( ( parser ) => {
 
 				// assigning `helperRoot` to options will make helpers appear
-				return new THREE_VRM.VRMLoaderPlugin( parser, { helperRoot } );
+				return new VRMLoaderPlugin( parser, { helperRoot } );
 
 			} );
 
@@ -78,8 +92,8 @@
 					const vrm = gltf.userData.vrm;
 
 					// calling this function greatly improves the performance
-					THREE_VRM.VRMUtils.removeUnnecessaryVertices( gltf.scene );
-					THREE_VRM.VRMUtils.removeUnnecessaryJoints( gltf.scene );
+					VRMUtils.removeUnnecessaryVertices( gltf.scene );
+					VRMUtils.removeUnnecessaryJoints( gltf.scene );
 
 					// Disable frustum culling
 					vrm.scene.traverse( ( obj ) => {

--- a/packages/three-vrm/examples/dnd.html
+++ b/packages/three-vrm/examples/dnd.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.147/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.147/examples/jsm/",
+					"three": "https://unpkg.com/three@0.146/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.146/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/dnd.html
+++ b/packages/three-vrm/examples/dnd.html
@@ -19,12 +19,26 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
-		<script src="../lib/three-vrm.js"></script>
-		<script>
-			/* global THREE_VRM */
+		<!-- Import maps polyfill -->
+		<!-- Remove this when import maps will be widely supported -->
+		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+		<script type="importmap">
+			{
+				"imports": {
+					"three": "https://unpkg.com/three@0.147/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.147/examples/jsm/",
+					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
+				}
+			}
+		</script>
+
+		<script type="module">
+			import * as THREE from 'three';
+			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+			import { VRMLoaderPlugin, VRMUtils } from '@pixiv/three-vrm';
+
 			// renderer
 			const renderer = new THREE.WebGLRenderer();
 			renderer.outputEncoding = THREE.sRGBEncoding;
@@ -37,7 +51,7 @@
 			camera.position.set( 0.0, 1.0, 5.0 );
 
 			// camera controls
-			const controls = new THREE.OrbitControls( camera, renderer.domElement );
+			const controls = new OrbitControls( camera, renderer.domElement );
 			controls.screenSpacePanning = true;
 			controls.target.set( 0.0, 1.0, 0.0 );
 			controls.update();
@@ -52,12 +66,12 @@
 
 			// gltf and vrm
 			let currentVrm = undefined;
-			const loader = new THREE.GLTFLoader();
+			const loader = new GLTFLoader();
 			loader.crossOrigin = 'anonymous';
 
 			loader.register( ( parser ) => {
 
-				return new THREE_VRM.VRMLoaderPlugin( parser );
+				return new VRMLoaderPlugin( parser );
 
 			} );
 
@@ -72,13 +86,13 @@
 						const vrm = gltf.userData.vrm;
 
 						// calling these functions greatly improves the performance
-						THREE_VRM.VRMUtils.removeUnnecessaryVertices( gltf.scene );
-						THREE_VRM.VRMUtils.removeUnnecessaryJoints( gltf.scene );
+						VRMUtils.removeUnnecessaryVertices( gltf.scene );
+						VRMUtils.removeUnnecessaryJoints( gltf.scene );
 
 						if ( currentVrm ) {
 
 							scene.remove( currentVrm.scene );
-							THREE_VRM.VRMUtils.deepDispose( currentVrm.scene );
+							VRMUtils.deepDispose( currentVrm.scene );
 
 						}
 
@@ -93,7 +107,7 @@
 						scene.add( vrm.scene );
 
 						// rotate if the VRM is VRM0.0
-						THREE_VRM.VRMUtils.rotateVRM0( vrm );
+						VRMUtils.rotateVRM0( vrm );
 
 						console.log( vrm );
 

--- a/packages/three-vrm/examples/expressions.html
+++ b/packages/three-vrm/examples/expressions.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.147/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.147/examples/jsm/",
+					"three": "https://unpkg.com/three@0.146/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.146/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/expressions.html
+++ b/packages/three-vrm/examples/expressions.html
@@ -19,12 +19,26 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
-		<script src="../lib/three-vrm.js"></script>
-		<script>
-			/* global THREE_VRM */
+		<!-- Import maps polyfill -->
+		<!-- Remove this when import maps will be widely supported -->
+		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+		<script type="importmap">
+			{
+				"imports": {
+					"three": "https://unpkg.com/three@0.147/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.147/examples/jsm/",
+					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
+				}
+			}
+		</script>
+
+		<script type="module">
+			import * as THREE from 'three';
+			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+			import { VRMLoaderPlugin, VRMUtils } from '@pixiv/three-vrm';
+
 			// renderer
 			const renderer = new THREE.WebGLRenderer();
 			renderer.outputEncoding = THREE.sRGBEncoding;
@@ -37,7 +51,7 @@
 			camera.position.set( 0.0, 1.0, 5.0 );
 
 			// camera controls
-			const controls = new THREE.OrbitControls( camera, renderer.domElement );
+			const controls = new OrbitControls( camera, renderer.domElement );
 			controls.screenSpacePanning = true;
 			controls.target.set( 0.0, 1.0, 0.0 );
 			controls.update();
@@ -52,12 +66,12 @@
 
 			// gltf and vrm
 			let currentVrm = undefined;
-			const loader = new THREE.GLTFLoader();
+			const loader = new GLTFLoader();
 			loader.crossOrigin = 'anonymous';
 
 			loader.register( ( parser ) => {
 
-				return new THREE_VRM.VRMLoaderPlugin( parser );
+				return new VRMLoaderPlugin( parser );
 
 			} );
 
@@ -70,8 +84,8 @@
 					const vrm = gltf.userData.vrm;
 			
 					// calling these functions greatly improves the performance
-					THREE_VRM.VRMUtils.removeUnnecessaryVertices( gltf.scene );
-					THREE_VRM.VRMUtils.removeUnnecessaryJoints( gltf.scene );
+					VRMUtils.removeUnnecessaryVertices( gltf.scene );
+					VRMUtils.removeUnnecessaryJoints( gltf.scene );
 
 					// Disable frustum culling
 					vrm.scene.traverse( ( obj ) => {
@@ -113,8 +127,8 @@
 
 					// tweak expressions
 					const s = Math.sin( Math.PI * clock.elapsedTime );
-					currentVrm.expressionManager.setValue( THREE_VRM.VRMExpressionPresetName.Aa, 0.5 + 0.5 * s );
-					currentVrm.expressionManager.setValue( THREE_VRM.VRMExpressionPresetName.BlinkLeft, 0.5 - 0.5 * s );
+					currentVrm.expressionManager.setValue( 'aa', 0.5 + 0.5 * s );
+					currentVrm.expressionManager.setValue( 'blinkLeft', 0.5 - 0.5 * s );
 
 					// update vrm
 					currentVrm.update( deltaTime );

--- a/packages/three-vrm/examples/firstperson.html
+++ b/packages/three-vrm/examples/firstperson.html
@@ -19,12 +19,26 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
-		<script src="../lib/three-vrm.js"></script>
-		<script>
-			/* global THREE_VRM */
+		<!-- Import maps polyfill -->
+		<!-- Remove this when import maps will be widely supported -->
+		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+		<script type="importmap">
+			{
+				"imports": {
+					"three": "https://unpkg.com/three@0.146/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.146/examples/jsm/",
+					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
+				}
+			}
+		</script>
+
+		<script type="module">
+			import * as THREE from 'three';
+			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+			import { VRMLoaderPlugin, VRMUtils } from '@pixiv/three-vrm';
+
 			// renderer
 			const renderer = new THREE.WebGLRenderer();
 			renderer.outputEncoding = THREE.sRGBEncoding;
@@ -37,7 +51,7 @@
 			camera.position.set( 0.0, 1.0, 5.0 );
 
 			// camera controls
-			const controls = new THREE.OrbitControls( camera, renderer.domElement );
+			const controls = new OrbitControls( camera, renderer.domElement );
 			controls.screenSpacePanning = true;
 			controls.target.set( 0.0, 1.0, 0.0 );
 			controls.update();
@@ -52,12 +66,12 @@
 
 			// gltf and vrm
 			let currentVrm = undefined;
-			const loader = new THREE.GLTFLoader();
+			const loader = new GLTFLoader();
 			loader.crossOrigin = 'anonymous';
 
 			loader.register( ( parser ) => {
 
-				return new THREE.VRMLoaderPlugin( parser );
+				return new VRMLoaderPlugin( parser );
 
 			} );
 
@@ -70,8 +84,8 @@
 					const vrm = gltf.userData.vrm;
 
 					// calling these functions greatly improves the performance
-					THREE_VRM.VRMUtils.removeUnnecessaryVertices( gltf.scene );
-					THREE_VRM.VRMUtils.removeUnnecessaryJoints( gltf.scene );
+					VRMUtils.removeUnnecessaryVertices( gltf.scene );
+					VRMUtils.removeUnnecessaryJoints( gltf.scene );
 
 					// Disable frustum culling
 					vrm.scene.traverse( ( obj ) => {
@@ -137,7 +151,7 @@
 				if ( currentVrm ) {
 
 					if ( isFirstPerson ) {
-			
+
 						camera.layers.enable( currentVrm.firstPerson.firstPersonOnlyLayer );
 						camera.layers.disable( currentVrm.firstPerson.thirdPersonOnlyLayer );
 

--- a/packages/three-vrm/examples/humanoidAnimation/index.html
+++ b/packages/three-vrm/examples/humanoidAnimation/index.html
@@ -30,14 +30,21 @@
 			drag and drop <a href="https://www.mixamo.com/" target="_blank" rel="noopener noreferrer">mixamo</a> animation (.fbx)
 		</div>
 
-		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
-		<script src="https://cdn.jsdelivr.net/npm/fflate/umd/index.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/FBXLoader.js"></script>
-		<script src="../../lib/three-vrm.js"></script>
-		<script src="mixamoRigMap.js"></script>
-		<script src="loadMixamoAnimation.js"></script>
-		<script src="main.js""></script>
+		<!-- Import maps polyfill -->
+		<!-- Remove this when import maps will be widely supported -->
+		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+		<script type="importmap">
+			{
+				"imports": {
+					"fflate": "https://unpkg.com/fflate@0.7.4/esm/browser.js",
+					"three": "https://unpkg.com/three@0.146/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.146/examples/jsm/",
+					"@pixiv/three-vrm": "../../lib/three-vrm.module.js"
+				}
+			}
+		</script>
+
+		<script src="main.js" type="module"></script>
 	</body>
 </html>

--- a/packages/three-vrm/examples/humanoidAnimation/loadMixamoAnimation.js
+++ b/packages/three-vrm/examples/humanoidAnimation/loadMixamoAnimation.js
@@ -1,4 +1,6 @@
-/* global THREE, mixamoVRMRigMap */
+import * as THREE from 'three';
+import { FBXLoader } from 'three/addons/loaders/FBXLoader.js';
+import { mixamoVRMRigMap } from './mixamoVRMRigMap.js';
 
 /**
  * Load Mixamo animation, convert for three-vrm use, and return it.
@@ -7,9 +9,9 @@
  * @param {VRM} vrm A target VRM
  * @returns {Promise<THREE.AnimationClip>} The converted AnimationClip
  */
-function loadMixamoAnimation( url, vrm ) {
+export function loadMixamoAnimation( url, vrm ) {
 
-	const loader = new THREE.FBXLoader(); // A loader which loads FBX
+	const loader = new FBXLoader(); // A loader which loads FBX
 	return loader.loadAsync( url ).then( ( asset ) => {
 
 		const clip = THREE.AnimationClip.findByName( asset.animations, 'mixamo.com' ); // extract the AnimationClip

--- a/packages/three-vrm/examples/humanoidAnimation/main.js
+++ b/packages/three-vrm/examples/humanoidAnimation/main.js
@@ -1,4 +1,8 @@
-/* global THREE, THREE_VRM, loadMixamoAnimation */
+import * as THREE from 'three';
+import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+import { VRMLoaderPlugin, VRMUtils } from '@pixiv/three-vrm';
+import { loadMixamoAnimation } from './loadMixamoAnimation.js';
 
 // renderer
 const renderer = new THREE.WebGLRenderer();
@@ -12,7 +16,7 @@ const camera = new THREE.PerspectiveCamera( 30.0, window.innerWidth / window.inn
 camera.position.set( 0.0, 1.0, 5.0 );
 
 // camera controls
-const controls = new THREE.OrbitControls( camera, renderer.domElement );
+const controls = new OrbitControls( camera, renderer.domElement );
 controls.screenSpacePanning = true;
 controls.target.set( 0.0, 1.0, 0.0 );
 controls.update();
@@ -38,14 +42,14 @@ scene.add( helperRoot );
 
 function loadVRM( modelUrl ) {
 
-	const loader = new THREE.GLTFLoader();
+	const loader = new GLTFLoader();
 	loader.crossOrigin = 'anonymous';
 
 	helperRoot.clear();
 
 	loader.register( ( parser ) => {
 
-		return new THREE_VRM.VRMLoaderPlugin( parser, { helperRoot: helperRoot, autoUpdateHumanBones: true } );
+		return new VRMLoaderPlugin( parser, { helperRoot: helperRoot, autoUpdateHumanBones: true } );
 
 	} );
 
@@ -62,7 +66,7 @@ function loadVRM( modelUrl ) {
 
 				scene.remove( currentVrm.scene );
 
-				THREE_VRM.VRMUtils.deepDispose( currentVrm.scene );
+				VRMUtils.deepDispose( currentVrm.scene );
 
 			}
 
@@ -84,7 +88,7 @@ function loadVRM( modelUrl ) {
 			}
 
 			// rotate if the VRM is VRM0.0
-			THREE_VRM.VRMUtils.rotateVRM0( vrm );
+			VRMUtils.rotateVRM0( vrm );
 
 			console.log( vrm );
 

--- a/packages/three-vrm/examples/humanoidAnimation/mixamoVRMRigMap.js
+++ b/packages/three-vrm/examples/humanoidAnimation/mixamoVRMRigMap.js
@@ -1,7 +1,7 @@
 /**
  * A map from Mixamo rig name to VRM Humanoid bone name
  */
-const mixamoVRMRigMap = {
+export const mixamoVRMRigMap = {
 	mixamorigHips: 'hips',
 	mixamorigSpine: 'spine',
 	mixamorigSpine1: 'chest',

--- a/packages/three-vrm/examples/lookat-advanced.html
+++ b/packages/three-vrm/examples/lookat-advanced.html
@@ -21,16 +21,30 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
-		<script src="../lib/three-vrm.js"></script>
-		<script>
-			/* global THREE_VRM */
+		<!-- Import maps polyfill -->
+		<!-- Remove this when import maps will be widely supported -->
+		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+		<script type="importmap">
+			{
+				"imports": {
+					"three": "https://unpkg.com/three@0.146/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.146/examples/jsm/",
+					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
+				}
+			}
+		</script>
+
+		<script type="module">
+			import * as THREE from 'three';
+			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+			import { VRMLoaderPlugin, VRMLookAt, VRMUtils } from '@pixiv/three-vrm';
+
 			const _v3A = new THREE.Vector3();
 
 			// extended lookat
-			class VRMSmoothLookAt extends THREE_VRM.VRMLookAt {
+			class VRMSmoothLookAt extends VRMLookAt {
 
 				constructor( humanoid, applier ) {
 
@@ -108,7 +122,7 @@
 			camera.position.set( 0.0, 1.0, 5.0 );
 
 			// camera controls
-			const controls = new THREE.OrbitControls( camera, renderer.domElement );
+			const controls = new OrbitControls( camera, renderer.domElement );
 			controls.screenSpacePanning = true;
 			controls.target.set( 0.0, 1.0, 0.0 );
 			controls.update();
@@ -123,12 +137,12 @@
 
 			// gltf and vrm
 			let currentVrm = undefined;
-			const loader = new THREE.GLTFLoader();
+			const loader = new GLTFLoader();
 			loader.crossOrigin = 'anonymous';
 
 			loader.register( ( parser ) => {
 
-				return new THREE_VRM.VRMLoaderPlugin( parser );
+				return new VRMLoaderPlugin( parser );
 
 			} );
 
@@ -139,10 +153,10 @@
 				( gltf ) => {
 
 					const vrm = gltf.userData.vrm;
-			
+
 					// calling these functions greatly improves the performance
-					THREE_VRM.VRMUtils.removeUnnecessaryVertices( gltf.scene );
-					THREE_VRM.VRMUtils.removeUnnecessaryJoints( gltf.scene );
+					VRMUtils.removeUnnecessaryVertices( gltf.scene );
+					VRMUtils.removeUnnecessaryJoints( gltf.scene );
 
 					// Disable frustum culling
 					vrm.scene.traverse( ( obj ) => {

--- a/packages/three-vrm/examples/lookat.html
+++ b/packages/three-vrm/examples/lookat.html
@@ -19,12 +19,26 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
-		<script src="../lib/three-vrm.js"></script>
-		<script>
-			/* global THREE_VRM */
+		<!-- Import maps polyfill -->
+		<!-- Remove this when import maps will be widely supported -->
+		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+		<script type="importmap">
+			{
+				"imports": {
+					"three": "https://unpkg.com/three@0.146/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.146/examples/jsm/",
+					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
+				}
+			}
+		</script>
+
+		<script type="module">
+			import * as THREE from 'three';
+			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+			import { VRMLoaderPlugin, VRMUtils } from '@pixiv/three-vrm';
+
 			// renderer
 			const renderer = new THREE.WebGLRenderer();
 			renderer.outputEncoding = THREE.sRGBEncoding;
@@ -37,7 +51,7 @@
 			camera.position.set( 0.0, 1.0, 5.0 );
 
 			// camera controls
-			const controls = new THREE.OrbitControls( camera, renderer.domElement );
+			const controls = new OrbitControls( camera, renderer.domElement );
 			controls.screenSpacePanning = true;
 			controls.target.set( 0.0, 1.0, 0.0 );
 			controls.update();
@@ -56,12 +70,12 @@
 
 			// gltf and vrm
 			let currentVrm = undefined;
-			const loader = new THREE.GLTFLoader();
+			const loader = new GLTFLoader();
 			loader.crossOrigin = 'anonymous';
 
 			loader.register( ( parser ) => {
 
-				return new THREE_VRM.VRMLoaderPlugin( parser );
+				return new VRMLoaderPlugin( parser );
 
 			} );
 
@@ -72,10 +86,10 @@
 				( gltf ) => {
 
 					const vrm = gltf.userData.vrm;
-			
+
 					// calling these functions greatly improves the performance
-					THREE_VRM.VRMUtils.removeUnnecessaryVertices( gltf.scene );
-					THREE_VRM.VRMUtils.removeUnnecessaryJoints( gltf.scene );
+					VRMUtils.removeUnnecessaryVertices( gltf.scene );
+					VRMUtils.removeUnnecessaryJoints( gltf.scene );
 
 					// Disable frustum culling
 					vrm.scene.traverse( ( obj ) => {

--- a/packages/three-vrm/examples/materials-debug.html
+++ b/packages/three-vrm/examples/materials-debug.html
@@ -19,12 +19,26 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
-		<script src="../lib/three-vrm.js"></script>
-		<script>
-			/* global THREE_VRM */
+		<!-- Import maps polyfill -->
+		<!-- Remove this when import maps will be widely supported -->
+		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+		<script type="importmap">
+			{
+				"imports": {
+					"three": "https://unpkg.com/three@0.146/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.146/examples/jsm/",
+					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
+				}
+			}
+		</script>
+
+		<script type="module">
+			import * as THREE from 'three';
+			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+			import { VRMLoaderPlugin, VRMUtils } from '@pixiv/three-vrm';
+
 			// renderer
 			const renderer = new THREE.WebGLRenderer();
 			renderer.outputEncoding = THREE.sRGBEncoding;
@@ -37,7 +51,7 @@
 			camera.position.set( 0.0, 1.0, 5.0 );
 
 			// camera controls
-			const controls = new THREE.OrbitControls( camera, renderer.domElement );
+			const controls = new OrbitControls( camera, renderer.domElement );
 			controls.screenSpacePanning = true;
 			controls.target.set( 0.0, 1.0, 0.0 );
 			controls.update();
@@ -52,12 +66,12 @@
 
 			// gltf and vrm
 			let currentVrm = undefined;
-			const loader = new THREE.GLTFLoader();
+			const loader = new GLTFLoader();
 			loader.crossOrigin = 'anonymous';
 
 			loader.register( ( parser ) => {
 
-				return new THREE_VRM.VRMLoaderPlugin( parser );
+				return new VRMLoaderPlugin( parser );
 
 			} );
 
@@ -70,8 +84,8 @@
 					const vrm = gltf.userData.vrm;
 
 					// calling these functions greatly improves the performance
-					THREE_VRM.VRMUtils.removeUnnecessaryVertices( gltf.scene );
-					THREE_VRM.VRMUtils.removeUnnecessaryJoints( gltf.scene );
+					VRMUtils.removeUnnecessaryVertices( gltf.scene );
+					VRMUtils.removeUnnecessaryJoints( gltf.scene );
 
 					// Disable frustum culling
 					vrm.scene.traverse( ( obj ) => {
@@ -138,21 +152,14 @@
 			window.addEventListener( 'keydown', () => {
 
 				if ( ! currentVrm ) {
-			
+
 					return;
-			
+
 				}
 
 				debugModeIndex = ( debugModeIndex + 1 ) % 4;
 
-				const debugMode = [
-
-					THREE.MToonMaterialDebugMode.None,
-					THREE.MToonMaterialDebugMode.Normal,
-					THREE.MToonMaterialDebugMode.LitShadeRate,
-					THREE.MToonMaterialDebugMode.UV,
-
-				][ debugModeIndex ];
+				const debugMode = [ 'none', 'normal', 'litShadeRate', 'uv' ][ debugModeIndex ];
 
 				currentVrm.scene.traverse( ( object ) => {
 

--- a/packages/three-vrm/examples/meta.html
+++ b/packages/three-vrm/examples/meta.html
@@ -31,12 +31,26 @@
 	<body>
 		<span id="meta"></span>
 		<img id="thumbnail" alt="thumbnail" />
-		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
-		<script src="../lib/three-vrm.js"></script>
-		<script>
-			/* global THREE_VRM */
+		<!-- Import maps polyfill -->
+		<!-- Remove this when import maps will be widely supported -->
+		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+		<script type="importmap">
+			{
+				"imports": {
+					"three": "https://unpkg.com/three@0.147/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.147/examples/jsm/",
+					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
+				}
+			}
+		</script>
+
+		<script type="module">
+			import * as THREE from 'three';
+			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
+			import { VRMLoaderPlugin, VRMUtils } from '@pixiv/three-vrm';
+
 			// renderer
 			const renderer = new THREE.WebGLRenderer();
 			renderer.outputEncoding = THREE.sRGBEncoding;
@@ -49,7 +63,7 @@
 			camera.position.set( 0.0, 1.0, 5.0 );
 
 			// camera controls
-			const controls = new THREE.OrbitControls( camera, renderer.domElement );
+			const controls = new OrbitControls( camera, renderer.domElement );
 			controls.screenSpacePanning = true;
 			controls.target.set( 0.0, 1.0, 0.0 );
 			controls.update();
@@ -64,12 +78,12 @@
 
 			// gltf and vrm
 			let currentVrm = undefined;
-			const loader = new THREE.GLTFLoader();
+			const loader = new GLTFLoader();
 			loader.crossOrigin = 'anonymous';
 
 			loader.register( ( parser ) => {
 
-				return new THREE_VRM.VRMLoaderPlugin( parser );
+				return new VRMLoaderPlugin( parser );
 
 			} );
 
@@ -84,8 +98,8 @@
 					const vrm = gltf.userData.vrm;
 
 					// calling these functions greatly improves the performance
-					THREE_VRM.VRMUtils.removeUnnecessaryVertices( gltf.scene );
-					THREE_VRM.VRMUtils.removeUnnecessaryJoints( gltf.scene );
+					VRMUtils.removeUnnecessaryVertices( gltf.scene );
+					VRMUtils.removeUnnecessaryJoints( gltf.scene );
 
 					// Disable frustum culling
 					vrm.scene.traverse( ( obj ) => {

--- a/packages/three-vrm/examples/meta.html
+++ b/packages/three-vrm/examples/meta.html
@@ -38,8 +38,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.147/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.147/examples/jsm/",
+					"three": "https://unpkg.com/three@0.146/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.146/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/mouse.html
+++ b/packages/three-vrm/examples/mouse.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.147/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.147/examples/jsm/",
+					"three": "https://unpkg.com/three@0.146/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.146/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/mouse.html
+++ b/packages/three-vrm/examples/mouse.html
@@ -19,11 +19,25 @@
 	</head>
 
 	<body>
-		<script src="https://unpkg.com/three@0.146.0/build/three.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/loaders/GLTFLoader.js"></script>
-		<script src="https://unpkg.com/three@0.146.0/examples/js/controls/OrbitControls.js"></script>
-		<script src="../lib/three-vrm.js"></script>
-		<script>
+		<!-- Import maps polyfill -->
+		<!-- Remove this when import maps will be widely supported -->
+		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+
+		<script type="importmap">
+			{
+				"imports": {
+					"three": "https://unpkg.com/three@0.147/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.147/examples/jsm/",
+					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
+				}
+			}
+		</script>
+
+		<script type="module">
+			import * as THREE from 'three';
+			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
+			import { VRMLoaderPlugin, VRMUtils } from '@pixiv/three-vrm';
+
 			/* global THREE_VRM */
 			// renderer
 			const renderer = new THREE.WebGLRenderer();
@@ -48,12 +62,12 @@
 
 			// gltf and vrm
 			let currentVrm = undefined;
-			const loader = new THREE.GLTFLoader();
+			const loader = new GLTFLoader();
 			loader.crossOrigin = 'anonymous';
 
 			loader.register( ( parser ) => {
 
-				return new THREE_VRM.VRMLoaderPlugin( parser );
+				return new VRMLoaderPlugin( parser );
 
 			} );
 
@@ -66,8 +80,8 @@
 					const vrm = gltf.userData.vrm;
 
 					// calling these functions greatly improves the performance
-					THREE_VRM.VRMUtils.removeUnnecessaryVertices( gltf.scene );
-					THREE_VRM.VRMUtils.removeUnnecessaryJoints( gltf.scene );
+					VRMUtils.removeUnnecessaryVertices( gltf.scene );
+					VRMUtils.removeUnnecessaryJoints( gltf.scene );
 
 					// Disable frustum culling
 					vrm.scene.traverse( ( obj ) => {
@@ -104,9 +118,9 @@
 				requestAnimationFrame( animate );
 
 				if ( currentVrm ) {
-			
+
 					currentVrm.update( clock.getDelta() );
-			
+
 				}
 
 				renderer.render( scene, camera );
@@ -127,7 +141,7 @@
 					const px = ( 2.0 * event.clientX - window.innerWidth ) / window.innerHeight * range;
 					const py = - ( 2.0 * event.clientY - window.innerHeight ) / window.innerHeight * range;
 
-					currentVrm.humanoid.getNormalizedBoneNode( THREE_VRM.VRMHumanBoneName.Hips ).position.set( px, py, 0.0 );
+					currentVrm.humanoid.getNormalizedBoneNode( 'hips' ).position.set( px, py, 0.0 );
 
 				}
 

--- a/packages/three-vrm/examples/mouse.html
+++ b/packages/three-vrm/examples/mouse.html
@@ -38,7 +38,6 @@
 			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 			import { VRMLoaderPlugin, VRMUtils } from '@pixiv/three-vrm';
 
-			/* global THREE_VRM */
 			// renderer
 			const renderer = new THREE.WebGLRenderer();
 			renderer.outputEncoding = THREE.sRGBEncoding;


### PR DESCRIPTION
### Description

This PR is to replace the uses of IIFE modules in examples with ES Modules.

This PR also changes the README example to encourage the use of import maps.

See: https://threejs.org/docs/index.html#manual/en/introduction/Installation

### Reason

In Three.js r148, `examples/js` (the IIFE modules of Three.js addons) will be removed.

See: https://discourse.threejs.org/t/the-examples-js-directory-will-be-removed-with-r148/45349

### Side Note

We are not planning to remove our umd modules (`three-vrm.js` and `three-vrm.min.js`) yet.
