### PR TITLE
fix: Fix internal dependency version from three-vrm-animation to three-vrm to latest

### DIFF
--- a/packages/three-vrm-animation/examples/dnd.html
+++ b/packages/three-vrm-animation/examples/dnd.html
@@ -28,7 +28,7 @@
 				"imports": {
 					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
 					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
-					"@pixiv/three-vrm": "https://unpkg.com/@pixiv/three-vrm@2.0.8/lib/three-vrm.module.js",
+					"@pixiv/three-vrm": "https://unpkg.com/@pixiv/three-vrm@2.1.0/lib/three-vrm.module.js",
 					"@pixiv/three-vrm-animation": "../lib/three-vrm-animation.module.js"
 				}
 			}

--- a/packages/three-vrm-animation/examples/loader-plugin.html
+++ b/packages/three-vrm-animation/examples/loader-plugin.html
@@ -28,7 +28,7 @@
 				"imports": {
 					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
 					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
-					"@pixiv/three-vrm": "https://unpkg.com/@pixiv/three-vrm@2.0.8/lib/three-vrm.module.js",
+					"@pixiv/three-vrm": "https://unpkg.com/@pixiv/three-vrm@2.1.0/lib/three-vrm.module.js",
 					"@pixiv/three-vrm-animation": "../lib/three-vrm-animation.module.js"
 				}
 			}

--- a/packages/three-vrm-animation/package.json
+++ b/packages/three-vrm-animation/package.json
@@ -47,7 +47,7 @@
   },
   "dependencies": {
     "@pixiv/three-vrm-core": "2.1.0",
-    "@pixiv/types-vrmc-vrm-1.0": "2.0.8",
+    "@pixiv/types-vrmc-vrm-1.0": "2.1.0",
     "@pixiv/types-vrmc-vrm-animation-1.0": "2.1.0"
   },
   "devDependencies": {


### PR DESCRIPTION
- Fix dependency version to `@pixiv/three-vrm` in VRMA examples
- Fix dependency version from `@pixiv/three-vrm-animation` -> `@pixiv/types-vrmc-vrm-1.0` to latest
