### PR TITLE
Bump Three.js to r162

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Code like this:
 <script type="importmap">
   {
     "imports": {
-      "three": "https://unpkg.com/three@0.160.0/build/three.module.js",
-      "three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
+      "three": "https://unpkg.com/three@0.162.0/build/three.module.js",
+      "three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
       "@pixiv/three-vrm": "three-vrm.module.js"
     }
   }

--- a/packages/three-vrm-animation/examples/dnd.html
+++ b/packages/three-vrm-animation/examples/dnd.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
 					"@pixiv/three-vrm": "https://unpkg.com/@pixiv/three-vrm@2.1.0/lib/three-vrm.module.js",
 					"@pixiv/three-vrm-animation": "../lib/three-vrm-animation.module.js"
 				}

--- a/packages/three-vrm-animation/examples/loader-plugin.html
+++ b/packages/three-vrm-animation/examples/loader-plugin.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
 					"@pixiv/three-vrm": "https://unpkg.com/@pixiv/three-vrm@2.1.0/lib/three-vrm.module.js",
 					"@pixiv/three-vrm-animation": "../lib/three-vrm-animation.module.js"
 				}

--- a/packages/three-vrm-animation/package.json
+++ b/packages/three-vrm-animation/package.json
@@ -51,12 +51,12 @@
     "@pixiv/types-vrmc-vrm-animation-1.0": "2.1.0"
   },
   "devDependencies": {
-    "@types/three": "^0.160.0",
+    "@types/three": "^0.162.0",
     "lint-staged": "13.1.2",
-    "three": "^0.160.0"
+    "three": "^0.162.0"
   },
   "peerDependencies": {
-    "@types/three": "^0.160.0",
-    "three": "^0.160.0"
+    "@types/three": "^0.162.0",
+    "three": "^0.162.0"
   }
 }

--- a/packages/three-vrm-core/examples/expressions.html
+++ b/packages/three-vrm-core/examples/expressions.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
 					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/examples/firstPerson.html
+++ b/packages/three-vrm-core/examples/firstPerson.html
@@ -32,8 +32,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
 					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/examples/humanoid.html
+++ b/packages/three-vrm-core/examples/humanoid.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
 					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/examples/humanoidAnimation/index.html
+++ b/packages/three-vrm-core/examples/humanoidAnimation/index.html
@@ -38,8 +38,8 @@
 			{
 				"imports": {
 					"fflate": "https://unpkg.com/fflate@0.7.4/esm/browser.js",
-					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
 					"@pixiv/three-vrm-core": "../../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/examples/lookAt.html
+++ b/packages/three-vrm-core/examples/lookAt.html
@@ -32,8 +32,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
 					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/examples/meta.html
+++ b/packages/three-vrm-core/examples/meta.html
@@ -39,8 +39,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
 					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/package.json
+++ b/packages/three-vrm-core/package.json
@@ -54,11 +54,11 @@
     "@pixiv/types-vrmc-vrm-1.0": "2.1.0"
   },
   "devDependencies": {
-    "@types/three": "^0.160.0",
-    "three": "^0.160.0"
+    "@types/three": "^0.162.0",
+    "three": "^0.162.0"
   },
   "peerDependencies": {
-    "@types/three": "^0.160.0",
-    "three": "^0.160.0"
+    "@types/three": "^0.162.0",
+    "three": "^0.162.0"
   }
 }

--- a/packages/three-vrm-core/src/VRMCoreLoaderPluginOptions.ts
+++ b/packages/three-vrm-core/src/VRMCoreLoaderPluginOptions.ts
@@ -1,3 +1,4 @@
+import type * as THREE from 'three';
 import { VRMExpressionLoaderPlugin } from './expressions/VRMExpressionLoaderPlugin';
 import { VRMFirstPersonLoaderPlugin } from './firstPerson/VRMFirstPersonLoaderPlugin';
 import { VRMHumanoidLoaderPlugin } from './humanoid/VRMHumanoidLoaderPlugin';

--- a/packages/three-vrm-core/src/VRMCoreParameters.ts
+++ b/packages/three-vrm-core/src/VRMCoreParameters.ts
@@ -1,3 +1,4 @@
+import type * as THREE from 'three';
 import type { VRMExpressionManager } from './expressions/VRMExpressionManager';
 import type { VRMFirstPerson } from './firstPerson/VRMFirstPerson';
 import type { VRMHumanoid } from './humanoid/VRMHumanoid';

--- a/packages/three-vrm-core/src/firstPerson/VRMFirstPersonMeshAnnotation.ts
+++ b/packages/three-vrm-core/src/firstPerson/VRMFirstPersonMeshAnnotation.ts
@@ -1,3 +1,4 @@
+import type * as THREE from 'three';
 import type { VRMFirstPersonMeshAnnotationType } from './VRMFirstPersonMeshAnnotationType';
 
 export interface VRMFirstPersonMeshAnnotation {

--- a/packages/three-vrm-core/src/humanoid/VRMHumanoidLoaderPlugin.ts
+++ b/packages/three-vrm-core/src/humanoid/VRMHumanoidLoaderPlugin.ts
@@ -1,3 +1,4 @@
+import type * as THREE from 'three';
 import type * as V0VRM from '@pixiv/types-vrm-0.0';
 import type * as V1VRMSchema from '@pixiv/types-vrmc-vrm-1.0';
 import type { GLTF, GLTFLoaderPlugin, GLTFParser } from 'three/examples/jsm/loaders/GLTFLoader.js';

--- a/packages/three-vrm-core/src/humanoid/VRMHumanoidLoaderPluginOptions.ts
+++ b/packages/three-vrm-core/src/humanoid/VRMHumanoidLoaderPluginOptions.ts
@@ -1,3 +1,4 @@
+import type * as THREE from 'three';
 export interface VRMHumanoidLoaderPluginOptions {
   /**
    * Specify an Object3D to add {@link VRMHumanoidHelper}.

--- a/packages/three-vrm-core/src/lookAt/VRMLookAtLoaderPlugin.ts
+++ b/packages/three-vrm-core/src/lookAt/VRMLookAtLoaderPlugin.ts
@@ -1,3 +1,4 @@
+import type * as THREE from 'three';
 import type * as V0VRM from '@pixiv/types-vrm-0.0';
 import type * as V1VRMSchema from '@pixiv/types-vrmc-vrm-1.0';
 import type { GLTF, GLTFLoaderPlugin, GLTFParser } from 'three/examples/jsm/loaders/GLTFLoader.js';

--- a/packages/three-vrm-core/src/lookAt/VRMLookAtLoaderPluginOptions.ts
+++ b/packages/three-vrm-core/src/lookAt/VRMLookAtLoaderPluginOptions.ts
@@ -1,3 +1,5 @@
+import type * as THREE from 'three';
+
 export interface VRMLookAtLoaderPluginOptions {
   /**
    * Specify an Object3D to add {@link VRMLookAtHelper} s.

--- a/packages/three-vrm-core/src/utils/gltfExtractPrimitivesFromNode.ts
+++ b/packages/three-vrm-core/src/utils/gltfExtractPrimitivesFromNode.ts
@@ -1,3 +1,4 @@
+import type * as THREE from 'three';
 import type { GLTF } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import { GLTF as GLTFSchema } from '@gltf-transform/core';
 

--- a/packages/three-vrm-materials-hdr-emissive-multiplier/examples/loader-plugin.html
+++ b/packages/three-vrm-materials-hdr-emissive-multiplier/examples/loader-plugin.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
 					"@pixiv/three-vrm-materials-hdr-emissive-multiplier": "../lib/three-vrm-materials-hdr-emissive-multiplier.module.js"
 				}
 			}

--- a/packages/three-vrm-materials-hdr-emissive-multiplier/package.json
+++ b/packages/three-vrm-materials-hdr-emissive-multiplier/package.json
@@ -52,11 +52,11 @@
     "@pixiv/types-vrmc-materials-hdr-emissive-multiplier-1.0": "2.1.0"
   },
   "devDependencies": {
-    "@types/three": "^0.160.0",
-    "three": "^0.160.0"
+    "@types/three": "^0.162.0",
+    "three": "^0.162.0"
   },
   "peerDependencies": {
-    "@types/three": "^0.160.0",
-    "three": "^0.160.0"
+    "@types/three": "^0.162.0",
+    "three": "^0.162.0"
   }
 }

--- a/packages/three-vrm-materials-mtoon/examples/emissive-strength.html
+++ b/packages/three-vrm-materials-mtoon/examples/emissive-strength.html
@@ -24,8 +24,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
 					"@pixiv/three-vrm-materials-mtoon": "../lib/three-vrm-materials-mtoon.module.js"
 				}
 			}

--- a/packages/three-vrm-materials-mtoon/examples/feature-test.html
+++ b/packages/three-vrm-materials-mtoon/examples/feature-test.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
 					"@pixiv/three-vrm-materials-mtoon": "../lib/three-vrm-materials-mtoon.module.js"
 				}
 			}

--- a/packages/three-vrm-materials-mtoon/examples/loader-plugin.html
+++ b/packages/three-vrm-materials-mtoon/examples/loader-plugin.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
 					"@pixiv/three-vrm-materials-mtoon": "../lib/three-vrm-materials-mtoon.module.js"
 				}
 			}

--- a/packages/three-vrm-materials-mtoon/package.json
+++ b/packages/three-vrm-materials-mtoon/package.json
@@ -53,11 +53,11 @@
     "@pixiv/types-vrmc-materials-mtoon-1.0": "2.1.0"
   },
   "devDependencies": {
-    "@types/three": "^0.160.0",
-    "three": "^0.160.0"
+    "@types/three": "^0.162.0",
+    "three": "^0.162.0"
   },
   "peerDependencies": {
-    "@types/three": "^0.160.0",
-    "three": "^0.160.0"
+    "@types/three": "^0.162.0",
+    "three": "^0.162.0"
   }
 }

--- a/packages/three-vrm-materials-mtoon/src/MToonMaterialParameters.ts
+++ b/packages/three-vrm-materials-mtoon/src/MToonMaterialParameters.ts
@@ -1,3 +1,4 @@
+import type * as THREE from 'three';
 import type { MToonMaterialDebugMode } from './MToonMaterialDebugMode';
 import type { MToonMaterialOutlineWidthMode } from './MToonMaterialOutlineWidthMode';
 

--- a/packages/three-vrm-materials-v0compat/package.json
+++ b/packages/three-vrm-materials-v0compat/package.json
@@ -49,11 +49,11 @@
     "@pixiv/types-vrmc-materials-mtoon-1.0": "2.1.0"
   },
   "devDependencies": {
-    "@types/three": "^0.160.0",
-    "three": "^0.160.0"
+    "@types/three": "^0.162.0",
+    "three": "^0.162.0"
   },
   "peerDependencies": {
-    "@types/three": "^0.160.0",
-    "three": "^0.160.0"
+    "@types/three": "^0.162.0",
+    "three": "^0.162.0"
   }
 }

--- a/packages/three-vrm-node-constraint/examples/aim.html
+++ b/packages/three-vrm-node-constraint/examples/aim.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
 					"tweakpane": "https://unpkg.com/tweakpane@3.0",
 					"tweakpane-plugin-rotation": "https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1",
 					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"

--- a/packages/three-vrm-node-constraint/examples/importer.html
+++ b/packages/three-vrm-node-constraint/examples/importer.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
 					"tweakpane": "https://unpkg.com/tweakpane@3.0",
 					"tweakpane-plugin-rotation": "https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1",
 					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"

--- a/packages/three-vrm-node-constraint/examples/roll.html
+++ b/packages/three-vrm-node-constraint/examples/roll.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
 					"tweakpane": "https://unpkg.com/tweakpane@3.0",
 					"tweakpane-plugin-rotation": "https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1",
 					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"

--- a/packages/three-vrm-node-constraint/examples/rotation.html
+++ b/packages/three-vrm-node-constraint/examples/rotation.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
 					"tweakpane": "https://unpkg.com/tweakpane@3.0",
 					"tweakpane-plugin-rotation": "https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1",
 					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"

--- a/packages/three-vrm-node-constraint/examples/upper-arm.html
+++ b/packages/three-vrm-node-constraint/examples/upper-arm.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
 					"tweakpane": "https://unpkg.com/tweakpane@3.0",
 					"tweakpane-plugin-rotation": "https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1",
 					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"

--- a/packages/three-vrm-node-constraint/package.json
+++ b/packages/three-vrm-node-constraint/package.json
@@ -53,11 +53,11 @@
     "@pixiv/types-vrmc-node-constraint-1.0": "2.1.0"
   },
   "devDependencies": {
-    "@types/three": "^0.160.0",
-    "three": "^0.160.0"
+    "@types/three": "^0.162.0",
+    "three": "^0.162.0"
   },
   "peerDependencies": {
-    "@types/three": "^0.160.0",
-    "three": "^0.160.0"
+    "@types/three": "^0.162.0",
+    "three": "^0.162.0"
   }
 }

--- a/packages/three-vrm-node-constraint/src/VRMNodeConstraintLoaderPluginOptions.ts
+++ b/packages/three-vrm-node-constraint/src/VRMNodeConstraintLoaderPluginOptions.ts
@@ -1,3 +1,5 @@
+import type * as THREE from 'three';
+
 export interface VRMNodeConstraintLoaderPluginOptions {
   /**
    * Specify an Object3D to add {@link VRMNodeConstraintHelper} s.

--- a/packages/three-vrm-springbone/examples/collider.html
+++ b/packages/three-vrm-springbone/examples/collider.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-				"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
-				"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
+				"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
+				"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
 				"@pixiv/three-vrm-springbone": "../lib/three-vrm-springbone.module.js"
 			  }
 			}

--- a/packages/three-vrm-springbone/examples/loader-plugin.html
+++ b/packages/three-vrm-springbone/examples/loader-plugin.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-				"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
-				"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
+				"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
+				"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
 				"@pixiv/three-vrm-springbone": "../lib/three-vrm-springbone.module.js"
 			  }
 			}

--- a/packages/three-vrm-springbone/examples/multiple.html
+++ b/packages/three-vrm-springbone/examples/multiple.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-				"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
-				"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
+				"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
+				"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
 				"@pixiv/three-vrm-springbone": "../lib/three-vrm-springbone.module.js"
 			  }
 			}

--- a/packages/three-vrm-springbone/examples/single.html
+++ b/packages/three-vrm-springbone/examples/single.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-				"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
-				"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
+				"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
+				"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
 				"@pixiv/three-vrm-springbone": "../lib/three-vrm-springbone.module.js"
 			  }
 			}

--- a/packages/three-vrm-springbone/package.json
+++ b/packages/three-vrm-springbone/package.json
@@ -54,9 +54,9 @@
     "@pixiv/types-vrmc-springbone-1.0": "2.1.0"
   },
   "devDependencies": {
-    "three": "^0.160.0"
+    "three": "^0.162.0"
   },
   "peerDependencies": {
-    "three": "^0.160.0"
+    "three": "^0.162.0"
   }
 }

--- a/packages/three-vrm-springbone/src/VRMSpringBoneColliderShape.ts
+++ b/packages/three-vrm-springbone/src/VRMSpringBoneColliderShape.ts
@@ -1,3 +1,5 @@
+import type * as THREE from 'three';
+
 /**
  * Represents a shape of a collider.
  */

--- a/packages/three-vrm-springbone/src/VRMSpringBoneJointSettings.ts
+++ b/packages/three-vrm-springbone/src/VRMSpringBoneJointSettings.ts
@@ -1,3 +1,5 @@
+import type * as THREE from 'three';
+
 export interface VRMSpringBoneJointSettings {
   /**
    * Radius of the bone, will be used for collision.

--- a/packages/three-vrm-springbone/src/VRMSpringBoneLoaderPluginOptions.ts
+++ b/packages/three-vrm-springbone/src/VRMSpringBoneLoaderPluginOptions.ts
@@ -1,3 +1,5 @@
+import type * as THREE from 'three';
+
 export interface VRMSpringBoneLoaderPluginOptions {
   /**
    * Specify an Object3D to add {@link VRMSpringBoneJointHelper} s.

--- a/packages/three-vrm-springbone/src/utils/traverseChildrenUntilConditionMet.ts
+++ b/packages/three-vrm-springbone/src/utils/traverseChildrenUntilConditionMet.ts
@@ -1,3 +1,5 @@
+import type * as THREE from 'three';
+
 /**
  * Traverse children of given object and execute given callback.
  * The given object itself wont be given to the callback.

--- a/packages/three-vrm/README.md
+++ b/packages/three-vrm/README.md
@@ -46,8 +46,8 @@ Code like this:
 <script type="importmap">
   {
     "imports": {
-      "three": "https://unpkg.com/three@0.160.0/build/three.module.js",
-      "three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
+      "three": "https://unpkg.com/three@0.162.0/build/three.module.js",
+      "three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
       "@pixiv/three-vrm": "three-vrm.module.js"
     }
   }

--- a/packages/three-vrm/examples/animations.html
+++ b/packages/three-vrm/examples/animations.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/basic.html
+++ b/packages/three-vrm/examples/basic.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/bones.html
+++ b/packages/three-vrm/examples/bones.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/debug.html
+++ b/packages/three-vrm/examples/debug.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/dnd.html
+++ b/packages/three-vrm/examples/dnd.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/expressions.html
+++ b/packages/three-vrm/examples/expressions.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/firstperson.html
+++ b/packages/three-vrm/examples/firstperson.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/humanoidAnimation/index.html
+++ b/packages/three-vrm/examples/humanoidAnimation/index.html
@@ -38,8 +38,8 @@
 			{
 				"imports": {
 					"fflate": "https://unpkg.com/fflate@0.7.4/esm/browser.js",
-					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
 					"@pixiv/three-vrm": "../../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/lookat-advanced.html
+++ b/packages/three-vrm/examples/lookat-advanced.html
@@ -28,8 +28,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/lookat.html
+++ b/packages/three-vrm/examples/lookat.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/materials-debug.html
+++ b/packages/three-vrm/examples/materials-debug.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/meta.html
+++ b/packages/three-vrm/examples/meta.html
@@ -38,8 +38,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/mouse.html
+++ b/packages/three-vrm/examples/mouse.html
@@ -26,8 +26,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.160.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.160.0/examples/jsm/",
+					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/package.json
+++ b/packages/three-vrm/package.json
@@ -59,11 +59,11 @@
   },
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.0.1",
-    "@types/three": "^0.160.0",
-    "three": "^0.160.0"
+    "@types/three": "^0.162.0",
+    "three": "^0.162.0"
   },
   "peerDependencies": {
-    "@types/three": "^0.160.0",
-    "three": "^0.160.0"
+    "@types/three": "^0.162.0",
+    "three": "^0.162.0"
   }
 }

--- a/packages/three-vrm/src/VRMParameters.ts
+++ b/packages/three-vrm/src/VRMParameters.ts
@@ -1,3 +1,4 @@
+import type * as THREE from 'three';
 import { VRMCoreParameters } from '@pixiv/three-vrm-core';
 import { VRMSpringBoneManager } from '@pixiv/three-vrm-springbone';
 import { VRMNodeConstraintManager } from '@pixiv/three-vrm-node-constraint';

--- a/yarn.lock
+++ b/yarn.lock
@@ -1301,6 +1301,11 @@
     "@tufjs/canonical-json" "1.0.0"
     minimatch "^9.0.0"
 
+"@tweenjs/tween.js@~23.1.1":
+  version "23.1.1"
+  resolved "https://registry.yarnpkg.com/@tweenjs/tween.js/-/tween.js-23.1.1.tgz#0ae28ed9c635805557f78c2626464018d5f1b5e2"
+  integrity sha512-ZpboH7pCPPeyBWKf8c7TJswtCEQObFo3bOBYalm99NzZarATALYCo5OhbCa/n4RQyJyHfhkdx+hNrdL5ByFYDw==
+
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.7":
   version "7.1.15"
   resolved "https://registry.yarnpkg.com/@types/babel__core/-/babel__core-7.1.15.tgz#2ccfb1ad55a02c83f8e0ad327cbc332f55eb1024"
@@ -1423,11 +1428,12 @@
   resolved "https://registry.yarnpkg.com/@types/stats.js/-/stats.js-0.17.0.tgz#0ed81d48e03b590c24da85540c1d952077a9fe20"
   integrity sha512-9w+a7bR8PeB0dCT/HBULU2fMqf6BAzvKbxFboYhmDtDkKPiyXYbjoe2auwsXlEFI7CFNMF1dCv3dFH5Poy9R1w==
 
-"@types/three@^0.160.0":
-  version "0.160.0"
-  resolved "https://registry.yarnpkg.com/@types/three/-/three-0.160.0.tgz#7915a97e0a14ccaa9ccbb9f190c5730b04a23075"
-  integrity sha512-jWlbUBovicUKaOYxzgkLlhkiEQJkhCVvg4W2IYD2trqD2om3VK4DGLpHH5zQHNr7RweZK/5re/4IVhbhvxbV9w==
+"@types/three@^0.162.0":
+  version "0.162.0"
+  resolved "https://registry.yarnpkg.com/@types/three/-/three-0.162.0.tgz#79d170c88f14b2eaee6b76af00fc4016a533e586"
+  integrity sha512-0j5yZcVukVIhrhSIC7+LmBPkkMoMuEJ1AfYBZfgNytdYqYREMuiyXWhYOMeZLBElTEAlJIZn7r2W3vqTIgjWlg==
   dependencies:
+    "@tweenjs/tween.js" "~23.1.1"
     "@types/stats.js" "*"
     "@types/webxr" "*"
     fflate "~0.6.10"
@@ -7708,10 +7714,10 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
-three@^0.160.0:
-  version "0.160.0"
-  resolved "https://registry.yarnpkg.com/three/-/three-0.160.0.tgz#cd1e4dbd01aee0719280a9086d75545db52b7a8f"
-  integrity sha512-DLU8lc0zNIPkM7rH5/e1Ks1Z8tWCGRq6g8mPowdDJpw1CFBJMU7UoJjC6PefXW7z//SSl0b2+GCw14LB+uDhng==
+three@^0.162.0:
+  version "0.162.0"
+  resolved "https://registry.yarnpkg.com/three/-/three-0.162.0.tgz#b15a511f1498e0c42d4d00bbb411c7527b06097e"
+  integrity sha512-xfCYj4RnlozReCmUd+XQzj6/5OjDNHBy5nT6rVwrOKGENAvpXe2z1jL+DZYaMu4/9pNsjH/4Os/VvS9IrH7IOQ==
 
 throat@^5.0.0:
   version "5.0.0"


### PR DESCRIPTION
This PR bumps Three.js to r162.

See: https://github.com/mrdoob/three.js/releases/tag/r162

`@types/three` no longer expose THREE to global and I somehow forgot to import the types in many files, so I fixed it also.
