### PR TITLE
chore, docs: fix the instruction of `CONTRIBUTING.md` + change order of `yarn all`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -8,6 +8,7 @@ The below should work:
 
 ```sh
 yarn
+yarn build
 cd packages/three-vrm
 yarn dev
 ```

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
     "packages/*"
   ],
   "scripts": {
-    "all": "yarn test && yarn lint && yarn clean && yarn build && yarn docs",
+    "all": "yarn clean && yarn build && yarn test && yarn lint && yarn docs",
     "clean": "lerna run clean",
     "build": "lerna run build",
     "test": "lerna run test",


### PR DESCRIPTION
Building packages using `yarn build` is required before starting the development of `@pixiv/three-vrm`.

It also changes the execution order of commands inside the `yarn all`, since the order in the previous instruction does not work properly.
It's a temporary workaround. We will replace the task runner with a better one later

should resolve https://github.com/pixiv/three-vrm/issues/1190

### TODO

- [x] make sure the CONTRIBUTING.md instruction is correct
- [x] make sure the `yarn all` works from scratch
