### PR TITLE
Bump Three.js to r150

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Code like this:
 <script type="importmap">
   {
     "imports": {
-      "three": "https://unpkg.com/three@0.148.0/build/three.module.js",
-      "three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
+      "three": "https://unpkg.com/three@0.150.1/build/three.module.js",
+      "three/addons/": "https://unpkg.com/three@0.150.1/examples/jsm/",
       "@pixiv/three-vrm": "three-vrm.module.js"
     }
   }

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "ts-node": "^9.0.0",
     "tslib": "^2.0.3",
     "typedoc": "^0.22.18",
-    "typescript": "^4.0.5"
+    "typescript": "^4.3.5"
   },
   "name": "three-vrm"
 }

--- a/packages/three-vrm-core/examples/expressions.html
+++ b/packages/three-vrm-core/examples/expressions.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.150.1/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.150.1/examples/jsm/",
 					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/examples/firstPerson.html
+++ b/packages/three-vrm-core/examples/firstPerson.html
@@ -32,8 +32,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.150.1/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.150.1/examples/jsm/",
 					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/examples/humanoid.html
+++ b/packages/three-vrm-core/examples/humanoid.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.150.1/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.150.1/examples/jsm/",
 					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/examples/humanoidAnimation/index.html
+++ b/packages/three-vrm-core/examples/humanoidAnimation/index.html
@@ -38,8 +38,8 @@
 			{
 				"imports": {
 					"fflate": "https://unpkg.com/fflate@0.7.4/esm/browser.js",
-					"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.150.1/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.150.1/examples/jsm/",
 					"@pixiv/three-vrm-core": "../../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/examples/lookAt.html
+++ b/packages/three-vrm-core/examples/lookAt.html
@@ -32,8 +32,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.150.1/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.150.1/examples/jsm/",
 					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/examples/meta.html
+++ b/packages/three-vrm-core/examples/meta.html
@@ -39,8 +39,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.150.1/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.150.1/examples/jsm/",
 					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/package.json
+++ b/packages/three-vrm-core/package.json
@@ -50,12 +50,12 @@
     "@pixiv/types-vrmc-vrm-1.0": "1.0.0"
   },
   "devDependencies": {
-    "@types/three": "^0.149.0",
+    "@types/three": "^0.150.1",
     "lint-staged": "13.1.2",
-    "three": "^0.149.0"
+    "three": "^0.150.1"
   },
   "peerDependencies": {
-    "@types/three": "^0.149.0",
-    "three": "^0.149.0"
+    "@types/three": "^0.150.1",
+    "three": "^0.150.1"
   }
 }

--- a/packages/three-vrm-core/src/expressions/VRMExpression.ts
+++ b/packages/three-vrm-core/src/expressions/VRMExpression.ts
@@ -38,6 +38,8 @@ export class VRMExpression extends THREE.Object3D {
 
   private _binds: VRMExpressionBind[] = [];
 
+  override readonly type: string | 'VRMExpression';
+
   /**
    * A value represents how much it should override blink expressions.
    * `0.0` == no override at all, `1.0` == completely block the expressions.
@@ -88,6 +90,7 @@ export class VRMExpression extends THREE.Object3D {
 
     // traverse 時の救済手段として Object3D ではないことを明示しておく
     this.type = 'VRMExpression';
+
     // 表示目的のオブジェクトではないので、負荷軽減のために visible を false にしておく。
     // これにより、このインスタンスに対する毎フレームの matrix 自動計算を省略できる。
     this.visible = false;

--- a/packages/three-vrm-core/src/humanoid/helpers/VRMHumanoidHelper.ts
+++ b/packages/three-vrm-core/src/humanoid/helpers/VRMHumanoidHelper.ts
@@ -28,7 +28,7 @@ export class VRMHumanoidHelper extends THREE.Group {
       this.add(helper);
 
       // TODO: type assertion is not needed in later versions of TypeScript
-      this._boneAxesMap.set(bone!, helper);
+      this._boneAxesMap.set(bone, helper);
     });
   }
 

--- a/packages/three-vrm-core/src/humanoid/helpers/VRMHumanoidHelper.ts
+++ b/packages/three-vrm-core/src/humanoid/helpers/VRMHumanoidHelper.ts
@@ -27,7 +27,6 @@ export class VRMHumanoidHelper extends THREE.Group {
 
       this.add(helper);
 
-      // TODO: type assertion is not needed in later versions of TypeScript
       this._boneAxesMap.set(bone, helper);
     });
   }

--- a/packages/three-vrm-materials-hdr-emissive-multiplier/examples/loader-plugin.html
+++ b/packages/three-vrm-materials-hdr-emissive-multiplier/examples/loader-plugin.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.150.1/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.150.1/examples/jsm/",
 					"@pixiv/three-vrm-materials-hdr-emissive-multiplier": "../lib/three-vrm-materials-hdr-emissive-multiplier.module.js"
 				}
 			}

--- a/packages/three-vrm-materials-hdr-emissive-multiplier/package.json
+++ b/packages/three-vrm-materials-hdr-emissive-multiplier/package.json
@@ -44,11 +44,11 @@
     "@pixiv/types-vrmc-materials-hdr-emissive-multiplier-1.0": "1.0.0"
   },
   "devDependencies": {
-    "@types/three": "^0.149.0",
-    "three": "^0.149.0"
+    "@types/three": "^0.150.1",
+    "three": "^0.150.1"
   },
   "peerDependencies": {
-    "@types/three": "^0.149.0",
-    "three": "^0.149.0"
+    "@types/three": "^0.150.1",
+    "three": "^0.150.1"
   }
 }

--- a/packages/three-vrm-materials-mtoon/examples/emissive-strength.html
+++ b/packages/three-vrm-materials-mtoon/examples/emissive-strength.html
@@ -24,8 +24,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.150.1/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.150.1/examples/jsm/",
 					"@pixiv/three-vrm-materials-mtoon": "../lib/three-vrm-materials-mtoon.module.js"
 				}
 			}

--- a/packages/three-vrm-materials-mtoon/examples/loader-plugin.html
+++ b/packages/three-vrm-materials-mtoon/examples/loader-plugin.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.150.1/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.150.1/examples/jsm/",
 					"@pixiv/three-vrm-materials-mtoon": "../lib/three-vrm-materials-mtoon.module.js"
 				}
 			}

--- a/packages/three-vrm-materials-mtoon/package.json
+++ b/packages/three-vrm-materials-mtoon/package.json
@@ -45,11 +45,11 @@
     "@pixiv/types-vrmc-materials-mtoon-1.0": "1.0.0"
   },
   "devDependencies": {
-    "@types/three": "^0.149.0",
-    "three": "^0.149.0"
+    "@types/three": "^0.150.1",
+    "three": "^0.150.1"
   },
   "peerDependencies": {
-    "@types/three": "^0.149.0",
-    "three": "^0.149.0"
+    "@types/three": "^0.150.1",
+    "three": "^0.150.1"
   }
 }

--- a/packages/three-vrm-materials-mtoon/src/MToonMaterialLoaderPlugin.ts
+++ b/packages/three-vrm-materials-mtoon/src/MToonMaterialLoaderPlugin.ts
@@ -267,7 +267,7 @@ export class MToonMaterialLoaderPlugin implements GLTFLoaderPlugin {
     mesh.material = [surfaceMaterial]; // mesh.material is guaranteed to be a Material in GLTFLoader
 
     // duplicate the material for outline use
-    const outlineMaterial = surfaceMaterial.clone() as MToonMaterial;
+    const outlineMaterial = surfaceMaterial.clone();
     outlineMaterial.name += ' (Outline)';
     outlineMaterial.isOutline = true;
     outlineMaterial.side = THREE.BackSide;

--- a/packages/three-vrm-materials-mtoon/src/utils/getTexelDecodingFunction.ts
+++ b/packages/three-vrm-materials-mtoon/src/utils/getTexelDecodingFunction.ts
@@ -9,12 +9,20 @@ const RGBDEncoding = 3006;
 const GammaEncoding = 3007;
 /* eslint-enable @typescript-eslint/naming-convention */
 
+type TextureEncoding =
+  | THREE.TextureEncoding
+  | typeof RGBEEncoding
+  | typeof RGBM7Encoding
+  | typeof RGBM16Encoding
+  | typeof RGBDEncoding
+  | typeof GammaEncoding;
+
 /**
  * COMPAT: pre-r137
  *
  * Ref: https://github.com/mrdoob/three.js/blob/r136/src/renderers/webgl/WebGLProgram.js#L22
  */
-export const getEncodingComponents = (encoding: THREE.TextureEncoding): [string, string] => {
+export const getEncodingComponents = (encoding: TextureEncoding): [string, string] => {
   if (parseInt(THREE.REVISION, 10) >= 136) {
     switch (encoding) {
       case THREE.LinearEncoding:
@@ -55,7 +63,7 @@ export const getEncodingComponents = (encoding: THREE.TextureEncoding): [string,
  *
  * https://github.com/mrdoob/three.js/blob/r136/src/renderers/webgl/WebGLProgram.js#L52
  */
-export const getTexelDecodingFunction = (functionName: string, encoding: THREE.TextureEncoding): string => {
+export const getTexelDecodingFunction = (functionName: string, encoding: TextureEncoding): string => {
   const components = getEncodingComponents(encoding);
   return 'vec4 ' + functionName + '( vec4 value ) { return ' + components[0] + 'ToLinear' + components[1] + '; }';
 };

--- a/packages/three-vrm-materials-v0compat/package.json
+++ b/packages/three-vrm-materials-v0compat/package.json
@@ -44,12 +44,12 @@
     "@pixiv/types-vrmc-materials-mtoon-1.0": "1.0.0"
   },
   "devDependencies": {
-    "@types/three": "^0.149.0",
+    "@types/three": "^0.150.1",
     "lint-staged": "13.1.2",
-    "three": "^0.149.0"
+    "three": "^0.150.1"
   },
   "peerDependencies": {
-    "@types/three": "^0.149.0",
-    "three": "^0.149.0"
+    "@types/three": "^0.150.1",
+    "three": "^0.150.1"
   }
 }

--- a/packages/three-vrm-node-constraint/examples/aim.html
+++ b/packages/three-vrm-node-constraint/examples/aim.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-					"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.150.1/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.150.1/examples/jsm/",
 					"tweakpane": "https://unpkg.com/tweakpane@3.0",
 					"tweakpane-plugin-rotation": "https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1",
 					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"

--- a/packages/three-vrm-node-constraint/examples/importer.html
+++ b/packages/three-vrm-node-constraint/examples/importer.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-					"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.150.1/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.150.1/examples/jsm/",
 					"tweakpane": "https://unpkg.com/tweakpane@3.0",
 					"tweakpane-plugin-rotation": "https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1",
 					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"

--- a/packages/three-vrm-node-constraint/examples/roll.html
+++ b/packages/three-vrm-node-constraint/examples/roll.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-					"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.150.1/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.150.1/examples/jsm/",
 					"tweakpane": "https://unpkg.com/tweakpane@3.0",
 					"tweakpane-plugin-rotation": "https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1",
 					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"

--- a/packages/three-vrm-node-constraint/examples/rotation.html
+++ b/packages/three-vrm-node-constraint/examples/rotation.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-					"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.150.1/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.150.1/examples/jsm/",
 					"tweakpane": "https://unpkg.com/tweakpane@3.0",
 					"tweakpane-plugin-rotation": "https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1",
 					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"

--- a/packages/three-vrm-node-constraint/examples/upper-arm.html
+++ b/packages/three-vrm-node-constraint/examples/upper-arm.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-					"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.150.1/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.150.1/examples/jsm/",
 					"tweakpane": "https://unpkg.com/tweakpane@3.0",
 					"tweakpane-plugin-rotation": "https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1",
 					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"

--- a/packages/three-vrm-node-constraint/package.json
+++ b/packages/three-vrm-node-constraint/package.json
@@ -45,12 +45,12 @@
     "@pixiv/types-vrmc-node-constraint-1.0": "1.0.0"
   },
   "devDependencies": {
-    "@types/three": "^0.149.0",
+    "@types/three": "^0.150.1",
     "lint-staged": "13.1.2",
-    "three": "^0.149.0"
+    "three": "^0.150.1"
   },
   "peerDependencies": {
-    "@types/three": "^0.149.0",
-    "three": "^0.149.0"
+    "@types/three": "^0.150.1",
+    "three": "^0.150.1"
   }
 }

--- a/packages/three-vrm-node-constraint/src/utils/Matrix4InverseCache.ts
+++ b/packages/three-vrm-node-constraint/src/utils/Matrix4InverseCache.ts
@@ -42,7 +42,7 @@ export class Matrix4InverseCache {
     this.matrix = matrix;
 
     const handler: ProxyHandler<number[]> = {
-      set: (obj, prop: number, newVal) => {
+      set: (obj, prop: any, newVal) => {
         this._shouldUpdateInverse = true;
         obj[prop] = newVal;
 

--- a/packages/three-vrm-springbone/examples/collider.html
+++ b/packages/three-vrm-springbone/examples/collider.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-				"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
-				"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
+				"three": "https://unpkg.com/three@0.150.1/build/three.module.js",
+				"three/addons/": "https://unpkg.com/three@0.150.1/examples/jsm/",
 				"@pixiv/three-vrm-springbone": "../lib/three-vrm-springbone.module.js"
 			  }
 			}

--- a/packages/three-vrm-springbone/examples/loader-plugin.html
+++ b/packages/three-vrm-springbone/examples/loader-plugin.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-				"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
-				"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
+				"three": "https://unpkg.com/three@0.150.1/build/three.module.js",
+				"three/addons/": "https://unpkg.com/three@0.150.1/examples/jsm/",
 				"@pixiv/three-vrm-springbone": "../lib/three-vrm-springbone.module.js"
 			  }
 			}

--- a/packages/three-vrm-springbone/examples/multiple.html
+++ b/packages/three-vrm-springbone/examples/multiple.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-				"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
-				"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
+				"three": "https://unpkg.com/three@0.150.1/build/three.module.js",
+				"three/addons/": "https://unpkg.com/three@0.150.1/examples/jsm/",
 				"@pixiv/three-vrm-springbone": "../lib/three-vrm-springbone.module.js"
 			  }
 			}

--- a/packages/three-vrm-springbone/examples/single.html
+++ b/packages/three-vrm-springbone/examples/single.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-				"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
-				"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
+				"three": "https://unpkg.com/three@0.150.1/build/three.module.js",
+				"three/addons/": "https://unpkg.com/three@0.150.1/examples/jsm/",
 				"@pixiv/three-vrm-springbone": "../lib/three-vrm-springbone.module.js"
 			  }
 			}

--- a/packages/three-vrm-springbone/package.json
+++ b/packages/three-vrm-springbone/package.json
@@ -47,9 +47,9 @@
   },
   "devDependencies": {
     "lint-staged": "13.1.2",
-    "three": "^0.149.0"
+    "three": "^0.150.1"
   },
   "peerDependencies": {
-    "three": "^0.149.0"
+    "three": "^0.150.1"
   }
 }

--- a/packages/three-vrm-springbone/src/utils/Matrix4InverseCache.ts
+++ b/packages/three-vrm-springbone/src/utils/Matrix4InverseCache.ts
@@ -42,7 +42,7 @@ export class Matrix4InverseCache {
     this.matrix = matrix;
 
     const handler: ProxyHandler<number[]> = {
-      set: (obj, prop: number, newVal) => {
+      set: (obj, prop: any, newVal) => {
         this._shouldUpdateInverse = true;
         obj[prop] = newVal;
 

--- a/packages/three-vrm/README.md
+++ b/packages/three-vrm/README.md
@@ -46,8 +46,8 @@ Code like this:
 <script type="importmap">
   {
     "imports": {
-      "three": "https://unpkg.com/three@0.148.0/build/three.module.js",
-      "three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
+      "three": "https://unpkg.com/three@0.150.1/build/three.module.js",
+      "three/addons/": "https://unpkg.com/three@0.150.1/examples/jsm/",
       "@pixiv/three-vrm": "three-vrm.module.js"
     }
   }

--- a/packages/three-vrm/examples/animations.html
+++ b/packages/three-vrm/examples/animations.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.150.1/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.150.1/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/basic.html
+++ b/packages/three-vrm/examples/basic.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.150.1/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.150.1/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/bones.html
+++ b/packages/three-vrm/examples/bones.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.150.1/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.150.1/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/debug.html
+++ b/packages/three-vrm/examples/debug.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.150.1/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.150.1/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/dnd.html
+++ b/packages/three-vrm/examples/dnd.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.150.1/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.150.1/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/expressions.html
+++ b/packages/three-vrm/examples/expressions.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.150.1/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.150.1/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/firstperson.html
+++ b/packages/three-vrm/examples/firstperson.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.150.1/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.150.1/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/humanoidAnimation/index.html
+++ b/packages/three-vrm/examples/humanoidAnimation/index.html
@@ -38,8 +38,8 @@
 			{
 				"imports": {
 					"fflate": "https://unpkg.com/fflate@0.7.4/esm/browser.js",
-					"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.150.1/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.150.1/examples/jsm/",
 					"@pixiv/three-vrm": "../../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/lookat-advanced.html
+++ b/packages/three-vrm/examples/lookat-advanced.html
@@ -28,8 +28,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.150.1/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.150.1/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/lookat.html
+++ b/packages/three-vrm/examples/lookat.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.150.1/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.150.1/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/materials-debug.html
+++ b/packages/three-vrm/examples/materials-debug.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.150.1/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.150.1/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/meta.html
+++ b/packages/three-vrm/examples/meta.html
@@ -38,8 +38,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.150.1/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.150.1/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/mouse.html
+++ b/packages/three-vrm/examples/mouse.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.148.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.148.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.150.1/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.150.1/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/package.json
+++ b/packages/three-vrm/package.json
@@ -55,12 +55,12 @@
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.0.1",
-    "@types/three": "^0.149.0",
+    "@types/three": "^0.150.1",
     "lint-staged": "13.1.2",
-    "three": "^0.149.0"
+    "three": "^0.150.1"
   },
   "peerDependencies": {
-    "@types/three": "^0.149.0",
-    "three": "^0.149.0"
+    "@types/three": "^0.150.1",
+    "three": "^0.150.1"
   }
 }

--- a/packages/three-vrm/src/utils/Matrix4InverseCache.ts
+++ b/packages/three-vrm/src/utils/Matrix4InverseCache.ts
@@ -41,7 +41,7 @@ export class Matrix4InverseCache {
     this.matrix = matrix;
 
     const handler: ProxyHandler<number[]> = {
-      set: (obj, prop: number, newVal) => {
+      set: (obj, prop: any, newVal) => {
         this._shouldUpdateInverse = true;
         obj[prop] = newVal;
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1725,9 +1725,9 @@
   integrity sha512-jhuKLIRrhvCPLqwPcx6INqmKeiA5EWrsCOPhrlFSrbrmU4ZMPjj5Ul/oLCMDO98XRUIwVm78xICz4EPCektzeQ==
 
 "@types/node@*":
-  version "18.7.23"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.7.23.tgz#75c580983846181ebe5f4abc40fe9dfb2d65665f"
-  integrity sha512-DWNcCHolDq0ZKGizjx2DZjR/PqsYwAcYUJmfMWqtVU2MBMG5Mo+xFZrhGId5r/O5HOuMPyQEcM6KUBp5lBZZBg==
+  version "18.15.11"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.15.11.tgz#b3b790f09cb1696cffcec605de025b088fa4225f"
+  integrity sha512-E5Kwq2n4SbMzQOn6wnmBjuK9ouqlURrcZDVfbo9ftDDTFt3nk7ZKK4GMOzoYgnpQJKcxwQw+lGaBvvlMo0qN/Q==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1754,12 +1754,20 @@
   resolved "https://registry.yarnpkg.com/@types/stack-utils/-/stack-utils-2.0.1.tgz#20f18294f797f2209b5f65c8e3b5c8e8261d127c"
   integrity sha512-Hl219/BT5fLAaz6NDkSuhzasy49dwQS/DSdu4MdggFB8zcXv7vflBI3xp7FEmkmdDkBUI2bPUNeMttp2knYdxw==
 
-"@types/three@^0.149.0":
-  version "0.149.0"
-  resolved "https://registry.yarnpkg.com/@types/three/-/three-0.149.0.tgz#f48c03ffcf35b2d196f3532b51bc845e96f6090e"
-  integrity sha512-fgNBm9LWc65ER/W0cvoXdC0iMy7Ke9e2CONmEr6Jt8sDSY3sw4DgOubZfmdZ747dkPhbQrgRQAWwDEr2S/7IEg==
+"@types/stats.js@*":
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/@types/stats.js/-/stats.js-0.17.0.tgz#0ed81d48e03b590c24da85540c1d952077a9fe20"
+  integrity sha512-9w+a7bR8PeB0dCT/HBULU2fMqf6BAzvKbxFboYhmDtDkKPiyXYbjoe2auwsXlEFI7CFNMF1dCv3dFH5Poy9R1w==
+
+"@types/three@^0.150.1":
+  version "0.150.1"
+  resolved "https://registry.yarnpkg.com/@types/three/-/three-0.150.1.tgz#32a594ac0d8452d37ad3abbb22a9496878ac6c77"
+  integrity sha512-ZXS1M3brsfAAbTeeUEt0defPi98yWQuEyPBnvjEYY1dCEYfJnFaww0mYgRpJ9JVfmtwRxqISpVcv/g/0lMl1DQ==
   dependencies:
+    "@types/stats.js" "*"
     "@types/webxr" "*"
+    fflate "~0.6.9"
+    lil-gui "~0.17.0"
 
 "@types/webxr@*":
   version "0.5.0"
@@ -3591,6 +3599,11 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
+fflate@~0.6.9:
+  version "0.6.10"
+  resolved "https://registry.yarnpkg.com/fflate/-/fflate-0.6.10.tgz#5f40f9659205936a2d18abf88b2e7781662b6d43"
+  integrity sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==
+
 figures@3.2.0, figures@^3.0.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/figures/-/figures-3.2.0.tgz#625c18bd293c604dc4a8ddb2febf0c88341746af"
@@ -5175,6 +5188,11 @@ libnpmpublish@^6.0.4:
     npm-registry-fetch "^13.0.0"
     semver "^7.3.7"
     ssri "^9.0.0"
+
+lil-gui@~0.17.0:
+  version "0.17.0"
+  resolved "https://registry.yarnpkg.com/lil-gui/-/lil-gui-0.17.0.tgz#b41ae55d0023fcd9185f7395a218db0f58189663"
+  integrity sha512-MVBHmgY+uEbmJNApAaPbtvNh1RCAeMnKym82SBjtp5rODTYKWtM+MXHCifLe2H2Ti1HuBGBtK/5SyG4ShQ3pUQ==
 
 lilconfig@2.0.6:
   version "2.0.6"
@@ -7338,10 +7356,10 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
-three@^0.149.0:
-  version "0.149.0"
-  resolved "https://registry.yarnpkg.com/three/-/three-0.149.0.tgz#a9cf78b17d02f063ffe6dfca1e300eff2eab2927"
-  integrity sha512-tohpUxPDht0qExRLDTM8sjRLc5d9STURNrdnK3w9A+V4pxaTBfKWWT/IqtiLfg23Vfc3Z+ImNfvRw1/0CtxrkQ==
+three@^0.150.1:
+  version "0.150.1"
+  resolved "https://registry.yarnpkg.com/three/-/three-0.150.1.tgz#870d324a4d2daf1c7d55be97f3f73d83783e28be"
+  integrity sha512-5C1MqKUWaHYo13BX0Q64qcdwImgnnjSOFgBscOzAo8MYCzEtqfQqorEKMcajnA3FHy1yVlIe9AmaMQ0OQracNA==
 
 throat@^5.0.0:
   version "5.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -7610,10 +7610,10 @@ typedoc@^0.22.18:
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.8.4.tgz#c464abca159669597be5f96b8943500b238e60e6"
   integrity sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==
 
-typescript@^4.0.5:
-  version "4.1.5"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.1.5.tgz#123a3b214aaff3be32926f0d8f1f6e704eb89a72"
-  integrity sha512-6OSu9PTIzmn9TCDiovULTnET6BgXtDYL4Gg4szY+cGsc3JP1dQL8qvE8kShTRx1NIw4Q9IBHlwODjkjWEtMUyA==
+typescript@^4.3.5:
+  version "4.9.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.9.5.tgz#095979f9bcc0d09da324d58d03ce8f8374cbe65a"
+  integrity sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==
 
 typescript@next:
   version "5.0.0-dev.20221212"


### PR DESCRIPTION
Bumped Three.js to r150.

This should fix the issue that causes an infinite loop:
https://github.com/mrdoob/three.js/pull/25377

three-ts-types starts to use `override` decorator, which is only available starting from TypeScript 4.3.
Because of this, this PR also bumps TypeScript to v4.3.5.
