### PR TITLE
deps: Bump three to r160

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Code like this:
 <script type="importmap">
   {
     "imports": {
-      "three": "https://unpkg.com/three@0.154.0/build/three.module.js",
-      "three/addons/": "https://unpkg.com/three@0.154.0/examples/jsm/",
+      "three": "https://unpkg.com/three@0.160.0/build/three.module.js",
+      "three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
       "@pixiv/three-vrm": "three-vrm.module.js"
     }
   }

--- a/packages/three-vrm-core/examples/expressions.html
+++ b/packages/three-vrm-core/examples/expressions.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.154.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.154.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
 					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/examples/expressions.html
+++ b/packages/three-vrm-core/examples/expressions.html
@@ -59,7 +59,7 @@
 			const scene = new THREE.Scene();
 
 			// light
-			const light = new THREE.DirectionalLight( 0xffffff );
+			const light = new THREE.DirectionalLight( 0xffffff, Math.PI );
 			light.position.set( 1.0, 1.0, 1.0 ).normalize();
 			scene.add( light );
 

--- a/packages/three-vrm-core/examples/firstPerson.html
+++ b/packages/three-vrm-core/examples/firstPerson.html
@@ -32,8 +32,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.154.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.154.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
 					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/examples/firstPerson.html
+++ b/packages/three-vrm-core/examples/firstPerson.html
@@ -65,7 +65,7 @@
 			const scene = new THREE.Scene();
 
 			// light
-			const light = new THREE.DirectionalLight( 0xffffff );
+			const light = new THREE.DirectionalLight( 0xffffff, Math.PI );
 			light.position.set( 1.0, 1.0, 1.0 ).normalize();
 			scene.add( light );
 

--- a/packages/three-vrm-core/examples/humanoid.html
+++ b/packages/three-vrm-core/examples/humanoid.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.154.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.154.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
 					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/examples/humanoid.html
+++ b/packages/three-vrm-core/examples/humanoid.html
@@ -59,7 +59,7 @@
 			const scene = new THREE.Scene();
 
 			// light
-			const light = new THREE.DirectionalLight( 0xffffff );
+			const light = new THREE.DirectionalLight( 0xffffff, Math.PI );
 			light.position.set( 1.0, 1.0, 1.0 ).normalize();
 			scene.add( light );
 

--- a/packages/three-vrm-core/examples/humanoidAnimation/index.html
+++ b/packages/three-vrm-core/examples/humanoidAnimation/index.html
@@ -38,8 +38,8 @@
 			{
 				"imports": {
 					"fflate": "https://unpkg.com/fflate@0.7.4/esm/browser.js",
-					"three": "https://unpkg.com/three@0.154.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.154.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
 					"@pixiv/three-vrm-core": "../../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/examples/humanoidAnimation/main.js
+++ b/packages/three-vrm-core/examples/humanoidAnimation/main.js
@@ -25,7 +25,7 @@ controls.update();
 const scene = new THREE.Scene();
 
 // light
-const light = new THREE.DirectionalLight( 0xffffff );
+const light = new THREE.DirectionalLight( 0xffffff, Math.PI );
 light.position.set( 1.0, 1.0, 1.0 ).normalize();
 scene.add( light );
 

--- a/packages/three-vrm-core/examples/lookAt.html
+++ b/packages/three-vrm-core/examples/lookAt.html
@@ -32,8 +32,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.154.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.154.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
 					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/examples/lookAt.html
+++ b/packages/three-vrm-core/examples/lookAt.html
@@ -65,7 +65,7 @@
 			const scene = new THREE.Scene();
 
 			// light
-			const light = new THREE.DirectionalLight( 0xffffff );
+			const light = new THREE.DirectionalLight( 0xffffff, Math.PI );
 			light.position.set( 1.0, 1.0, 1.0 ).normalize();
 			scene.add( light );
 

--- a/packages/three-vrm-core/examples/meta.html
+++ b/packages/three-vrm-core/examples/meta.html
@@ -39,8 +39,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.154.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.154.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
 					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/examples/meta.html
+++ b/packages/three-vrm-core/examples/meta.html
@@ -72,7 +72,7 @@
 			const scene = new THREE.Scene();
 
 			// light
-			const light = new THREE.DirectionalLight( 0xffffff );
+			const light = new THREE.DirectionalLight( 0xffffff, Math.PI );
 			light.position.set( 1.0, 1.0, 1.0 ).normalize();
 			scene.add( light );
 

--- a/packages/three-vrm-core/package.json
+++ b/packages/three-vrm-core/package.json
@@ -54,11 +54,11 @@
     "@pixiv/types-vrmc-vrm-1.0": "2.0.7"
   },
   "devDependencies": {
-    "@types/three": "^0.154.0",
-    "three": "^0.154.0"
+    "@types/three": "^0.160.0",
+    "three": "^0.160.0"
   },
   "peerDependencies": {
-    "@types/three": "^0.154.0",
-    "three": "^0.154.0"
+    "@types/three": "^0.160.0",
+    "three": "^0.160.0"
   }
 }

--- a/packages/three-vrm-materials-hdr-emissive-multiplier/examples/loader-plugin.html
+++ b/packages/three-vrm-materials-hdr-emissive-multiplier/examples/loader-plugin.html
@@ -59,7 +59,7 @@
 			const scene = new THREE.Scene();
 
 			// light
-			const light = new THREE.DirectionalLight( 0xffffff );
+			const light = new THREE.DirectionalLight( 0xffffff, Math.PI );
 			scene.add( light );
 
 			// gltf and vrm

--- a/packages/three-vrm-materials-hdr-emissive-multiplier/examples/loader-plugin.html
+++ b/packages/three-vrm-materials-hdr-emissive-multiplier/examples/loader-plugin.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.154.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.154.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
 					"@pixiv/three-vrm-materials-hdr-emissive-multiplier": "../lib/three-vrm-materials-hdr-emissive-multiplier.module.js"
 				}
 			}

--- a/packages/three-vrm-materials-hdr-emissive-multiplier/package.json
+++ b/packages/three-vrm-materials-hdr-emissive-multiplier/package.json
@@ -52,11 +52,11 @@
     "@pixiv/types-vrmc-materials-hdr-emissive-multiplier-1.0": "2.0.7"
   },
   "devDependencies": {
-    "@types/three": "^0.154.0",
-    "three": "^0.154.0"
+    "@types/three": "^0.160.0",
+    "three": "^0.160.0"
   },
   "peerDependencies": {
-    "@types/three": "^0.154.0",
-    "three": "^0.154.0"
+    "@types/three": "^0.160.0",
+    "three": "^0.160.0"
   }
 }

--- a/packages/three-vrm-materials-mtoon/examples/emissive-strength.html
+++ b/packages/three-vrm-materials-mtoon/examples/emissive-strength.html
@@ -62,7 +62,7 @@
 			const scene = new THREE.Scene();
 
 			// light
-			const light = new THREE.DirectionalLight( 0xffffff );
+			const light = new THREE.DirectionalLight( 0xffffff, Math.PI );
 			scene.add( light );
 
 			// gltf and vrm

--- a/packages/three-vrm-materials-mtoon/examples/emissive-strength.html
+++ b/packages/three-vrm-materials-mtoon/examples/emissive-strength.html
@@ -24,8 +24,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.154.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.154.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
 					"@pixiv/three-vrm-materials-mtoon": "../lib/three-vrm-materials-mtoon.module.js"
 				}
 			}

--- a/packages/three-vrm-materials-mtoon/examples/feature-test.html
+++ b/packages/three-vrm-materials-mtoon/examples/feature-test.html
@@ -58,7 +58,7 @@
 			const scene = new THREE.Scene();
 
 			// light
-			const light = new THREE.DirectionalLight( 0xffffff );
+			const light = new THREE.DirectionalLight( 0xffffff, Math.PI );
 			scene.add( light );
 
 			// test objects

--- a/packages/three-vrm-materials-mtoon/examples/feature-test.html
+++ b/packages/three-vrm-materials-mtoon/examples/feature-test.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.154.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.154.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
 					"@pixiv/three-vrm-materials-mtoon": "../lib/three-vrm-materials-mtoon.module.js"
 				}
 			}

--- a/packages/three-vrm-materials-mtoon/examples/loader-plugin.html
+++ b/packages/three-vrm-materials-mtoon/examples/loader-plugin.html
@@ -59,7 +59,7 @@
 			const scene = new THREE.Scene();
 
 			// light
-			const light = new THREE.DirectionalLight( 0xffffff );
+			const light = new THREE.DirectionalLight( 0xffffff, Math.PI );
 			scene.add( light );
 
 			// gltf and vrm

--- a/packages/three-vrm-materials-mtoon/examples/loader-plugin.html
+++ b/packages/three-vrm-materials-mtoon/examples/loader-plugin.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.154.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.154.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
 					"@pixiv/three-vrm-materials-mtoon": "../lib/three-vrm-materials-mtoon.module.js"
 				}
 			}

--- a/packages/three-vrm-materials-mtoon/package.json
+++ b/packages/three-vrm-materials-mtoon/package.json
@@ -53,11 +53,11 @@
     "@pixiv/types-vrmc-materials-mtoon-1.0": "2.0.7"
   },
   "devDependencies": {
-    "@types/three": "^0.154.0",
-    "three": "^0.154.0"
+    "@types/three": "^0.160.0",
+    "three": "^0.160.0"
   },
   "peerDependencies": {
-    "@types/three": "^0.154.0",
-    "three": "^0.154.0"
+    "@types/three": "^0.160.0",
+    "three": "^0.160.0"
   }
 }

--- a/packages/three-vrm-materials-mtoon/src/MToonMaterial.ts
+++ b/packages/three-vrm-materials-mtoon/src/MToonMaterial.ts
@@ -445,8 +445,8 @@ export class MToonMaterial extends THREE.ShaderMaterial {
         uvAnimationScrollYOffset: { value: 0.0 },
         uvAnimationRotationPhase: { value: 0.0 },
       },
-      parameters.uniforms,
-    ]);
+      parameters.uniforms ?? {},
+    ]) as any;
 
     // == finally compile the shader program =======================================================
     this.setValues(parameters);

--- a/packages/three-vrm-materials-mtoon/src/shaders/mtoon.frag
+++ b/packages/three-vrm-materials-mtoon/src/shaders/mtoon.frag
@@ -170,16 +170,11 @@ vec3 getDiffuse(
   return col;
 }
 
+// COMPAT: pre-r156 uses a struct GeometricContext
 #if THREE_VRM_THREE_REVISION >= 157
   void RE_Direct_MToon( const in IncidentLight directLight, const in vec3 geometryPosition, const in vec3 geometryNormal, const in vec3 geometryViewDir, const in vec3 geometryClearcoatNormal, const in MToonMaterial material, const in float shadow, inout ReflectedLight reflectedLight ) {
     float dotNL = clamp( dot( geometryNormal, directLight.direction ), -1.0, 1.0 );
     vec3 irradiance = directLight.color;
-
-    #if THREE_VRM_THREE_REVISION < 132
-      #ifndef PHYSICALLY_CORRECT_LIGHTS
-        irradiance *= PI;
-      #endif
-    #endif
 
     // directSpecular will be used for rim lighting, not an actual specular
     reflectedLight.directSpecular += irradiance;
@@ -611,11 +606,12 @@ void main() {
   // Since we want to take shadows into account of shading instead of irradiance,
   // we had to modify the codes that multiplies the results of shadowmap into color of direct lights.
 
+  // COMPAT: pre-r156 uses a struct GeometricContext
   #if THREE_VRM_THREE_REVISION >= 157
     vec3 geometryPosition = - vViewPosition;
     vec3 geometryNormal = normal;
     vec3 geometryViewDir = ( isOrthographic ) ? vec3( 0, 0, 1 ) : normalize( vViewPosition );
-    
+
     vec3 geometryClearcoatNormal;
 
     #ifdef USE_CLEARCOAT
@@ -654,6 +650,7 @@ void main() {
 
       pointLight = pointLights[ i ];
 
+      // COMPAT: pre-r156 uses a struct GeometricContext
       #if THREE_VRM_THREE_REVISION >= 157
         getPointLightInfo( pointLight, geometryPosition, directLight );
       #elif THREE_VRM_THREE_REVISION >= 132
@@ -668,6 +665,7 @@ void main() {
       shadow = all( bvec2( directLight.visible, receiveShadow ) ) ? getPointShadow( pointShadowMap[ i ], pointLightShadow.shadowMapSize, pointLightShadow.shadowBias, pointLightShadow.shadowRadius, vPointShadowCoord[ i ], pointLightShadow.shadowCameraNear, pointLightShadow.shadowCameraFar ) : 1.0;
       #endif
 
+      // COMPAT: pre-r156 uses a struct GeometricContext
       #if THREE_VRM_THREE_REVISION >= 157
         RE_Direct( directLight, geometryPosition, geometryNormal, geometryViewDir, geometryClearcoatNormal, material, shadow, reflectedLight );
       #else
@@ -691,6 +689,7 @@ void main() {
 
       spotLight = spotLights[ i ];
 
+      // COMPAT: pre-r156 uses a struct GeometricContext
       #if THREE_VRM_THREE_REVISION >= 157
         getSpotLightInfo( spotLight, geometryPosition, directLight );
       #elif THREE_VRM_THREE_REVISION >= 132
@@ -705,6 +704,7 @@ void main() {
       shadow = all( bvec2( directLight.visible, receiveShadow ) ) ? getShadow( spotShadowMap[ i ], spotLightShadow.shadowMapSize, spotLightShadow.shadowBias, spotLightShadow.shadowRadius, vSpotShadowCoord[ i ] ) : 1.0;
       #endif
 
+      // COMPAT: pre-r156 uses a struct GeometricContext
       #if THREE_VRM_THREE_REVISION >= 157
         RE_Direct( directLight, geometryPosition, geometryNormal, geometryViewDir, geometryClearcoatNormal, material, shadow, reflectedLight );
       #else
@@ -728,6 +728,7 @@ void main() {
 
       directionalLight = directionalLights[ i ];
 
+      // COMPAT: pre-r156 uses a struct GeometricContext
       #if THREE_VRM_THREE_REVISION >= 157
         getDirectionalLightInfo( directionalLight, directLight );
       #elif THREE_VRM_THREE_REVISION >= 132
@@ -742,6 +743,7 @@ void main() {
       shadow = all( bvec2( directLight.visible, receiveShadow ) ) ? getShadow( directionalShadowMap[ i ], directionalLightShadow.shadowMapSize, directionalLightShadow.shadowBias, directionalLightShadow.shadowRadius, vDirectionalShadowCoord[ i ] ) : 1.0;
       #endif
 
+      // COMPAT: pre-r156 uses a struct GeometricContext
       #if THREE_VRM_THREE_REVISION >= 157
         RE_Direct( directLight, geometryPosition, geometryNormal, geometryViewDir, geometryClearcoatNormal, material, shadow, reflectedLight );
       #else
@@ -774,6 +776,8 @@ void main() {
 
     vec3 irradiance = getAmbientLightIrradiance( ambientLightColor );
 
+    // COMPAT: pre-r156 uses a struct GeometricContext
+    // COMPAT: pre-r156 doesn't have a define USE_LIGHT_PROBES
     #if THREE_VRM_THREE_REVISION >= 157
       #if defined( USE_LIGHT_PROBES )
         irradiance += getLightProbeIrradiance( lightProbe, geometryNormal );
@@ -789,6 +793,7 @@ void main() {
       #pragma unroll_loop_start
       for ( int i = 0; i < NUM_HEMI_LIGHTS; i ++ ) {
 
+        // COMPAT: pre-r156 uses a struct GeometricContext
         #if THREE_VRM_THREE_REVISION >= 157
           irradiance += getHemisphereLightIrradiance( hemisphereLights[ i ], geometryNormal );
         #elif THREE_VRM_THREE_REVISION >= 133

--- a/packages/three-vrm-materials-v0compat/package.json
+++ b/packages/three-vrm-materials-v0compat/package.json
@@ -49,11 +49,11 @@
     "@pixiv/types-vrmc-materials-mtoon-1.0": "2.0.7"
   },
   "devDependencies": {
-    "@types/three": "^0.154.0",
-    "three": "^0.154.0"
+    "@types/three": "^0.160.0",
+    "three": "^0.160.0"
   },
   "peerDependencies": {
-    "@types/three": "^0.154.0",
-    "three": "^0.154.0"
+    "@types/three": "^0.160.0",
+    "three": "^0.160.0"
   }
 }

--- a/packages/three-vrm-node-constraint/examples/aim.html
+++ b/packages/three-vrm-node-constraint/examples/aim.html
@@ -93,7 +93,7 @@
 			const scene = new THREE.Scene();
 
 			// light
-			const light = new THREE.DirectionalLight( 0xffffff );
+			const light = new THREE.DirectionalLight( 0xffffff, Math.PI );
 			light.position.set( 1.0, 2.0, 3.0 ).normalize();
 			scene.add( light );
 

--- a/packages/three-vrm-node-constraint/examples/aim.html
+++ b/packages/three-vrm-node-constraint/examples/aim.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-					"three": "https://unpkg.com/three@0.154.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.154.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
 					"tweakpane": "https://unpkg.com/tweakpane@3.0",
 					"tweakpane-plugin-rotation": "https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1",
 					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"

--- a/packages/three-vrm-node-constraint/examples/importer.html
+++ b/packages/three-vrm-node-constraint/examples/importer.html
@@ -77,7 +77,7 @@
 			const scene = new THREE.Scene();
 
 			// light
-			const light = new THREE.DirectionalLight( 0xffffff );
+			const light = new THREE.DirectionalLight( 0xffffff, Math.PI );
 			light.position.set( 1.0, 2.0, 3.0 ).normalize();
 			scene.add( light );
 

--- a/packages/three-vrm-node-constraint/examples/importer.html
+++ b/packages/three-vrm-node-constraint/examples/importer.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-					"three": "https://unpkg.com/three@0.154.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.154.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
 					"tweakpane": "https://unpkg.com/tweakpane@3.0",
 					"tweakpane-plugin-rotation": "https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1",
 					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"

--- a/packages/three-vrm-node-constraint/examples/roll.html
+++ b/packages/three-vrm-node-constraint/examples/roll.html
@@ -94,7 +94,7 @@
 			const scene = new THREE.Scene();
 
 			// light
-			const light = new THREE.DirectionalLight( 0xffffff );
+			const light = new THREE.DirectionalLight( 0xffffff, Math.PI );
 			light.position.set( 1.0, 2.0, 3.0 ).normalize();
 			scene.add( light );
 

--- a/packages/three-vrm-node-constraint/examples/roll.html
+++ b/packages/three-vrm-node-constraint/examples/roll.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-					"three": "https://unpkg.com/three@0.154.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.154.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
 					"tweakpane": "https://unpkg.com/tweakpane@3.0",
 					"tweakpane-plugin-rotation": "https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1",
 					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"

--- a/packages/three-vrm-node-constraint/examples/rotation.html
+++ b/packages/three-vrm-node-constraint/examples/rotation.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-					"three": "https://unpkg.com/three@0.154.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.154.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
 					"tweakpane": "https://unpkg.com/tweakpane@3.0",
 					"tweakpane-plugin-rotation": "https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1",
 					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"

--- a/packages/three-vrm-node-constraint/examples/rotation.html
+++ b/packages/three-vrm-node-constraint/examples/rotation.html
@@ -84,7 +84,7 @@
 			const scene = new THREE.Scene();
 
 			// light
-			const light = new THREE.DirectionalLight( 0xffffff );
+			const light = new THREE.DirectionalLight( 0xffffff, Math.PI );
 			light.position.set( 1.0, 2.0, 3.0 ).normalize();
 			scene.add( light );
 

--- a/packages/three-vrm-node-constraint/examples/upper-arm.html
+++ b/packages/three-vrm-node-constraint/examples/upper-arm.html
@@ -85,7 +85,7 @@
 			const scene = new THREE.Scene();
 
 			// light
-			const light = new THREE.DirectionalLight( 0xffffff );
+			const light = new THREE.DirectionalLight( 0xffffff, Math.PI );
 			light.position.set( 1.0, 2.0, 3.0 ).normalize();
 			scene.add( light );
 

--- a/packages/three-vrm-node-constraint/examples/upper-arm.html
+++ b/packages/three-vrm-node-constraint/examples/upper-arm.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-					"three": "https://unpkg.com/three@0.154.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.154.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
 					"tweakpane": "https://unpkg.com/tweakpane@3.0",
 					"tweakpane-plugin-rotation": "https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1",
 					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"

--- a/packages/three-vrm-node-constraint/package.json
+++ b/packages/three-vrm-node-constraint/package.json
@@ -53,11 +53,11 @@
     "@pixiv/types-vrmc-node-constraint-1.0": "2.0.7"
   },
   "devDependencies": {
-    "@types/three": "^0.154.0",
-    "three": "^0.154.0"
+    "@types/three": "^0.160.0",
+    "three": "^0.160.0"
   },
   "peerDependencies": {
-    "@types/three": "^0.154.0",
-    "three": "^0.154.0"
+    "@types/three": "^0.160.0",
+    "three": "^0.160.0"
   }
 }

--- a/packages/three-vrm-node-constraint/src/VRMAimConstraint.ts
+++ b/packages/three-vrm-node-constraint/src/VRMAimConstraint.ts
@@ -51,7 +51,7 @@ export class VRMAimConstraint extends VRMNodeConstraint {
    */
   private _dstRestQuat: THREE.Quaternion;
 
-  public get dependencies(): Set<THREE.Object3D<THREE.Event>> {
+  public get dependencies(): Set<THREE.Object3D> {
     const set = new Set<THREE.Object3D>([this.source]);
 
     if (this.destination.parent) {

--- a/packages/three-vrm-node-constraint/src/VRMRollConstraint.ts
+++ b/packages/three-vrm-node-constraint/src/VRMRollConstraint.ts
@@ -52,7 +52,7 @@ export class VRMRollConstraint extends VRMNodeConstraint {
    */
   private _invSrcRestQuatMulDstRestQuat: THREE.Quaternion;
 
-  public get dependencies(): Set<THREE.Object3D<THREE.Event>> {
+  public get dependencies(): Set<THREE.Object3D> {
     return new Set([this.source]);
   }
 

--- a/packages/three-vrm-node-constraint/src/VRMRotationConstraint.ts
+++ b/packages/three-vrm-node-constraint/src/VRMRotationConstraint.ts
@@ -21,7 +21,7 @@ export class VRMRotationConstraint extends VRMNodeConstraint {
    */
   private _invSrcRestQuat: THREE.Quaternion;
 
-  public get dependencies(): Set<THREE.Object3D<THREE.Event>> {
+  public get dependencies(): Set<THREE.Object3D> {
     return new Set([this.source]);
   }
 

--- a/packages/three-vrm-node-constraint/src/tests/VRMMockedConstraint.ts
+++ b/packages/three-vrm-node-constraint/src/tests/VRMMockedConstraint.ts
@@ -2,7 +2,7 @@ import * as THREE from 'three';
 import { VRMNodeConstraint } from '../VRMNodeConstraint';
 
 export class VRMMockedConstraint extends VRMNodeConstraint {
-  public dependencies: Set<THREE.Object3D<THREE.Event>>;
+  public dependencies: Set<THREE.Object3D>;
 
   public onSetInitState?: () => void;
   public onUpdate?: () => void;

--- a/packages/three-vrm-springbone/examples/collider.html
+++ b/packages/three-vrm-springbone/examples/collider.html
@@ -62,7 +62,7 @@
 			const scene = new THREE.Scene();
 
 			// light
-			const light = new THREE.DirectionalLight( 0xffffff );
+			const light = new THREE.DirectionalLight( 0xffffff, Math.PI );
 			light.position.set( 1.0, 2.0, 3.0 ).normalize();
 			scene.add( light );
 

--- a/packages/three-vrm-springbone/examples/collider.html
+++ b/packages/three-vrm-springbone/examples/collider.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-				"three": "https://unpkg.com/three@0.154.0/build/three.module.js",
-				"three/addons/": "https://unpkg.com/three@0.154.0/examples/jsm/",
+				"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
+				"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
 				"@pixiv/three-vrm-springbone": "../lib/three-vrm-springbone.module.js"
 			  }
 			}

--- a/packages/three-vrm-springbone/examples/loader-plugin.html
+++ b/packages/three-vrm-springbone/examples/loader-plugin.html
@@ -55,7 +55,7 @@
 			const scene = new THREE.Scene();
 
 			// light
-			const light = new THREE.DirectionalLight( 0xffffff );
+			const light = new THREE.DirectionalLight( 0xffffff, Math.PI );
 			light.position.set( 1.0, 1.0, 1.0 ).normalize();
 			scene.add( light );
 

--- a/packages/three-vrm-springbone/examples/loader-plugin.html
+++ b/packages/three-vrm-springbone/examples/loader-plugin.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-				"three": "https://unpkg.com/three@0.154.0/build/three.module.js",
-				"three/addons/": "https://unpkg.com/three@0.154.0/examples/jsm/",
+				"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
+				"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
 				"@pixiv/three-vrm-springbone": "../lib/three-vrm-springbone.module.js"
 			  }
 			}

--- a/packages/three-vrm-springbone/examples/multiple.html
+++ b/packages/three-vrm-springbone/examples/multiple.html
@@ -54,7 +54,7 @@
 			const scene = new THREE.Scene();
 
 			// light
-			const light = new THREE.DirectionalLight( 0xffffff );
+			const light = new THREE.DirectionalLight( 0xffffff, Math.PI );
 			light.position.set( 1.0, 2.0, 3.0 ).normalize();
 			scene.add( light );
 

--- a/packages/three-vrm-springbone/examples/multiple.html
+++ b/packages/three-vrm-springbone/examples/multiple.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-				"three": "https://unpkg.com/three@0.154.0/build/three.module.js",
-				"three/addons/": "https://unpkg.com/three@0.154.0/examples/jsm/",
+				"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
+				"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
 				"@pixiv/three-vrm-springbone": "../lib/three-vrm-springbone.module.js"
 			  }
 			}

--- a/packages/three-vrm-springbone/examples/single.html
+++ b/packages/three-vrm-springbone/examples/single.html
@@ -54,7 +54,7 @@
 			const scene = new THREE.Scene();
 
 			// light
-			const light = new THREE.DirectionalLight( 0xffffff );
+			const light = new THREE.DirectionalLight( 0xffffff, Math.PI );
 			light.position.set( 1.0, 2.0, 3.0 ).normalize();
 			scene.add( light );
 

--- a/packages/three-vrm-springbone/examples/single.html
+++ b/packages/three-vrm-springbone/examples/single.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-				"three": "https://unpkg.com/three@0.154.0/build/three.module.js",
-				"three/addons/": "https://unpkg.com/three@0.154.0/examples/jsm/",
+				"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
+				"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
 				"@pixiv/three-vrm-springbone": "../lib/three-vrm-springbone.module.js"
 			  }
 			}

--- a/packages/three-vrm-springbone/package.json
+++ b/packages/three-vrm-springbone/package.json
@@ -54,9 +54,9 @@
     "@pixiv/types-vrmc-springbone-1.0": "2.0.7"
   },
   "devDependencies": {
-    "three": "^0.154.0"
+    "three": "^0.160.0"
   },
   "peerDependencies": {
-    "three": "^0.154.0"
+    "three": "^0.160.0"
   }
 }

--- a/packages/three-vrm/README.md
+++ b/packages/three-vrm/README.md
@@ -46,8 +46,8 @@ Code like this:
 <script type="importmap">
   {
     "imports": {
-      "three": "https://unpkg.com/three@0.154.0/build/three.module.js",
-      "three/addons/": "https://unpkg.com/three@0.154.0/examples/jsm/",
+      "three": "https://unpkg.com/three@0.160.0/build/three.module.js",
+      "three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
       "@pixiv/three-vrm": "three-vrm.module.js"
     }
   }

--- a/packages/three-vrm/examples/animations.html
+++ b/packages/three-vrm/examples/animations.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.154.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.154.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/animations.html
+++ b/packages/three-vrm/examples/animations.html
@@ -59,7 +59,7 @@
 			const scene = new THREE.Scene();
 
 			// light
-			const light = new THREE.DirectionalLight( 0xffffff );
+			const light = new THREE.DirectionalLight( 0xffffff, Math.PI );
 			light.position.set( 1.0, 1.0, 1.0 ).normalize();
 			scene.add( light );
 

--- a/packages/three-vrm/examples/basic.html
+++ b/packages/three-vrm/examples/basic.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.154.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.154.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/basic.html
+++ b/packages/three-vrm/examples/basic.html
@@ -59,7 +59,7 @@
 			const scene = new THREE.Scene();
 
 			// light
-			const light = new THREE.DirectionalLight( 0xffffff );
+			const light = new THREE.DirectionalLight( 0xffffff, Math.PI );
 			light.position.set( 1.0, 1.0, 1.0 ).normalize();
 			scene.add( light );
 

--- a/packages/three-vrm/examples/bones.html
+++ b/packages/three-vrm/examples/bones.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.154.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.154.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/bones.html
+++ b/packages/three-vrm/examples/bones.html
@@ -59,7 +59,7 @@
 			const scene = new THREE.Scene();
 
 			// light
-			const light = new THREE.DirectionalLight( 0xffffff );
+			const light = new THREE.DirectionalLight( 0xffffff, Math.PI );
 			light.position.set( 1.0, 1.0, 1.0 ).normalize();
 			scene.add( light );
 

--- a/packages/three-vrm/examples/debug.html
+++ b/packages/three-vrm/examples/debug.html
@@ -64,7 +64,7 @@
 			scene.add( helperRoot );
 
 			// light
-			const light = new THREE.DirectionalLight( 0xffffff );
+			const light = new THREE.DirectionalLight( 0xffffff, Math.PI );
 			light.position.set( 1.0, 1.0, 1.0 ).normalize();
 			scene.add( light );
 

--- a/packages/three-vrm/examples/debug.html
+++ b/packages/three-vrm/examples/debug.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.154.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.154.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/dnd.html
+++ b/packages/three-vrm/examples/dnd.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.154.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.154.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/dnd.html
+++ b/packages/three-vrm/examples/dnd.html
@@ -59,7 +59,7 @@
 			const scene = new THREE.Scene();
 
 			// light
-			const light = new THREE.DirectionalLight( 0xffffff );
+			const light = new THREE.DirectionalLight( 0xffffff, Math.PI );
 			light.position.set( 1.0, 1.0, 1.0 ).normalize();
 			scene.add( light );
 

--- a/packages/three-vrm/examples/expressions.html
+++ b/packages/three-vrm/examples/expressions.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.154.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.154.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/expressions.html
+++ b/packages/three-vrm/examples/expressions.html
@@ -59,7 +59,7 @@
 			const scene = new THREE.Scene();
 
 			// light
-			const light = new THREE.DirectionalLight( 0xffffff );
+			const light = new THREE.DirectionalLight( 0xffffff, Math.PI );
 			light.position.set( 1.0, 1.0, 1.0 ).normalize();
 			scene.add( light );
 

--- a/packages/three-vrm/examples/firstperson.html
+++ b/packages/three-vrm/examples/firstperson.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.154.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.154.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/firstperson.html
+++ b/packages/three-vrm/examples/firstperson.html
@@ -59,7 +59,7 @@
 			const scene = new THREE.Scene();
 
 			// light
-			const light = new THREE.DirectionalLight( 0xffffff );
+			const light = new THREE.DirectionalLight( 0xffffff, Math.PI );
 			light.position.set( 1.0, 1.0, 1.0 ).normalize();
 			scene.add( light );
 

--- a/packages/three-vrm/examples/humanoidAnimation/index.html
+++ b/packages/three-vrm/examples/humanoidAnimation/index.html
@@ -38,8 +38,8 @@
 			{
 				"imports": {
 					"fflate": "https://unpkg.com/fflate@0.7.4/esm/browser.js",
-					"three": "https://unpkg.com/three@0.154.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.154.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
 					"@pixiv/three-vrm": "../../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/humanoidAnimation/main.js
+++ b/packages/three-vrm/examples/humanoidAnimation/main.js
@@ -25,7 +25,7 @@ controls.update();
 const scene = new THREE.Scene();
 
 // light
-const light = new THREE.DirectionalLight( 0xffffff );
+const light = new THREE.DirectionalLight( 0xffffff, Math.PI );
 light.position.set( 1.0, 1.0, 1.0 ).normalize();
 scene.add( light );
 

--- a/packages/three-vrm/examples/lookat-advanced.html
+++ b/packages/three-vrm/examples/lookat-advanced.html
@@ -130,7 +130,7 @@
 			const scene = new THREE.Scene();
 
 			// light
-			const light = new THREE.DirectionalLight( 0xffffff );
+			const light = new THREE.DirectionalLight( 0xffffff, Math.PI );
 			light.position.set( 1.0, 1.0, 1.0 ).normalize();
 			scene.add( light );
 

--- a/packages/three-vrm/examples/lookat-advanced.html
+++ b/packages/three-vrm/examples/lookat-advanced.html
@@ -28,8 +28,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.154.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.154.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/lookat.html
+++ b/packages/three-vrm/examples/lookat.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.154.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.154.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/lookat.html
+++ b/packages/three-vrm/examples/lookat.html
@@ -59,7 +59,7 @@
 			const scene = new THREE.Scene();
 
 			// light
-			const light = new THREE.DirectionalLight( 0xffffff );
+			const light = new THREE.DirectionalLight( 0xffffff, Math.PI );
 			light.position.set( 1.0, 1.0, 1.0 ).normalize();
 			scene.add( light );
 

--- a/packages/three-vrm/examples/materials-debug.html
+++ b/packages/three-vrm/examples/materials-debug.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.154.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.154.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/materials-debug.html
+++ b/packages/three-vrm/examples/materials-debug.html
@@ -59,7 +59,7 @@
 			const scene = new THREE.Scene();
 
 			// light
-			const light = new THREE.DirectionalLight( 0xffffff );
+			const light = new THREE.DirectionalLight( 0xffffff, Math.PI );
 			light.position.set( 1.0, 1.0, 1.0 ).normalize();
 			scene.add( light );
 

--- a/packages/three-vrm/examples/meta.html
+++ b/packages/three-vrm/examples/meta.html
@@ -38,8 +38,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.154.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.154.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/meta.html
+++ b/packages/three-vrm/examples/meta.html
@@ -71,7 +71,7 @@
 			const scene = new THREE.Scene();
 
 			// light
-			const light = new THREE.DirectionalLight( 0xffffff );
+			const light = new THREE.DirectionalLight( 0xffffff, Math.PI );
 			light.position.set( 1.0, 1.0, 1.0 ).normalize();
 			scene.add( light );
 

--- a/packages/three-vrm/examples/mouse.html
+++ b/packages/three-vrm/examples/mouse.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.154.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.154.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/mouse.html
+++ b/packages/three-vrm/examples/mouse.html
@@ -54,7 +54,7 @@
 			const scene = new THREE.Scene();
 
 			// light
-			const light = new THREE.DirectionalLight( 0xffffff );
+			const light = new THREE.DirectionalLight( 0xffffff, Math.PI );
 			light.position.set( 1.0, 1.0, 1.0 ).normalize();
 			scene.add( light );
 

--- a/packages/three-vrm/package.json
+++ b/packages/three-vrm/package.json
@@ -59,11 +59,11 @@
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.0.1",
-    "@types/three": "^0.154.0",
-    "three": "^0.154.0"
+    "@types/three": "^0.160.0",
+    "three": "^0.160.0"
   },
   "peerDependencies": {
-    "@types/three": "^0.154.0",
-    "three": "^0.154.0"
+    "@types/three": "^0.160.0",
+    "three": "^0.160.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1296,11 +1296,6 @@
     "@tufjs/canonical-json" "1.0.0"
     minimatch "^9.0.0"
 
-"@tweenjs/tween.js@~18.6.4":
-  version "18.6.4"
-  resolved "https://registry.yarnpkg.com/@tweenjs/tween.js/-/tween.js-18.6.4.tgz#40a3d0a93647124872dec8e0fd1bd5926695b6ca"
-  integrity sha512-lB9lMjuqjtuJrx7/kOkqQBtllspPIN+96OvTCeJ2j5FEzinoAXTdAMFnDAQT1KVPRlnYfBrqxtqP66vDM40xxQ==
-
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.7":
   version "7.1.15"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.15.tgz#2ccfb1ad55a02c83f8e0ad327cbc332f55eb1024"
@@ -1423,16 +1418,14 @@
   resolved "https://registry.yarnpkg.com/@types/stats.js/-/stats.js-0.17.0.tgz#0ed81d48e03b590c24da85540c1d952077a9fe20"
   integrity sha512-9w+a7bR8PeB0dCT/HBULU2fMqf6BAzvKbxFboYhmDtDkKPiyXYbjoe2auwsXlEFI7CFNMF1dCv3dFH5Poy9R1w==
 
-"@types/three@^0.154.0":
-  version "0.154.0"
-  resolved "https://registry.yarnpkg.com/@types/three/-/three-0.154.0.tgz#91f4384930ed050a14d7f13c09d5785cc167a064"
-  integrity sha512-IioqpGhch6FdLDh4zazRn3rXHj6Vn2nVOziJdXVbJFi9CaI65LtP9qqUtpzbsHK2Ezlox8NtsLNHSw3AQzucjA==
+"@types/three@^0.160.0":
+  version "0.160.0"
+  resolved "https://registry.yarnpkg.com/@types/three/-/three-0.160.0.tgz#7915a97e0a14ccaa9ccbb9f190c5730b04a23075"
+  integrity sha512-jWlbUBovicUKaOYxzgkLlhkiEQJkhCVvg4W2IYD2trqD2om3VK4DGLpHH5zQHNr7RweZK/5re/4IVhbhvxbV9w==
   dependencies:
-    "@tweenjs/tween.js" "~18.6.4"
     "@types/stats.js" "*"
     "@types/webxr" "*"
-    fflate "~0.6.9"
-    lil-gui "~0.17.0"
+    fflate "~0.6.10"
     meshoptimizer "~0.18.1"
 
 "@types/webxr@*":
@@ -3354,7 +3347,7 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
-fflate@~0.6.9:
+fflate@~0.6.10:
   version "0.6.10"
   resolved "https://registry.yarnpkg.com/fflate/-/fflate-0.6.10.tgz#5f40f9659205936a2d18abf88b2e7781662b6d43"
   integrity sha512-IQrh3lEPM93wVCEczc9SaAOvkmcoQn/G8Bo1e8ZPlY3X3bnAxWaBdvTdvM1hP62iZp0BXWDy4vTAy4fF0+Dlpg==
@@ -5103,11 +5096,6 @@ libnpmpublish@7.1.4:
     semver "^7.3.7"
     sigstore "^1.4.0"
     ssri "^10.0.1"
-
-lil-gui@~0.17.0:
-  version "0.17.0"
-  resolved "https://registry.yarnpkg.com/lil-gui/-/lil-gui-0.17.0.tgz#b41ae55d0023fcd9185f7395a218db0f58189663"
-  integrity sha512-MVBHmgY+uEbmJNApAaPbtvNh1RCAeMnKym82SBjtp5rODTYKWtM+MXHCifLe2H2Ti1HuBGBtK/5SyG4ShQ3pUQ==
 
 lilconfig@3.0.0:
   version "3.0.0"
@@ -7605,10 +7593,10 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
-three@^0.154.0:
-  version "0.154.0"
-  resolved "https://registry.yarnpkg.com/three/-/three-0.154.0.tgz#dbef21e10fe6015ec283acc60d0eb58733991e27"
-  integrity sha512-Uzz8C/5GesJzv8i+Y2prEMYUwodwZySPcNhuJUdsVMH2Yn4Nm8qlbQe6qRN5fOhg55XB0WiLfTPBxVHxpE60ug==
+three@^0.160.0:
+  version "0.160.0"
+  resolved "https://registry.yarnpkg.com/three/-/three-0.160.0.tgz#cd1e4dbd01aee0719280a9086d75545db52b7a8f"
+  integrity sha512-DLU8lc0zNIPkM7rH5/e1Ks1Z8tWCGRq6g8mPowdDJpw1CFBJMU7UoJjC6PefXW7z//SSl0b2+GCw14LB+uDhng==
 
 throat@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
This PR will bump Three.js to r160.

- Since it's bumped from r154, we have to address the change regarding the legacy light.
    - Updated all examples because of this change.
    - You have to multiply the directional light intensity by PI since now the light unit is set to a physically based one by default.
- I also added several COMPAT comments on pre-156 compats addressed in #1304.

I checked that all examples are working properly.
