### PR TITLE
fix: Fix compatibility breaks at three r157 on MToon

### DIFF
--- a/packages/three-vrm-materials-mtoon/src/shaders/mtoon.frag
+++ b/packages/three-vrm-materials-mtoon/src/shaders/mtoon.frag
@@ -633,7 +633,7 @@ void main() {
     geometry.normal = normal;
     geometry.viewDir = ( isOrthographic ) ? vec3( 0, 0, 1 ) : normalize( vViewPosition );
 
-    #ifdef CLEARCOAT
+    #ifdef USE_CLEARCOAT
 
       geometry.clearcoatNormal = clearcoatNormal;
 

--- a/packages/three-vrm-materials-mtoon/src/shaders/mtoon.frag
+++ b/packages/three-vrm-materials-mtoon/src/shaders/mtoon.frag
@@ -51,10 +51,6 @@ uniform float uvAnimationScrollXOffset;
 uniform float uvAnimationScrollYOffset;
 uniform float uvAnimationRotationPhase;
 
-#if THREE_VRM_THREE_REVISION >= 157
-  uniform vec3 lightProbe[ 9 ];
-#endif
-
 #include <common>
 #include <packing>
 #include <dithering_pars_fragment>
@@ -777,12 +773,14 @@ void main() {
 
     vec3 irradiance = getAmbientLightIrradiance( ambientLightColor );
 
-    #if THREE_VRM_THREE_REVISION >= 157
-      irradiance += getLightProbeIrradiance( lightProbe, geometryNormal );
-    #elif THREE_VRM_THREE_REVISION >= 133
-      irradiance += getLightProbeIrradiance( lightProbe, geometry.normal );
-    #else
-      irradiance += getLightProbeIrradiance( lightProbe, geometry );
+    #if defined( USE_LIGHT_PROBES )
+      #if THREE_VRM_THREE_REVISION >= 157
+        irradiance += getLightProbeIrradiance( lightProbe, geometryNormal );
+      #elif THREE_VRM_THREE_REVISION >= 133
+        irradiance += getLightProbeIrradiance( lightProbe, geometry.normal );
+      #else
+        irradiance += getLightProbeIrradiance( lightProbe, geometry );
+      #endif
     #endif
 
     #if ( NUM_HEMI_LIGHTS > 0 )

--- a/packages/three-vrm-materials-mtoon/src/shaders/mtoon.frag
+++ b/packages/three-vrm-materials-mtoon/src/shaders/mtoon.frag
@@ -774,14 +774,14 @@ void main() {
 
     vec3 irradiance = getAmbientLightIrradiance( ambientLightColor );
 
-    #if defined( USE_LIGHT_PROBES )
-      #if THREE_VRM_THREE_REVISION >= 157
+    #if THREE_VRM_THREE_REVISION >= 157
+      #if defined( USE_LIGHT_PROBES )
         irradiance += getLightProbeIrradiance( lightProbe, geometryNormal );
-      #elif THREE_VRM_THREE_REVISION >= 133
-        irradiance += getLightProbeIrradiance( lightProbe, geometry.normal );
-      #else
-        irradiance += getLightProbeIrradiance( lightProbe, geometry );
       #endif
+    #elif THREE_VRM_THREE_REVISION >= 133
+      irradiance += getLightProbeIrradiance( lightProbe, geometry.normal );
+    #else
+      irradiance += getLightProbeIrradiance( lightProbe, geometry );
     #endif
 
     #if ( NUM_HEMI_LIGHTS > 0 )

--- a/packages/three-vrm-materials-mtoon/src/shaders/mtoon.frag
+++ b/packages/three-vrm-materials-mtoon/src/shaders/mtoon.frag
@@ -621,7 +621,7 @@ void main() {
     
     vec3 geometryClearcoatNormal;
 
-    #ifdef CLEARCOAT
+    #ifdef USE_CLEARCOAT
 
       geometryClearcoatNormal = clearcoatNormal;
 

--- a/packages/three-vrm-materials-mtoon/src/shaders/mtoon.frag
+++ b/packages/three-vrm-materials-mtoon/src/shaders/mtoon.frag
@@ -506,7 +506,7 @@ void main() {
 
   // non perturbed normal for clearcoat among others
 
-  vec3 geometryNormal = normal;
+  vec3 nonPerturbedNormal = normal;
 
   #ifdef OUTLINE
     normal *= -1.0;
@@ -613,6 +613,7 @@ void main() {
 
   #if THREE_VRM_THREE_REVISION >= 157
     vec3 geometryPosition = - vViewPosition;
+    vec3 geometryNormal = normal;
     vec3 geometryViewDir = ( isOrthographic ) ? vec3( 0, 0, 1 ) : normalize( vViewPosition );
     
     vec3 geometryClearcoatNormal;


### PR DESCRIPTION
## Problem
- Update to r157 in three.js causes mtoon shader error.
![CleanShot 2023-10-01 at 14 30 38](https://github.com/pixiv/three-vrm/assets/233012/d328582b-768e-4a84-a80a-ee0a24274abd)

## Changes
- Add compat code (
  See: https://github.com/mrdoob/three.js/pull/26805