### PR TITLE
chore: use lint-staged also for examples directories

### DIFF
--- a/packages/three-vrm-core/package.json
+++ b/packages/three-vrm-core/package.json
@@ -37,13 +37,16 @@
     "docs": "typedoc --entryPoints ./src/index.ts --out docs",
     "test": "jest",
     "lint": "eslint \"src/**/*.{ts,tsx}\"  && yarn lint-examples &&  prettier \"src/**/*.{ts,tsx}\" --check",
-    "lint-examples": "eslint \"examples/**/*.{ts,tsx,js,html}\" --rule \"padded-blocks: error\"",
-    "lint-fix": "eslint \"src/**/*.{ts,tsx}\" --fix && eslint \"examples/**/*.{ts,tsx,js,html}\" --fix &&  prettier \"src/**/*.{ts,tsx}\" --write"
+    "lint-examples": "eslint \"examples/**/*.{js,html}\" --rule \"padded-blocks: error\"",
+    "lint-fix": "eslint \"src/**/*.{ts,tsx}\" --fix && eslint \"examples/**/*.{js,html}\" --fix &&  prettier \"src/**/*.{ts,tsx}\" --write"
   },
   "lint-staged": {
     "./src/**/*.{ts,tsx}": [
       "eslint --fix",
       "prettier --write"
+    ],
+    "./examples/**/*.{js,html}": [
+      "eslint --fix --rule \"padded-blocks: error\""
     ]
   },
   "dependencies": {

--- a/packages/three-vrm-materials-hdr-emissive-multiplier/package.json
+++ b/packages/three-vrm-materials-hdr-emissive-multiplier/package.json
@@ -36,13 +36,16 @@
     "build-types": "tsc --declaration --declarationDir ./types --emitDeclarationOnly && downlevel-dts types ts3.4/types",
     "docs": "typedoc --entryPoints ./src/index.ts --out docs",
     "lint": "eslint \"src/**/*.{ts,tsx}\"  && yarn lint-examples &&  prettier \"src/**/*.{ts,tsx}\" --check",
-    "lint-examples": "eslint \"examples/**/*.{ts,tsx,js,html}\" --rule \"padded-blocks: error\"",
-    "lint-fix": "eslint \"src/**/*.{ts,tsx}\" --fix && eslint \"examples/**/*.{ts,tsx,js,html}\" --fix &&  prettier \"src/**/*.{ts,tsx}\" --write"
+    "lint-examples": "eslint \"examples/**/*.{js,html}\" --rule \"padded-blocks: error\"",
+    "lint-fix": "eslint \"src/**/*.{ts,tsx}\" --fix && eslint \"examples/**/*.{js,html}\" --fix &&  prettier \"src/**/*.{ts,tsx}\" --write"
   },
   "lint-staged": {
     "./src/**/*.{ts,tsx}": [
       "eslint --fix",
       "prettier --write"
+    ],
+    "./examples/**/*.{js,html}": [
+      "eslint --fix --rule \"padded-blocks: error\""
     ]
   },
   "dependencies": {

--- a/packages/three-vrm-materials-mtoon/package.json
+++ b/packages/three-vrm-materials-mtoon/package.json
@@ -36,13 +36,16 @@
     "build-types": "tsc --declaration --declarationDir ./types --emitDeclarationOnly && downlevel-dts types ts3.4/types",
     "docs": "typedoc --entryPoints ./src/index.ts --out docs",
     "lint": "eslint \"src/**/*.{ts,tsx}\"  && yarn lint-examples &&  prettier \"src/**/*.{ts,tsx}\" --check",
-    "lint-examples": "eslint \"examples/**/*.{ts,tsx,js,html}\" --rule \"padded-blocks: error\"",
-    "lint-fix": "eslint \"src/**/*.{ts,tsx}\" --fix && eslint \"examples/**/*.{ts,tsx,js,html}\" --fix &&  prettier \"src/**/*.{ts,tsx}\" --write"
+    "lint-examples": "eslint \"examples/**/*.{js,html}\" --rule \"padded-blocks: error\"",
+    "lint-fix": "eslint \"src/**/*.{ts,tsx}\" --fix && eslint \"examples/**/*.{js,html}\" --fix &&  prettier \"src/**/*.{ts,tsx}\" --write"
   },
   "lint-staged": {
     "./src/**/*.{ts,tsx}": [
       "eslint --fix",
       "prettier --write"
+    ],
+    "./examples/**/*.{js,html}": [
+      "eslint --fix --rule \"padded-blocks: error\""
     ]
   },
   "dependencies": {

--- a/packages/three-vrm-node-constraint/package.json
+++ b/packages/three-vrm-node-constraint/package.json
@@ -37,13 +37,16 @@
     "docs": "typedoc --entryPoints ./src/index.ts --out docs",
     "test": "jest",
     "lint": "eslint \"src/**/*.{ts,tsx}\"  && yarn lint-examples &&  prettier \"src/**/*.{ts,tsx}\" --check",
-    "lint-examples": "eslint \"examples/**/*.{ts,tsx,js,html}\" --rule \"padded-blocks: error\"",
-    "lint-fix": "eslint \"src/**/*.{ts,tsx}\" --fix && eslint \"examples/**/*.{ts,tsx,js,html}\" --fix &&  prettier \"src/**/*.{ts,tsx}\" --write"
+    "lint-examples": "eslint \"examples/**/*.{js,html}\" --rule \"padded-blocks: error\"",
+    "lint-fix": "eslint \"src/**/*.{ts,tsx}\" --fix && eslint \"examples/**/*.{js,html}\" --fix &&  prettier \"src/**/*.{ts,tsx}\" --write"
   },
   "lint-staged": {
     "./src/**/*.{ts,tsx}": [
       "eslint --fix",
       "prettier --write"
+    ],
+    "./examples/**/*.{js,html}": [
+      "eslint --fix --rule \"padded-blocks: error\""
     ]
   },
   "dependencies": {

--- a/packages/three-vrm-springbone/package.json
+++ b/packages/three-vrm-springbone/package.json
@@ -37,13 +37,16 @@
     "docs": "typedoc --entryPoints ./src/index.ts --out docs",
     "test": "jest",
     "lint": "eslint \"src/**/*.{ts,tsx}\"  && yarn lint-examples &&  prettier \"src/**/*.{ts,tsx}\" --check",
-    "lint-examples": "eslint \"examples/**/*.{ts,tsx,js,html}\" --rule \"padded-blocks: error\"",
-    "lint-fix": "eslint \"src/**/*.{ts,tsx}\" --fix && eslint \"examples/**/*.{ts,tsx,js,html}\" --fix &&  prettier \"src/**/*.{ts,tsx}\" --write"
+    "lint-examples": "eslint \"examples/**/*.{js,html}\" --rule \"padded-blocks: error\"",
+    "lint-fix": "eslint \"src/**/*.{ts,tsx}\" --fix && eslint \"examples/**/*.{js,html}\" --fix &&  prettier \"src/**/*.{ts,tsx}\" --write"
   },
   "lint-staged": {
     "./src/**/*.{ts,tsx}": [
       "eslint --fix",
       "prettier --write"
+    ],
+    "./examples/**/*.{js,html}": [
+      "eslint --fix --rule \"padded-blocks: error\""
     ]
   },
   "dependencies": {

--- a/packages/three-vrm/package.json
+++ b/packages/three-vrm/package.json
@@ -37,13 +37,16 @@
     "docs": "typedoc --entryPoints ./src/index.ts --out docs",
     "test": "echo There is no test for three-vrm",
     "lint": "eslint \"src/**/*.{ts,tsx}\"  && yarn lint-examples &&  prettier \"src/**/*.{ts,tsx}\" --check",
-    "lint-examples": "eslint \"examples/**/*.{ts,tsx,js,html}\" --rule \"padded-blocks: error\"",
-    "lint-fix": "eslint \"src/**/*.{ts,tsx}\" --fix && eslint \"examples/**/*.{ts,tsx,js,html}\" --fix &&  prettier \"src/**/*.{ts,tsx}\" --write"
+    "lint-examples": "eslint \"examples/**/*.{js,html}\" --rule \"padded-blocks: error\"",
+    "lint-fix": "eslint \"src/**/*.{ts,tsx}\" --fix && eslint \"examples/**/*.{js,html}\" --fix &&  prettier \"src/**/*.{ts,tsx}\" --write"
   },
   "lint-staged": {
     "./src/**/*.{ts,tsx}": [
       "eslint --fix",
       "prettier --write"
+    ],
+    "./examples/**/*.{js,html}": [
+      "eslint --fix --rule \"padded-blocks: error\""
     ]
   },
   "dependencies": {


### PR DESCRIPTION
Sequel of #1332

This PR make it use lint-staged also for examples directories.

for examples directory, ts and tsx are not needed to be checked, removed them