### PR TITLE
deps: bump Three.js to r148

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Code like this:
 <script type="importmap">
   {
     "imports": {
-      "three": "https://unpkg.com/three@0.146/build/three.module.js",
-      "three/addons/": "https://unpkg.com/three@0.146/examples/jsm/",
+      "three": "https://unpkg.com/three@0.148.0/build/three.module.js",
+      "three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
       "@pixiv/three-vrm": "three-vrm.module.js"
     }
   }

--- a/packages/three-vrm-core/examples/expressions.html
+++ b/packages/three-vrm-core/examples/expressions.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.146/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.146/examples/jsm/",
+					"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
 					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/examples/firstPerson.html
+++ b/packages/three-vrm-core/examples/firstPerson.html
@@ -32,8 +32,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.146/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.146/examples/jsm/",
+					"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
 					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/examples/humanoid.html
+++ b/packages/three-vrm-core/examples/humanoid.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.146/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.146/examples/jsm/",
+					"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
 					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/examples/humanoidAnimation/index.html
+++ b/packages/three-vrm-core/examples/humanoidAnimation/index.html
@@ -38,8 +38,8 @@
 			{
 				"imports": {
 					"fflate": "https://unpkg.com/fflate@0.7.4/esm/browser.js",
-					"three": "https://unpkg.com/three@0.146/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.146/examples/jsm/",
+					"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
 					"@pixiv/three-vrm-core": "../../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/examples/lookAt.html
+++ b/packages/three-vrm-core/examples/lookAt.html
@@ -32,8 +32,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.146/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.146/examples/jsm/",
+					"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
 					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/examples/meta.html
+++ b/packages/three-vrm-core/examples/meta.html
@@ -39,8 +39,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.146/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.146/examples/jsm/",
+					"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
 					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/package.json
+++ b/packages/three-vrm-core/package.json
@@ -50,12 +50,12 @@
     "@pixiv/types-vrmc-vrm-1.0": "1.0.0"
   },
   "devDependencies": {
-    "@types/three": "^0.146.0",
+    "@types/three": "^0.148.0",
     "lint-staged": "13.0.3",
-    "three": "^0.146.0"
+    "three": "^0.148.0"
   },
   "peerDependencies": {
-    "@types/three": "^0.146.0",
-    "three": "^0.146.0"
+    "@types/three": "^0.148.0",
+    "three": "^0.148.0"
   }
 }

--- a/packages/three-vrm-materials-hdr-emissive-multiplier/examples/loader-plugin.html
+++ b/packages/three-vrm-materials-hdr-emissive-multiplier/examples/loader-plugin.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.146/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.146/examples/jsm/",
+					"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
 					"@pixiv/three-vrm-materials-hdr-emissive-multiplier": "../lib/three-vrm-materials-hdr-emissive-multiplier.module.js"
 				}
 			}

--- a/packages/three-vrm-materials-hdr-emissive-multiplier/package.json
+++ b/packages/three-vrm-materials-hdr-emissive-multiplier/package.json
@@ -44,11 +44,11 @@
     "@pixiv/types-vrmc-materials-hdr-emissive-multiplier-1.0": "1.0.0"
   },
   "devDependencies": {
-    "@types/three": "^0.146.0",
-    "three": "^0.146.0"
+    "@types/three": "^0.148.0",
+    "three": "^0.148.0"
   },
   "peerDependencies": {
-    "@types/three": "^0.146.0",
-    "three": "^0.146.0"
+    "@types/three": "^0.148.0",
+    "three": "^0.148.0"
   }
 }

--- a/packages/three-vrm-materials-mtoon/examples/emissive-strength.html
+++ b/packages/three-vrm-materials-mtoon/examples/emissive-strength.html
@@ -24,8 +24,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.146/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.146/examples/jsm/",
+					"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
 					"@pixiv/three-vrm-materials-mtoon": "../lib/three-vrm-materials-mtoon.module.js"
 				}
 			}

--- a/packages/three-vrm-materials-mtoon/examples/loader-plugin.html
+++ b/packages/three-vrm-materials-mtoon/examples/loader-plugin.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.146/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.146/examples/jsm/",
+					"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
 					"@pixiv/three-vrm-materials-mtoon": "../lib/three-vrm-materials-mtoon.module.js"
 				}
 			}

--- a/packages/three-vrm-materials-mtoon/package.json
+++ b/packages/three-vrm-materials-mtoon/package.json
@@ -45,11 +45,11 @@
     "@pixiv/types-vrmc-materials-mtoon-1.0": "1.0.0"
   },
   "devDependencies": {
-    "@types/three": "^0.146.0",
-    "three": "^0.146.0"
+    "@types/three": "^0.148.0",
+    "three": "^0.148.0"
   },
   "peerDependencies": {
-    "@types/three": "^0.146.0",
-    "three": "^0.146.0"
+    "@types/three": "^0.148.0",
+    "three": "^0.148.0"
   }
 }

--- a/packages/three-vrm-materials-v0compat/package.json
+++ b/packages/three-vrm-materials-v0compat/package.json
@@ -44,12 +44,12 @@
     "@pixiv/types-vrmc-materials-mtoon-1.0": "1.0.0"
   },
   "devDependencies": {
-    "@types/three": "^0.146.0",
+    "@types/three": "^0.148.0",
     "lint-staged": "13.0.3",
-    "three": "^0.146.0"
+    "three": "^0.148.0"
   },
   "peerDependencies": {
-    "@types/three": "^0.146.0",
-    "three": "^0.146.0"
+    "@types/three": "^0.148.0",
+    "three": "^0.148.0"
   }
 }

--- a/packages/three-vrm-node-constraint/examples/aim.html
+++ b/packages/three-vrm-node-constraint/examples/aim.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-					"three": "https://unpkg.com/three@0.146.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.146.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
 					"tweakpane": "https://unpkg.com/tweakpane@3.0",
 					"tweakpane-plugin-rotation": "https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1",
 					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"

--- a/packages/three-vrm-node-constraint/examples/importer.html
+++ b/packages/three-vrm-node-constraint/examples/importer.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-					"three": "https://unpkg.com/three@0.146.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.146.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
 					"tweakpane": "https://unpkg.com/tweakpane@3.0",
 					"tweakpane-plugin-rotation": "https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1",
 					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"

--- a/packages/three-vrm-node-constraint/examples/roll.html
+++ b/packages/three-vrm-node-constraint/examples/roll.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-					"three": "https://unpkg.com/three@0.146.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.146.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
 					"tweakpane": "https://unpkg.com/tweakpane@3.0",
 					"tweakpane-plugin-rotation": "https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1",
 					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"

--- a/packages/three-vrm-node-constraint/examples/rotation.html
+++ b/packages/three-vrm-node-constraint/examples/rotation.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-					"three": "https://unpkg.com/three@0.146.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.146.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
 					"tweakpane": "https://unpkg.com/tweakpane@3.0",
 					"tweakpane-plugin-rotation": "https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1",
 					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"

--- a/packages/three-vrm-node-constraint/examples/upper-arm.html
+++ b/packages/three-vrm-node-constraint/examples/upper-arm.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-					"three": "https://unpkg.com/three@0.146.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.146.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
 					"tweakpane": "https://unpkg.com/tweakpane@3.0",
 					"tweakpane-plugin-rotation": "https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1",
 					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"

--- a/packages/three-vrm-node-constraint/package.json
+++ b/packages/three-vrm-node-constraint/package.json
@@ -45,12 +45,12 @@
     "@pixiv/types-vrmc-node-constraint-1.0": "1.0.0"
   },
   "devDependencies": {
-    "@types/three": "^0.146.0",
+    "@types/three": "^0.148.0",
     "lint-staged": "13.0.3",
-    "three": "^0.146.0"
+    "three": "^0.148.0"
   },
   "peerDependencies": {
-    "@types/three": "^0.146.0",
-    "three": "^0.146.0"
+    "@types/three": "^0.148.0",
+    "three": "^0.148.0"
   }
 }

--- a/packages/three-vrm-springbone/examples/collider.html
+++ b/packages/three-vrm-springbone/examples/collider.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-				"three": "https://unpkg.com/three@0.146.0/build/three.module.js",
-				"three/addons/": "https://unpkg.com/three@0.146.0/examples/jsm/",
+				"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
+				"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
 				"@pixiv/three-vrm-springbone": "../lib/three-vrm-springbone.module.js"
 			  }
 			}

--- a/packages/three-vrm-springbone/examples/loader-plugin.html
+++ b/packages/three-vrm-springbone/examples/loader-plugin.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-				"three": "https://unpkg.com/three@0.146.0/build/three.module.js",
-				"three/addons/": "https://unpkg.com/three@0.146.0/examples/jsm/",
+				"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
+				"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
 				"@pixiv/three-vrm-springbone": "../lib/three-vrm-springbone.module.js"
 			  }
 			}

--- a/packages/three-vrm-springbone/examples/multiple.html
+++ b/packages/three-vrm-springbone/examples/multiple.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-				"three": "https://unpkg.com/three@0.146.0/build/three.module.js",
-				"three/addons/": "https://unpkg.com/three@0.146.0/examples/jsm/",
+				"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
+				"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
 				"@pixiv/three-vrm-springbone": "../lib/three-vrm-springbone.module.js"
 			  }
 			}

--- a/packages/three-vrm-springbone/examples/single.html
+++ b/packages/three-vrm-springbone/examples/single.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-				"three": "https://unpkg.com/three@0.146.0/build/three.module.js",
-				"three/addons/": "https://unpkg.com/three@0.146.0/examples/jsm/",
+				"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
+				"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
 				"@pixiv/three-vrm-springbone": "../lib/three-vrm-springbone.module.js"
 			  }
 			}

--- a/packages/three-vrm-springbone/package.json
+++ b/packages/three-vrm-springbone/package.json
@@ -47,9 +47,9 @@
   },
   "devDependencies": {
     "lint-staged": "13.0.3",
-    "three": "^0.146.0"
+    "three": "^0.148.0"
   },
   "peerDependencies": {
-    "three": "^0.146.0"
+    "three": "^0.148.0"
   }
 }

--- a/packages/three-vrm/README.md
+++ b/packages/three-vrm/README.md
@@ -46,8 +46,8 @@ Code like this:
 <script type="importmap">
   {
     "imports": {
-      "three": "https://unpkg.com/three@0.146/build/three.module.js",
-      "three/addons/": "https://unpkg.com/three@0.146/examples/jsm/",
+      "three": "https://unpkg.com/three@0.148.0/build/three.module.js",
+      "three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
       "@pixiv/three-vrm": "three-vrm.module.js"
     }
   }

--- a/packages/three-vrm/examples/animations.html
+++ b/packages/three-vrm/examples/animations.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.146/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.146/examples/jsm/",
+					"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/basic.html
+++ b/packages/three-vrm/examples/basic.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.146/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.146/examples/jsm/",
+					"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/bones.html
+++ b/packages/three-vrm/examples/bones.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.146/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.146/examples/jsm/",
+					"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/debug.html
+++ b/packages/three-vrm/examples/debug.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.146/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.146/examples/jsm/",
+					"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/dnd.html
+++ b/packages/three-vrm/examples/dnd.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.146/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.146/examples/jsm/",
+					"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/expressions.html
+++ b/packages/three-vrm/examples/expressions.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.146/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.146/examples/jsm/",
+					"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/firstperson.html
+++ b/packages/three-vrm/examples/firstperson.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.146/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.146/examples/jsm/",
+					"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/humanoidAnimation/index.html
+++ b/packages/three-vrm/examples/humanoidAnimation/index.html
@@ -38,8 +38,8 @@
 			{
 				"imports": {
 					"fflate": "https://unpkg.com/fflate@0.7.4/esm/browser.js",
-					"three": "https://unpkg.com/three@0.146/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.146/examples/jsm/",
+					"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
 					"@pixiv/three-vrm": "../../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/lookat-advanced.html
+++ b/packages/three-vrm/examples/lookat-advanced.html
@@ -28,8 +28,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.146/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.146/examples/jsm/",
+					"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/lookat.html
+++ b/packages/three-vrm/examples/lookat.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.146/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.146/examples/jsm/",
+					"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/materials-debug.html
+++ b/packages/three-vrm/examples/materials-debug.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.146/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.146/examples/jsm/",
+					"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/meta.html
+++ b/packages/three-vrm/examples/meta.html
@@ -38,8 +38,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.146/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.146/examples/jsm/",
+					"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/mouse.html
+++ b/packages/three-vrm/examples/mouse.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.146/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.146/examples/jsm/",
+					"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/package.json
+++ b/packages/three-vrm/package.json
@@ -55,12 +55,12 @@
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.0.1",
-    "@types/three": "^0.146.0",
+    "@types/three": "^0.148.0",
     "lint-staged": "13.0.3",
-    "three": "^0.146.0"
+    "three": "^0.148.0"
   },
   "peerDependencies": {
-    "@types/three": "^0.146.0",
-    "three": "^0.146.0"
+    "@types/three": "^0.148.0",
+    "three": "^0.148.0"
   }
 }


### PR DESCRIPTION
This PR bumps the Three.js to r148.

One notable update for us is that shadow maps support material.map with alphaTest: https://github.com/mrdoob/three.js/pull/25000