### PR TITLE
fix: Fix type definition of VRM Animation

### DIFF
--- a/packages/three-vrm-animation/src/VRMAnimationLoaderPlugin.ts
+++ b/packages/three-vrm-animation/src/VRMAnimationLoaderPlugin.ts
@@ -144,6 +144,10 @@ export class VRMAnimationLoaderPlugin implements GLTFLoaderPlugin {
 
     const worldMatrixMap: VRMAnimationLoaderPluginWorldMatrixMap = new Map();
 
+    if (defExtension.humanoid == null) {
+      return worldMatrixMap;
+    }
+
     for (const [boneName, humanBone] of Object.entries(defExtension.humanoid.humanBones)) {
       const node = humanBone?.node;
       if (node != null) {

--- a/packages/types-vrmc-vrm-1.0/src/HumanoidHumanBones.ts
+++ b/packages/types-vrmc-vrm-1.0/src/HumanoidHumanBones.ts
@@ -5,5 +5,5 @@ import type { HumanoidHumanBoneName } from './HumanoidHumanBoneName';
  * Represents a set of humanBones of a humanoid.
  */
 export type HumanoidHumanBones = {
-  [key in HumanoidHumanBoneName]: HumanoidHumanBone;
+  [key in HumanoidHumanBoneName]?: HumanoidHumanBone;
 };

--- a/packages/types-vrmc-vrm-animation-1.0/src/HumanoidHumanBones.ts
+++ b/packages/types-vrmc-vrm-animation-1.0/src/HumanoidHumanBones.ts
@@ -5,5 +5,5 @@ import type { HumanoidHumanBoneName } from '@pixiv/types-vrmc-vrm-1.0';
  * An object which maps humanoid bones to nodes.
  */
 export type HumanoidHumanBones = {
-  [key in HumanoidHumanBoneName]: HumanoidHumanBone;
+  [key in HumanoidHumanBoneName]?: HumanoidHumanBone;
 };

--- a/packages/types-vrmc-vrm-animation-1.0/src/VRMCVRMAnimation.ts
+++ b/packages/types-vrmc-vrm-animation-1.0/src/VRMCVRMAnimation.ts
@@ -14,7 +14,7 @@ export interface VRMCVRMAnimation {
   /**
    * An object which describes about humanoid bones.
    */
-  humanoid: Humanoid;
+  humanoid?: Humanoid;
 
   /**
    * An object which maps expressions to nodes.


### PR DESCRIPTION
Fixed type definition of `VRMC_vrm_animation`.

- Humanoid is optional
- Properties of HumanoidHumanBones are optional - Some bones are required but that would be handled in the implementation side - I also fixed the `VRMC_vrm` one

See: https://github.com/vrm-c/vrm-specification/blob/2d40293a5aa21f1a5011d7a53074056bd31cbad3/specification/VRMC_vrm_animation-1.0/schema/VRMC_vrm_animation.schema.json
See: https://github.com/vrm-c/vrm-specification/blob/2d40293a5aa21f1a5011d7a53074056bd31cbad3/specification/VRMC_vrm_animation-1.0/schema/VRMC_vrm_animation.humanoid.humanBones.schema.json