### PR TITLE
Draft: Fix LookAt position

### DIFF
--- a/packages/three-vrm-core/examples/lookAt.html
+++ b/packages/three-vrm-core/examples/lookAt.html
@@ -43,7 +43,8 @@
 			import * as THREE from 'three';
 			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
-			import { VRMCoreLoaderPlugin } from '@pixiv/three-vrm-core';
+			import { VRMCoreLoaderPlugin, VRMLookAtLoaderPlugin } from '@pixiv/three-vrm-core';
+			import GUI from 'three/addons/libs/lil-gui.module.min.js';
 
 			// renderer
 			const renderer = new THREE.WebGLRenderer();
@@ -75,6 +76,11 @@
 			lookAtTarget.position.z = - 1.0;
 			camera.add( lookAtTarget );
 
+			// helper root
+			const helperRoot = new THREE.Group();
+			helperRoot.renderOrder = 10000;
+			scene.add( helperRoot );
+
 			// gltf and vrm
 			let currentGltf = undefined;
 
@@ -83,7 +89,9 @@
 
 			loader.register( ( parser ) => {
 
-				return new VRMCoreLoaderPlugin( parser, { helperRoot: scene, autoUpdateHumanBones: true } );
+				const lookAtPlugin = new VRMLookAtLoaderPlugin( parser, { helperRoot } );
+
+				return new VRMCoreLoaderPlugin( parser, { lookAtPlugin, autoUpdateHumanBones: true } );
 
 			} );
 
@@ -145,6 +153,21 @@
 			}
 
 			animate();
+
+			// gui
+			const gui = new GUI();
+
+			const params = {
+
+				showGizmo: true,
+
+			};
+
+			gui.add( params, 'showGizmo' ).onChange( ( value ) => {
+
+				helperRoot.visible = value;
+
+			} );
 
 			// mouse listener
 			window.addEventListener( 'mousemove', ( event ) => {

--- a/packages/three-vrm/examples/lookat.html
+++ b/packages/three-vrm/examples/lookat.html
@@ -37,7 +37,8 @@
 			import * as THREE from 'three';
 			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
-			import { VRMLoaderPlugin, VRMUtils } from '@pixiv/three-vrm';
+			import { VRMLoaderPlugin, VRMLookAtLoaderPlugin, VRMUtils } from '@pixiv/three-vrm';
+			import GUI from 'three/addons/libs/lil-gui.module.min.js';
 
 			// renderer
 			const renderer = new THREE.WebGLRenderer();
@@ -68,6 +69,11 @@
 			const lookAtTarget = new THREE.Object3D();
 			camera.add( lookAtTarget );
 
+			// helper root
+			const helperRoot = new THREE.Group();
+			helperRoot.renderOrder = 10000;
+			scene.add( helperRoot );
+
 			// gltf and vrm
 			let currentVrm = undefined;
 			const loader = new GLTFLoader();
@@ -75,7 +81,9 @@
 
 			loader.register( ( parser ) => {
 
-				return new VRMLoaderPlugin( parser );
+				const lookAtPlugin = new VRMLookAtLoaderPlugin( parser, { helperRoot } );
+
+				return new VRMLoaderPlugin( parser, { lookAtPlugin } );
 
 			} );
 
@@ -141,6 +149,21 @@
 			}
 
 			animate();
+
+			// gui
+			const gui = new GUI();
+
+			const params = {
+
+				showGizmo: true,
+
+			};
+
+			gui.add( params, 'showGizmo' ).onChange( ( value ) => {
+
+				helperRoot.visible = value;
+
+			} );
 
 			// mouse listener
 			window.addEventListener( 'mousemove', ( event ) => {


### PR DESCRIPTION
Fixed the behavior of offsetFromHeadBone.

offsetFromHeadBone should be a world space offset instead of the local space offset.

However, the current specification unclearly says that it should be evaluated in the local space of the head bone, which is not convenient.
VRMC is now discussing the behavior.

This PR also improves the LookAt example, added the lookAt gizmo.
