### PR TITLE
MToon, Improve customProgramCacheKey

### DIFF
--- a/packages/three-vrm-materials-mtoon/src/MToonMaterial.ts
+++ b/packages/three-vrm-materials-mtoon/src/MToonMaterial.ts
@@ -458,11 +458,6 @@ export class MToonMaterial extends THREE.ShaderMaterial {
     // == update shader stuff ======================================================================
     this.customProgramCacheKey = () =>
       [
-        this._ignoreVertexColor ? 'ignoreVertexColor' : '',
-        this._v0CompatShade ? 'v0CompatShade' : '',
-        this._debugMode !== 'none' ? `debugMode:${this._debugMode}` : '',
-        this._outlineWidthMode !== 'none' ? `outlineWidthMode:${this._outlineWidthMode}` : '',
-        this._isOutline ? 'isOutline' : '',
         ...Object.entries(this._generateDefines()).map(([token, macro]) => `${token}:${macro}`),
         this.matcapTexture ? `matcapTextureEncoding:${this.matcapTexture.encoding}` : '',
         this.shadeMultiplyTexture ? `shadeMultiplyTextureEncoding:${this.shadeMultiplyTexture.encoding}` : '',

--- a/packages/three-vrm-materials-mtoon/src/MToonMaterial.ts
+++ b/packages/three-vrm-materials-mtoon/src/MToonMaterial.ts
@@ -647,14 +647,15 @@ export class MToonMaterial extends THREE.ShaderMaterial {
       USE_SHADINGSHIFTTEXTURE: this.shadingShiftTexture !== null,
       USE_MATCAPTEXTURE: this.matcapTexture !== null,
       USE_RIMMULTIPLYTEXTURE: this.rimMultiplyTexture !== null,
-      USE_OUTLINEWIDTHMULTIPLYTEXTURE: this.outlineWidthMultiplyTexture !== null,
+      USE_OUTLINEWIDTHMULTIPLYTEXTURE: this._isOutline && this.outlineWidthMultiplyTexture !== null,
       USE_UVANIMATIONMASKTEXTURE: this.uvAnimationMaskTexture !== null,
       IGNORE_VERTEX_COLOR: this._ignoreVertexColor === true,
       DEBUG_NORMAL: this._debugMode === 'normal',
       DEBUG_LITSHADERATE: this._debugMode === 'litShadeRate',
       DEBUG_UV: this._debugMode === 'uv',
-      OUTLINE_WIDTH_WORLD: this._outlineWidthMode === MToonMaterialOutlineWidthMode.WorldCoordinates,
-      OUTLINE_WIDTH_SCREEN: this._outlineWidthMode === MToonMaterialOutlineWidthMode.ScreenCoordinates,
+      OUTLINE_WIDTH_WORLD: this._isOutline && this._outlineWidthMode === MToonMaterialOutlineWidthMode.WorldCoordinates,
+      OUTLINE_WIDTH_SCREEN:
+        this._isOutline && this._outlineWidthMode === MToonMaterialOutlineWidthMode.ScreenCoordinates,
     };
   }
 


### PR DESCRIPTION
### Description

The compilation of MToon takes so much time when there are a lot of materials.
This change attempts to reduce the shader variants that Three.js need to compile.

- Enable outline related defines only when it's rendering the outline
    - `OUTLINE_WIDTH_WORLD`, `OUTLINE_WIDTH_SCREEN`, and `USE_OUTLINEWIDTHMULTIPLYTEXTURE` are not needed to set unless it's a material for outline.
- (tangential) Remove keys which overlap with existing defines.
