### PR TITLE
fix: Fix license year of three-vrm-animation

### DIFF
--- a/packages/three-vrm-animation/rollup.config.js
+++ b/packages/three-vrm-animation/rollup.config.js
@@ -8,7 +8,7 @@ import typescript from '@rollup/plugin-typescript';
 
 // == constants ====================================================================================
 /** copyright text */
-const copyright = '(c) 2023 pixiv Inc.';
+const copyright = '(c) 2023-2024 pixiv Inc.';
 
 /** name of the license */
 const licenseName = 'MIT License';


### PR DESCRIPTION
Fix license year of `@pixiv/three-vrm-animation` from `2023` to `2023-2024`. I simply forgot to change