### PR TITLE
fix (three-vrm-core): Fix expressions material bind to respect alpha

### DIFF
--- a/packages/three-vrm-core/src/expressions/VRMExpressionLoaderPlugin.ts
+++ b/packages/three-vrm-core/src/expressions/VRMExpressionLoaderPlugin.ts
@@ -202,6 +202,7 @@ export class VRMExpressionLoaderPlugin implements GLTFLoaderPlugin {
                   material,
                   type: bind.type,
                   targetValue: new THREE.Color().fromArray(bind.targetValue),
+                  targetAlpha: bind.targetValue[3],
                 }),
               );
             });
@@ -394,7 +395,8 @@ export class VRMExpressionLoaderPlugin implements GLTFLoaderPlugin {
                   new VRMExpressionMaterialColorBind({
                     material,
                     type: materialColorType,
-                    targetValue: new THREE.Color(...materialValue.targetValue!.slice(0, 3)),
+                    targetValue: new THREE.Color().fromArray(materialValue.targetValue!),
+                    targetAlpha: materialValue.targetValue![3],
                   }),
                 );
 

--- a/packages/three-vrm-core/src/expressions/VRMExpressionMaterialColorBind.ts
+++ b/packages/three-vrm-core/src/expressions/VRMExpressionMaterialColorBind.ts
@@ -73,8 +73,8 @@ export class VRMExpressionMaterialColorBind implements VRMExpressionBind {
   public readonly targetAlpha: number;
 
   /**
-   * Its state.
-   * If it cannot find the target property in constructor, it will be null instead.
+   * Its binding state.
+   * If it cannot find the target property in the constructor, each property will be null instead.
    */
   private _state: BindState;
 

--- a/packages/three-vrm-core/src/expressions/VRMExpressionMaterialColorBind.ts
+++ b/packages/three-vrm-core/src/expressions/VRMExpressionMaterialColorBind.ts
@@ -30,8 +30,10 @@ export class VRMExpressionMaterialColorBind implements VRMExpressionBind {
    * The first element stands for color channels, the second element stands for the alpha channel.
    * The second element can be null if the target property doesn't exist.
    */
+  // TODO: We might want to use the `satisfies` operator once we bump TS to 4.9 or higher
+  // See: https://github.com/pixiv/three-vrm/pull/1323#discussion_r1374020035
   private static _propertyNameMapMap: {
-    [distinguisher: string]: { [type in VRMExpressionMaterialColorType]?: [string, string | null] };
+    [distinguisher: string]: { [type in VRMExpressionMaterialColorType]?: readonly [string, string | null] };
   } = {
     isMeshStandardMaterial: {
       color: ['color', 'opacity'],
@@ -204,7 +206,9 @@ export class VRMExpressionMaterialColorBind implements VRMExpressionBind {
     return { propertyName, initialValue, deltaValue };
   }
 
-  private _getPropertyNameMap(): { [type in VRMExpressionMaterialColorType]?: [string, string | null] } | null {
+  private _getPropertyNameMap():
+    | { [type in VRMExpressionMaterialColorType]?: readonly [string, string | null] }
+    | null {
     return (
       Object.entries(VRMExpressionMaterialColorBind._propertyNameMapMap).find(([distinguisher]) => {
         return (this.material as any)[distinguisher] === true;

--- a/packages/three-vrm-core/src/expressions/VRMExpressionMaterialColorBind.ts
+++ b/packages/three-vrm-core/src/expressions/VRMExpressionMaterialColorBind.ts
@@ -195,6 +195,16 @@ export class VRMExpressionMaterialColorBind implements VRMExpressionBind {
     const propertyNameMap = this._getPropertyNameMap();
     const propertyName = propertyNameMap?.[type]?.[1] ?? null;
 
+    if (propertyName == null && targetAlpha !== 1.0) {
+      console.warn(
+        `Tried to add a material alpha bind to the material ${
+          material.name ?? '(no name)'
+        }, the type ${type} but the material or the type does not support alpha.`,
+      );
+
+      return null;
+    }
+
     if (propertyName == null) {
       return null;
     }


### PR DESCRIPTION
will resolve #1301 

This PR fixes an issue that material binds of expression does not respect alpha values.

New optional property for the constructor of `VRMExpressionMaterialColorBind`: `targetAlpha`, which specifies the target alpha.

Alpha only applies to `"color"` type as spec specifies: https://github.com/vrm-c/vrm-specification/blob/master/specification/VRMC_vrm-1.0/expressions.md#materialcolorbind

Points need review:

- [ ] Is this working properly?
- [ ] Let me know if you spot any undesired breaking change
