### PR TITLE
fix: Fix a VRM0.0 texture offset issue

### DIFF
--- a/packages/three-vrm-core/src/expressions/VRMExpressionLoaderPlugin.ts
+++ b/packages/three-vrm-core/src/expressions/VRMExpressionLoaderPlugin.ts
@@ -374,7 +374,7 @@ export class VRMExpressionLoaderPlugin implements GLTFLoaderPlugin {
                 const scale = new THREE.Vector2(materialValue.targetValue![0], materialValue.targetValue![1]);
                 const offset = new THREE.Vector2(materialValue.targetValue![2], materialValue.targetValue![3]);
 
-                offset.y = (1.0 - offset.y - scale.y) % 1.0;
+                offset.y = 1.0 - offset.y - scale.y;
 
                 expression.addBind(
                   new VRMExpressionTextureTransformBind({

--- a/packages/three-vrm-core/src/expressions/VRMExpressionLoaderPlugin.ts
+++ b/packages/three-vrm-core/src/expressions/VRMExpressionLoaderPlugin.ts
@@ -373,6 +373,9 @@ export class VRMExpressionLoaderPlugin implements GLTFLoaderPlugin {
               if (materialPropertyName === '_MainTex_ST') {
                 const scale = new THREE.Vector2(materialValue.targetValue![0], materialValue.targetValue![1]);
                 const offset = new THREE.Vector2(materialValue.targetValue![2], materialValue.targetValue![3]);
+
+                offset.y = (1.0 - offset.y - scale.y) % 1.0;
+
                 expression.addBind(
                   new VRMExpressionTextureTransformBind({
                     material,

--- a/packages/three-vrm-materials-v0compat/src/VRMMaterialsV0CompatPlugin.ts
+++ b/packages/three-vrm-materials-v0compat/src/VRMMaterialsV0CompatPlugin.ts
@@ -336,7 +336,7 @@ export class VRMMaterialsV0CompatPlugin implements GLTFLoaderPlugin {
     const offset = [textureTransform?.[0] ?? 0.0, textureTransform?.[1] ?? 0.0];
     const scale = [textureTransform?.[2] ?? 1.0, textureTransform?.[3] ?? 1.0];
 
-    offset[1] = (1.0 - scale[1] - offset[1]) % 1.0;
+    offset[1] = 1.0 - scale[1] - offset[1];
 
     return {
       // eslint-disable-next-line @typescript-eslint/naming-convention

--- a/packages/three-vrm-materials-v0compat/src/VRMMaterialsV0CompatPlugin.ts
+++ b/packages/three-vrm-materials-v0compat/src/VRMMaterialsV0CompatPlugin.ts
@@ -336,7 +336,7 @@ export class VRMMaterialsV0CompatPlugin implements GLTFLoaderPlugin {
     const offset = [textureTransform?.[0] ?? 0.0, textureTransform?.[1] ?? 0.0];
     const scale = [textureTransform?.[2] ?? 1.0, textureTransform?.[3] ?? 1.0];
 
-    offset[1] = (scale[1] * (1.0 - offset[1])) % 1.0;
+    offset[1] = (1.0 - scale[1] - offset[1]) % 1.0;
 
     return {
       // eslint-disable-next-line @typescript-eslint/naming-convention


### PR DESCRIPTION
This PR fixes a VRM0.0 texture offset issue.

Fix the parsing of these properties:

- `materialProperties/i/vectorProperties/_MainTex`
- `blendShapeMaster/blendShapeGroups/i/materialValues/j/targetValue`

- See the image: https://imgur.com/a/W3SvUTm
- The previous commit to the change: 327e534516eff53967044ba5eaf45e2f44a8feb9