### PR TITLE
fix: Fix the issue that hips translation goes infinity

### DIFF
--- a/packages/three-vrm-animation/src/VRMAnimationLoaderPlugin.ts
+++ b/packages/three-vrm-animation/src/VRMAnimationLoaderPlugin.ts
@@ -59,9 +59,7 @@ export class VRMAnimationLoaderPlugin implements GLTFLoaderPlugin {
     const hips = hipsNode != null ? ((await gltf.parser.getDependency('node', hipsNode)) as THREE.Object3D) : null;
 
     const restHipsPosition = new THREE.Vector3();
-    if (restHipsPosition != null) {
-      hips?.getWorldPosition(new THREE.Vector3());
-    }
+    hips?.getWorldPosition(restHipsPosition);
 
     const clips = gltf.animations;
     const animations: VRMAnimation[] = clips.map((clip, iAnimation) => {


### PR DESCRIPTION
Fix the issue that hips translation goes infinity.

The `restHipsPosition` was always set to `Vector3(0, 0, 0)` which is pretty wrong.

I was probably quite sleepy when working on the restHipsPosition procedure last time

See: https://github.com/pixiv/three-vrm/commit/c11d6e9de74b1621292c5250cae7ae98cf26524a
