### PR TITLE
Bump/three r149

### DIFF
--- a/packages/three-vrm-core/package.json
+++ b/packages/three-vrm-core/package.json
@@ -50,12 +50,12 @@
     "@pixiv/types-vrmc-vrm-1.0": "1.0.0"
   },
   "devDependencies": {
-    "@types/three": "^0.148.0",
+    "@types/three": "^0.149.0",
     "lint-staged": "13.1.2",
-    "three": "^0.148.0"
+    "three": "^0.149.0"
   },
   "peerDependencies": {
-    "@types/three": "^0.148.0",
-    "three": "^0.148.0"
+    "@types/three": "^0.149.0",
+    "three": "^0.149.0"
   }
 }

--- a/packages/three-vrm-core/src/firstPerson/VRMFirstPerson.ts
+++ b/packages/three-vrm-core/src/firstPerson/VRMFirstPerson.ts
@@ -176,16 +176,28 @@ export class VRMFirstPerson {
 
     const geometry = dst.geometry;
 
-    const skinIndexAttr = geometry.getAttribute('skinIndex').array;
+    const skinIndexAttr = geometry.getAttribute('skinIndex');
+    const skinIndexAttrArray = skinIndexAttr instanceof THREE.GLBufferAttribute ? [] : skinIndexAttr.array;
     const skinIndex = [];
-    for (let i = 0; i < skinIndexAttr.length; i += 4) {
-      skinIndex.push([skinIndexAttr[i], skinIndexAttr[i + 1], skinIndexAttr[i + 2], skinIndexAttr[i + 3]]);
+    for (let i = 0; i < skinIndexAttrArray.length; i += 4) {
+      skinIndex.push([
+        skinIndexAttrArray[i],
+        skinIndexAttrArray[i + 1],
+        skinIndexAttrArray[i + 2],
+        skinIndexAttrArray[i + 3],
+      ]);
     }
 
-    const skinWeightAttr = geometry.getAttribute('skinWeight').array;
+    const skinWeightAttr = geometry.getAttribute('skinWeight');
+    const skinWeightAttrArray = skinWeightAttr instanceof THREE.GLBufferAttribute ? [] : skinWeightAttr.array;
     const skinWeight = [];
-    for (let i = 0; i < skinWeightAttr.length; i += 4) {
-      skinWeight.push([skinWeightAttr[i], skinWeightAttr[i + 1], skinWeightAttr[i + 2], skinWeightAttr[i + 3]]);
+    for (let i = 0; i < skinWeightAttrArray.length; i += 4) {
+      skinWeight.push([
+        skinWeightAttrArray[i],
+        skinWeightAttrArray[i + 1],
+        skinWeightAttrArray[i + 2],
+        skinWeightAttrArray[i + 3],
+      ]);
     }
 
     const index = geometry.getIndex();

--- a/packages/three-vrm-materials-hdr-emissive-multiplier/package.json
+++ b/packages/three-vrm-materials-hdr-emissive-multiplier/package.json
@@ -44,11 +44,11 @@
     "@pixiv/types-vrmc-materials-hdr-emissive-multiplier-1.0": "1.0.0"
   },
   "devDependencies": {
-    "@types/three": "^0.148.0",
-    "three": "^0.148.0"
+    "@types/three": "^0.149.0",
+    "three": "^0.149.0"
   },
   "peerDependencies": {
-    "@types/three": "^0.148.0",
-    "three": "^0.148.0"
+    "@types/three": "^0.149.0",
+    "three": "^0.149.0"
   }
 }

--- a/packages/three-vrm-materials-mtoon/package.json
+++ b/packages/three-vrm-materials-mtoon/package.json
@@ -45,11 +45,11 @@
     "@pixiv/types-vrmc-materials-mtoon-1.0": "1.0.0"
   },
   "devDependencies": {
-    "@types/three": "^0.148.0",
-    "three": "^0.148.0"
+    "@types/three": "^0.149.0",
+    "three": "^0.149.0"
   },
   "peerDependencies": {
-    "@types/three": "^0.148.0",
-    "three": "^0.148.0"
+    "@types/three": "^0.149.0",
+    "three": "^0.149.0"
   }
 }

--- a/packages/three-vrm-materials-v0compat/package.json
+++ b/packages/three-vrm-materials-v0compat/package.json
@@ -44,12 +44,12 @@
     "@pixiv/types-vrmc-materials-mtoon-1.0": "1.0.0"
   },
   "devDependencies": {
-    "@types/three": "^0.148.0",
+    "@types/three": "^0.149.0",
     "lint-staged": "13.1.2",
-    "three": "^0.148.0"
+    "three": "^0.149.0"
   },
   "peerDependencies": {
-    "@types/three": "^0.148.0",
-    "three": "^0.148.0"
+    "@types/three": "^0.149.0",
+    "three": "^0.149.0"
   }
 }

--- a/packages/three-vrm-node-constraint/package.json
+++ b/packages/three-vrm-node-constraint/package.json
@@ -45,12 +45,12 @@
     "@pixiv/types-vrmc-node-constraint-1.0": "1.0.0"
   },
   "devDependencies": {
-    "@types/three": "^0.148.0",
+    "@types/three": "^0.149.0",
     "lint-staged": "13.1.2",
-    "three": "^0.148.0"
+    "three": "^0.149.0"
   },
   "peerDependencies": {
-    "@types/three": "^0.148.0",
-    "three": "^0.148.0"
+    "@types/three": "^0.149.0",
+    "three": "^0.149.0"
   }
 }

--- a/packages/three-vrm-springbone/package.json
+++ b/packages/three-vrm-springbone/package.json
@@ -47,9 +47,9 @@
   },
   "devDependencies": {
     "lint-staged": "13.1.2",
-    "three": "^0.148.0"
+    "three": "^0.149.0"
   },
   "peerDependencies": {
-    "three": "^0.148.0"
+    "three": "^0.149.0"
   }
 }

--- a/packages/three-vrm/package.json
+++ b/packages/three-vrm/package.json
@@ -55,12 +55,12 @@
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.0.1",
-    "@types/three": "^0.148.0",
+    "@types/three": "^0.149.0",
     "lint-staged": "13.1.2",
-    "three": "^0.148.0"
+    "three": "^0.149.0"
   },
   "peerDependencies": {
-    "@types/three": "^0.148.0",
-    "three": "^0.148.0"
+    "@types/three": "^0.149.0",
+    "three": "^0.149.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1754,10 +1754,10 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
 
-"@types/three@^0.148.0":
-  version "0.148.1"
-  resolved "https://registry.yarnpkg.com/@types/three/-/three-0.148.1.tgz#e999a1a4840c12da8723187c315d8c8781d1066b"
-  integrity sha512-gZwIyTBMxKXqJHXmZ0dzvDieuQ4hz8MPNHtkRrAwER/xPlAh9eP2WIfaolvQY+wJAzlNV5a9ceS4JT+i/jybsw==
+"@types/three@^0.149.0":
+  version "0.149.0"
+  resolved "https://registry.yarnpkg.com/@types/three/-/three-0.149.0.tgz#f48c03ffcf35b2d196f3532b51bc845e96f6090e"
+  integrity sha512-fgNBm9LWc65ER/W0cvoXdC0iMy7Ke9e2CONmEr6Jt8sDSY3sw4DgOubZfmdZ747dkPhbQrgRQAWwDEr2S/7IEg==
   dependencies:
     "@types/webxr" "*"
 
@@ -7338,10 +7338,10 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
-three@^0.148.0:
-  version "0.148.0"
-  resolved "https://registry.yarnpkg.com/three/-/three-0.148.0.tgz#b6f62f9c84227f8d51c151bf17b67984ded8e4d7"
-  integrity sha512-8uzVV+qhTPi0bOFs/3te3RW6hb3urL8jYEl6irjCWo/l6sr8MPNMcClFev/MMYeIxr0gmDcoXTy/8LXh/LXkfw==
+three@^0.149.0:
+  version "0.149.0"
+  resolved "https://registry.yarnpkg.com/three/-/three-0.149.0.tgz#a9cf78b17d02f063ffe6dfca1e300eff2eab2927"
+  integrity sha512-tohpUxPDht0qExRLDTM8sjRLc5d9STURNrdnK3w9A+V4pxaTBfKWWT/IqtiLfg23Vfc3Z+ImNfvRw1/0CtxrkQ==
 
 throat@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
three.js と @types/three のバージョンアップを行います

getAttributeの型定義の更新に伴い、型ガードを追加しました。

動作に変更はありません。