### PR TITLE
Actionsのnodeのバージョンを.node_versionから参照する

### DIFF
--- a/.github/workflows/inspect.yml
+++ b/.github/workflows/inspect.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Setup Node
       uses: actions/setup-node@v3
       with:
-        node-version: '14'
+        node-version-file: './.node-version'
     - name: Cache Deps
       uses: actions/cache@v3
       with:
@@ -37,7 +37,7 @@ jobs:
     - name: Setup Node
       uses: actions/setup-node@v3
       with:
-        node-version: '14'
+        node-version-file: './.node-version'
     - name: Cache Deps
       uses: actions/cache@v3
       with:
@@ -67,7 +67,7 @@ jobs:
     - name: Setup Node
       uses: actions/setup-node@v3
       with:
-        node-version: '14'
+        node-version-file: './.node-version'
     - name: Cache Deps
       uses: actions/cache@v3
       with:
@@ -94,7 +94,7 @@ jobs:
     - name: Setup Node
       uses: actions/setup-node@v3
       with:
-        node-version: '14'
+        node-version-file: './.node-version'
     - name: Cache Deps
       uses: actions/cache@v3
       with:
@@ -121,7 +121,7 @@ jobs:
     - name: Setup Node
       uses: actions/setup-node@v3
       with:
-        node-version: '14'
+        node-version-file: './.node-version'
     - name: Cache Deps
       uses: actions/cache@v3
       with:
@@ -157,7 +157,7 @@ jobs:
     - name: Setup Node
       uses: actions/setup-node@v3
       with:
-        node-version: '14'
+        node-version-file: './.node-version'
     - name: Cache Deps
       uses: actions/cache@v3
       with:


### PR DESCRIPTION
Actionsのnode verが古く失敗していた。

.node_versionを参照するように変更する