### PR TITLE
chore: change cdn from unpkg to jsDelivr

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,22 +32,20 @@ You will need:
 
 - [Three.js build](https://github.com/mrdoob/three.js/blob/master/build/three.js)
 - [GLTFLoader](https://github.com/mrdoob/three.js/blob/master/examples/js/loaders/GLTFLoader.js)
-- [A build of @pixiv/three-vrm](https://unpkg.com/browse/@pixiv/three-vrm/lib/)
+- [A build of @pixiv/three-vrm](https://www.jsdelivr.com/package/npm/@pixiv/three-vrm?tab=files&path=lib)
   - `.module` ones are ESM, otherwise it's UMD and injects its modules into global `THREE`
   - `.min` ones are minified (for production), otherwise it's not minified and it comes with source maps
+
+You can import all of them via CDN. See the example below.
 
 Code like this:
 
 ```html
-<!-- About import maps, see the Three.js official docs: -->
-<!-- https://threejs.org/docs/#manual/en/introduction/Installation -->
-<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
-
 <script type="importmap">
   {
     "imports": {
-      "three": "https://unpkg.com/three@0.162.0/build/three.module.js",
-      "three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
+      "three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
+      "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
       "@pixiv/three-vrm": "three-vrm.module.js"
     }
   }

--- a/packages/three-vrm-animation/examples/dnd.html
+++ b/packages/three-vrm-animation/examples/dnd.html
@@ -19,16 +19,12 @@
 	</head>
 
 	<body>
-		<!-- Import maps polyfill -->
-		<!-- Remove this when import maps will be widely supported -->
-		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
-
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
-					"@pixiv/three-vrm": "https://unpkg.com/@pixiv/three-vrm@2.1.0/lib/three-vrm.module.js",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
+					"@pixiv/three-vrm": "https://cdn.jsdelivr.net/npm/@pixiv/three-vrm@2.1.0/lib/three-vrm.module.js",
 					"@pixiv/three-vrm-animation": "../lib/three-vrm-animation.module.js"
 				}
 			}

--- a/packages/three-vrm-animation/examples/loader-plugin.html
+++ b/packages/three-vrm-animation/examples/loader-plugin.html
@@ -19,16 +19,12 @@
 	</head>
 
 	<body>
-		<!-- Import maps polyfill -->
-		<!-- Remove this when import maps will be widely supported -->
-		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
-
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
-					"@pixiv/three-vrm": "https://unpkg.com/@pixiv/three-vrm@2.1.0/lib/three-vrm.module.js",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
+					"@pixiv/three-vrm": "https://cdn.jsdelivr.net/npm/@pixiv/three-vrm@2.1.0/lib/three-vrm.module.js",
 					"@pixiv/three-vrm-animation": "../lib/three-vrm-animation.module.js"
 				}
 			}

--- a/packages/three-vrm-core/examples/expressions.html
+++ b/packages/three-vrm-core/examples/expressions.html
@@ -19,15 +19,11 @@
 	</head>
 
 	<body>
-		<!-- Import maps polyfill -->
-		<!-- Remove this when import maps will be widely supported -->
-		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
-
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
 					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/examples/firstPerson.html
+++ b/packages/three-vrm-core/examples/firstPerson.html
@@ -25,15 +25,11 @@
 	<body>
 		<span id="info"></span>
 
-		<!-- Import maps polyfill -->
-		<!-- Remove this when import maps will be widely supported -->
-		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
-
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
 					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/examples/humanoid.html
+++ b/packages/three-vrm-core/examples/humanoid.html
@@ -19,15 +19,11 @@
 	</head>
 
 	<body>
-		<!-- Import maps polyfill -->
-		<!-- Remove this when import maps will be widely supported -->
-		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
-
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
 					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/examples/humanoidAnimation/index.html
+++ b/packages/three-vrm-core/examples/humanoidAnimation/index.html
@@ -30,16 +30,12 @@
 			drag and drop <a href="https://www.mixamo.com/" target="_blank" rel="noopener noreferrer">mixamo</a> animation (.fbx)<br />
 		</div>
 
-		<!-- Import maps polyfill -->
-		<!-- Remove this when import maps will be widely supported -->
-		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
-
 		<script type="importmap">
 			{
 				"imports": {
-					"fflate": "https://unpkg.com/fflate@0.7.4/esm/browser.js",
-					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
+					"fflate": "https://cdn.jsdelivr.net/npm/fflate@0.7.4/esm/browser.js",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
 					"@pixiv/three-vrm-core": "../../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/examples/lookAt.html
+++ b/packages/three-vrm-core/examples/lookAt.html
@@ -25,15 +25,11 @@
 	<body>
 		<span id="info"></span>
 
-		<!-- Import maps polyfill -->
-		<!-- Remove this when import maps will be widely supported -->
-		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
-
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
 					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/examples/meta.html
+++ b/packages/three-vrm-core/examples/meta.html
@@ -32,15 +32,11 @@
 		<span id="meta"></span>
 		<img id="thumbnail" alt="thumbnail" />
 
-		<!-- Import maps polyfill -->
-		<!-- Remove this when import maps will be widely supported -->
-		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
-
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
 					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-materials-hdr-emissive-multiplier/examples/loader-plugin.html
+++ b/packages/three-vrm-materials-hdr-emissive-multiplier/examples/loader-plugin.html
@@ -19,15 +19,11 @@
 	</head>
 
 	<body>
-		<!-- Import maps polyfill -->
-		<!-- Remove this when import maps will be widely supported -->
-		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
-
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
 					"@pixiv/three-vrm-materials-hdr-emissive-multiplier": "../lib/three-vrm-materials-hdr-emissive-multiplier.module.js"
 				}
 			}

--- a/packages/three-vrm-materials-mtoon/examples/emissive-strength.html
+++ b/packages/three-vrm-materials-mtoon/examples/emissive-strength.html
@@ -19,13 +19,13 @@
 	</head>
 
 	<body>
-		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+		<script async src="https://cdn.jsdelivr.net/npm/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
 
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
 					"@pixiv/three-vrm-materials-mtoon": "../lib/three-vrm-materials-mtoon.module.js"
 				}
 			}

--- a/packages/three-vrm-materials-mtoon/examples/feature-test.html
+++ b/packages/three-vrm-materials-mtoon/examples/feature-test.html
@@ -19,15 +19,11 @@
 	</head>
 
 	<body>
-		<!-- Import maps polyfill -->
-		<!-- Remove this when import maps will be widely supported -->
-		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
-
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
 					"@pixiv/three-vrm-materials-mtoon": "../lib/three-vrm-materials-mtoon.module.js"
 				}
 			}

--- a/packages/three-vrm-materials-mtoon/examples/loader-plugin.html
+++ b/packages/three-vrm-materials-mtoon/examples/loader-plugin.html
@@ -19,15 +19,11 @@
 	</head>
 
 	<body>
-		<!-- Import maps polyfill -->
-		<!-- Remove this when import maps will be widely supported -->
-		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
-
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
 					"@pixiv/three-vrm-materials-mtoon": "../lib/three-vrm-materials-mtoon.module.js"
 				}
 			}

--- a/packages/three-vrm-node-constraint/examples/aim.html
+++ b/packages/three-vrm-node-constraint/examples/aim.html
@@ -19,14 +19,14 @@
 	</head>
 
 	<body>
-		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+		<script async src="https://cdn.jsdelivr.net/npm/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
 		<script type="importmap">
 			{
 			  "imports": {
-					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
-					"tweakpane": "https://unpkg.com/tweakpane@3.0",
-					"tweakpane-plugin-rotation": "https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
+					"tweakpane": "https://cdn.jsdelivr.net/npm/tweakpane@3.0",
+					"tweakpane-plugin-rotation": "https://cdn.jsdelivr.net/npm/@0b5vr/tweakpane-plugin-rotation@0.1",
 					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"
 			  }
 			}

--- a/packages/three-vrm-node-constraint/examples/importer.html
+++ b/packages/three-vrm-node-constraint/examples/importer.html
@@ -19,14 +19,14 @@
 	</head>
 
 	<body>
-		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+		<script async src="https://cdn.jsdelivr.net/npm/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
 		<script type="importmap">
 			{
 			  "imports": {
-					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
-					"tweakpane": "https://unpkg.com/tweakpane@3.0",
-					"tweakpane-plugin-rotation": "https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
+					"tweakpane": "https://cdn.jsdelivr.net/npm/tweakpane@3.0",
+					"tweakpane-plugin-rotation": "https://cdn.jsdelivr.net/npm/@0b5vr/tweakpane-plugin-rotation@0.1",
 					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"
 			  }
 			}

--- a/packages/three-vrm-node-constraint/examples/roll.html
+++ b/packages/three-vrm-node-constraint/examples/roll.html
@@ -19,14 +19,14 @@
 	</head>
 
 	<body>
-		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+		<script async src="https://cdn.jsdelivr.net/npm/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
 		<script type="importmap">
 			{
 			  "imports": {
-					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
-					"tweakpane": "https://unpkg.com/tweakpane@3.0",
-					"tweakpane-plugin-rotation": "https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
+					"tweakpane": "https://cdn.jsdelivr.net/npm/tweakpane@3.0",
+					"tweakpane-plugin-rotation": "https://cdn.jsdelivr.net/npm/@0b5vr/tweakpane-plugin-rotation@0.1",
 					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"
 			  }
 			}

--- a/packages/three-vrm-node-constraint/examples/rotation.html
+++ b/packages/three-vrm-node-constraint/examples/rotation.html
@@ -19,14 +19,14 @@
 	</head>
 
 	<body>
-		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+		<script async src="https://cdn.jsdelivr.net/npm/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
 		<script type="importmap">
 			{
 			  "imports": {
-					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
-					"tweakpane": "https://unpkg.com/tweakpane@3.0",
-					"tweakpane-plugin-rotation": "https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
+					"tweakpane": "https://cdn.jsdelivr.net/npm/tweakpane@3.0",
+					"tweakpane-plugin-rotation": "https://cdn.jsdelivr.net/npm/@0b5vr/tweakpane-plugin-rotation@0.1",
 					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"
 			  }
 			}

--- a/packages/three-vrm-node-constraint/examples/upper-arm.html
+++ b/packages/three-vrm-node-constraint/examples/upper-arm.html
@@ -19,14 +19,14 @@
 	</head>
 
 	<body>
-		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+		<script async src="https://cdn.jsdelivr.net/npm/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
 		<script type="importmap">
 			{
 			  "imports": {
-					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
-					"tweakpane": "https://unpkg.com/tweakpane@3.0",
-					"tweakpane-plugin-rotation": "https://unpkg.com/@0b5vr/tweakpane-plugin-rotation@0.1",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
+					"tweakpane": "https://cdn.jsdelivr.net/npm/tweakpane@3.0",
+					"tweakpane-plugin-rotation": "https://cdn.jsdelivr.net/npm/@0b5vr/tweakpane-plugin-rotation@0.1",
 					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"
 			  }
 			}

--- a/packages/three-vrm-springbone/examples/collider.html
+++ b/packages/three-vrm-springbone/examples/collider.html
@@ -19,12 +19,12 @@
 	</head>
 
 	<body>
-		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+		<script async src="https://cdn.jsdelivr.net/npm/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
 		<script type="importmap">
 			{
 			  "imports": {
-				"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
-				"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
+				"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
+				"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
 				"@pixiv/three-vrm-springbone": "../lib/three-vrm-springbone.module.js"
 			  }
 			}

--- a/packages/three-vrm-springbone/examples/loader-plugin.html
+++ b/packages/three-vrm-springbone/examples/loader-plugin.html
@@ -19,12 +19,12 @@
 	</head>
 
 	<body>
-		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+		<script async src="https://cdn.jsdelivr.net/npm/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
 		<script type="importmap">
 			{
 			  "imports": {
-				"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
-				"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
+				"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
+				"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
 				"@pixiv/three-vrm-springbone": "../lib/three-vrm-springbone.module.js"
 			  }
 			}

--- a/packages/three-vrm-springbone/examples/multiple.html
+++ b/packages/three-vrm-springbone/examples/multiple.html
@@ -19,12 +19,12 @@
 	</head>
 
 	<body>
-		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+		<script async src="https://cdn.jsdelivr.net/npm/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
 		<script type="importmap">
 			{
 			  "imports": {
-				"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
-				"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
+				"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
+				"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
 				"@pixiv/three-vrm-springbone": "../lib/three-vrm-springbone.module.js"
 			  }
 			}

--- a/packages/three-vrm-springbone/examples/single.html
+++ b/packages/three-vrm-springbone/examples/single.html
@@ -19,12 +19,12 @@
 	</head>
 
 	<body>
-		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
+		<script async src="https://cdn.jsdelivr.net/npm/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
 		<script type="importmap">
 			{
 			  "imports": {
-				"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
-				"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
+				"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
+				"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
 				"@pixiv/three-vrm-springbone": "../lib/three-vrm-springbone.module.js"
 			  }
 			}

--- a/packages/three-vrm/README.md
+++ b/packages/three-vrm/README.md
@@ -32,22 +32,20 @@ You will need:
 
 - [Three.js build](https://github.com/mrdoob/three.js/blob/master/build/three.js)
 - [GLTFLoader](https://github.com/mrdoob/three.js/blob/master/examples/js/loaders/GLTFLoader.js)
-- [A build of @pixiv/three-vrm](https://unpkg.com/browse/@pixiv/three-vrm/lib/)
+- [A build of @pixiv/three-vrm](https://www.jsdelivr.com/package/npm/@pixiv/three-vrm?tab=files&path=lib)
   - `.module` ones are ESM, otherwise it's UMD and injects its modules into global `THREE`
   - `.min` ones are minified (for production), otherwise it's not minified and it comes with source maps
+
+You can import all of them via CDN. See the example below.
 
 Code like this:
 
 ```html
-<!-- About import maps, see the Three.js official docs: -->
-<!-- https://threejs.org/docs/#manual/en/introduction/Installation -->
-<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
-
 <script type="importmap">
   {
     "imports": {
-      "three": "https://unpkg.com/three@0.162.0/build/three.module.js",
-      "three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
+      "three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
+      "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
       "@pixiv/three-vrm": "three-vrm.module.js"
     }
   }

--- a/packages/three-vrm/examples/animations.html
+++ b/packages/three-vrm/examples/animations.html
@@ -19,15 +19,11 @@
 	</head>
 
 	<body>
-		<!-- Import maps polyfill -->
-		<!-- Remove this when import maps will be widely supported -->
-		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
-
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/basic.html
+++ b/packages/three-vrm/examples/basic.html
@@ -19,15 +19,11 @@
 	</head>
 
 	<body>
-		<!-- Import maps polyfill -->
-		<!-- Remove this when import maps will be widely supported -->
-		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
-
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/bones.html
+++ b/packages/three-vrm/examples/bones.html
@@ -19,15 +19,11 @@
 	</head>
 
 	<body>
-		<!-- Import maps polyfill -->
-		<!-- Remove this when import maps will be widely supported -->
-		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
-
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/debug.html
+++ b/packages/three-vrm/examples/debug.html
@@ -19,15 +19,11 @@
 	</head>
 
 	<body>
-		<!-- Import maps polyfill -->
-		<!-- Remove this when import maps will be widely supported -->
-		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
-
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/dnd.html
+++ b/packages/three-vrm/examples/dnd.html
@@ -19,15 +19,11 @@
 	</head>
 
 	<body>
-		<!-- Import maps polyfill -->
-		<!-- Remove this when import maps will be widely supported -->
-		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
-
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/expressions.html
+++ b/packages/three-vrm/examples/expressions.html
@@ -19,15 +19,11 @@
 	</head>
 
 	<body>
-		<!-- Import maps polyfill -->
-		<!-- Remove this when import maps will be widely supported -->
-		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
-
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/firstperson.html
+++ b/packages/three-vrm/examples/firstperson.html
@@ -19,15 +19,11 @@
 	</head>
 
 	<body>
-		<!-- Import maps polyfill -->
-		<!-- Remove this when import maps will be widely supported -->
-		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
-
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/humanoidAnimation/index.html
+++ b/packages/three-vrm/examples/humanoidAnimation/index.html
@@ -30,16 +30,12 @@
 			drag and drop <a href="https://www.mixamo.com/" target="_blank" rel="noopener noreferrer">mixamo</a> animation (.fbx)<br />
 		</div>
 
-		<!-- Import maps polyfill -->
-		<!-- Remove this when import maps will be widely supported -->
-		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
-
 		<script type="importmap">
 			{
 				"imports": {
-					"fflate": "https://unpkg.com/fflate@0.7.4/esm/browser.js",
-					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
+					"fflate": "https://cdn.jsdelivr.net/npm/fflate@0.7.4/esm/browser.js",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
 					"@pixiv/three-vrm": "../../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/lookat-advanced.html
+++ b/packages/three-vrm/examples/lookat-advanced.html
@@ -21,15 +21,11 @@
 	</head>
 
 	<body>
-		<!-- Import maps polyfill -->
-		<!-- Remove this when import maps will be widely supported -->
-		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
-
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/lookat.html
+++ b/packages/three-vrm/examples/lookat.html
@@ -19,15 +19,11 @@
 	</head>
 
 	<body>
-		<!-- Import maps polyfill -->
-		<!-- Remove this when import maps will be widely supported -->
-		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
-
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/materials-debug.html
+++ b/packages/three-vrm/examples/materials-debug.html
@@ -19,15 +19,11 @@
 	</head>
 
 	<body>
-		<!-- Import maps polyfill -->
-		<!-- Remove this when import maps will be widely supported -->
-		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
-
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/meta.html
+++ b/packages/three-vrm/examples/meta.html
@@ -31,15 +31,11 @@
 	<body>
 		<span id="meta"></span>
 		<img id="thumbnail" alt="thumbnail" />
-		<!-- Import maps polyfill -->
-		<!-- Remove this when import maps will be widely supported -->
-		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
-
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/mouse.html
+++ b/packages/three-vrm/examples/mouse.html
@@ -19,15 +19,11 @@
 	</head>
 
 	<body>
-		<!-- Import maps polyfill -->
-		<!-- Remove this when import maps will be widely supported -->
-		<script async src="https://unpkg.com/es-module-shims@1.3.6/dist/es-module-shims.js"></script>
-
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://unpkg.com/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://unpkg.com/three@0.162.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}


### PR DESCRIPTION
This PR replaces CDN from unpkg to jsDelivr.
I confirmed that all examples are working properly on my end.

Also update README to recommend jsDelivr.

Following the Three.js side change.
See: https://github.com/mrdoob/three.js/pull/28006

es-module-shims for import map is also no longer used in Three.js examples. See: https://github.com/mrdoob/three.js/pull/26836