### PR TITLE
fix: Fix pre-r154 incompatibility

### DIFF
--- a/packages/three-vrm-materials-mtoon/src/MToonMaterial.ts
+++ b/packages/three-vrm-materials-mtoon/src/MToonMaterial.ts
@@ -480,6 +480,15 @@ export class MToonMaterial extends THREE.ShaderMaterial {
 
       // -- compat ---------------------------------------------------------------------------------
 
+      // COMPAT: pre-r154
+      // Three.js r154 renames the shader chunk <colorspace_fragment> to <encodings_fragment>
+      if (threeRevision < 154) {
+        shader.fragmentShader = shader.fragmentShader.replace(
+          '#include <colorspace_fragment>',
+          '#include <encodings_fragment>',
+        );
+      }
+
       // COMPAT: pre-r132
       // Three.js r132 introduces new shader chunks <normal_pars_fragment> and <alphatest_pars_fragment>
       if (threeRevision < 132) {


### PR DESCRIPTION
pre-r154 says `<colorspace_fragment>` is not defined

<img width="416" alt="image" src="https://github.com/pixiv/three-vrm/assets/7824814/6e468dd0-38b7-4731-ab3f-e158dc053c32">

The change was introduced in https://github.com/pixiv/three-vrm/pull/1260, 8f0441aec569738e415291911705a92f36f3d5c1

Trivial: I just noticed that we still have several pre-r136 compats in our MToon implementation, what should we do...
