### PR TITLE
Examples: Replace ConeBufferGeometry with ConeGeometry

### DIFF
--- a/packages/three-vrm-node-constraint/examples/aim.html
+++ b/packages/three-vrm-node-constraint/examples/aim.html
@@ -98,7 +98,7 @@
 			scene.add( light );
 
 			// objects
-			const geometry = new THREE.ConeBufferGeometry( 0.25, 0.5, 5 );
+			const geometry = new THREE.ConeGeometry( 0.25, 0.5, 5 );
 			const material = new THREE.MeshStandardMaterial( { color: 0xbbbbbb } );
 
 			const upperArm = new THREE.Mesh( geometry, material );

--- a/packages/three-vrm-node-constraint/examples/roll.html
+++ b/packages/three-vrm-node-constraint/examples/roll.html
@@ -99,7 +99,7 @@
 			scene.add( light );
 
 			// objects
-			const geometry = new THREE.ConeBufferGeometry( 0.25, 0.5, 5 );
+			const geometry = new THREE.ConeGeometry( 0.25, 0.5, 5 );
 			const material = new THREE.MeshStandardMaterial( { color: 0xbbbbbb } );
 
 			const lowerArm = new THREE.Mesh( geometry, material );

--- a/packages/three-vrm-node-constraint/examples/rotation.html
+++ b/packages/three-vrm-node-constraint/examples/rotation.html
@@ -89,7 +89,7 @@
 			scene.add( light );
 
 			// objects
-			const geometry = new THREE.ConeBufferGeometry( 0.25, 0.5, 5 );
+			const geometry = new THREE.ConeGeometry( 0.25, 0.5, 5 );
 			const material = new THREE.MeshStandardMaterial( { color: 0xbbbbbb } );
 
 			const source = new THREE.Mesh( geometry, material );

--- a/packages/three-vrm-node-constraint/examples/upper-arm.html
+++ b/packages/three-vrm-node-constraint/examples/upper-arm.html
@@ -90,7 +90,7 @@
 			scene.add( light );
 
 			// objects
-			const geometry = new THREE.ConeBufferGeometry( 0.25, 0.5, 5 );
+			const geometry = new THREE.ConeGeometry( 0.25, 0.5, 5 );
 			const material = new THREE.MeshStandardMaterial( { color: 0xbbbbbb } );
 
 			const upperArm = new THREE.Object3D();


### PR DESCRIPTION
Resolves #1283 by replacing deprecated `THREE.ConeBufferGeometry` class with `THREE.ConeGeometry`