### PR TITLE
deps: Bump Three.js to r164 (2)

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,8 +44,8 @@ Code like this:
 <script type="importmap">
   {
     "imports": {
-      "three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
-      "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
+      "three": "https://cdn.jsdelivr.net/npm/three@0.164.1/build/three.module.js",
+      "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.164.1/examples/jsm/",
       "@pixiv/three-vrm": "three-vrm.module.js"
     }
   }

--- a/packages/three-vrm-animation/examples/dnd.html
+++ b/packages/three-vrm-animation/examples/dnd.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.164.1/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.164.1/examples/jsm/",
 					"@pixiv/three-vrm": "https://cdn.jsdelivr.net/npm/@pixiv/three-vrm@2.1.0/lib/three-vrm.module.js",
 					"@pixiv/three-vrm-animation": "../lib/three-vrm-animation.module.js"
 				}

--- a/packages/three-vrm-animation/examples/loader-plugin.html
+++ b/packages/three-vrm-animation/examples/loader-plugin.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.164.1/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.164.1/examples/jsm/",
 					"@pixiv/three-vrm": "https://cdn.jsdelivr.net/npm/@pixiv/three-vrm@2.1.0/lib/three-vrm.module.js",
 					"@pixiv/three-vrm-animation": "../lib/three-vrm-animation.module.js"
 				}

--- a/packages/three-vrm-animation/package.json
+++ b/packages/three-vrm-animation/package.json
@@ -53,10 +53,10 @@
   "devDependencies": {
     "@types/three": "^0.164.0",
     "lint-staged": "15.2.2",
-    "three": "^0.164.0"
+    "three": "^0.164.1"
   },
   "peerDependencies": {
     "@types/three": "^0.164.0",
-    "three": "^0.164.0"
+    "three": "^0.164.1"
   }
 }

--- a/packages/three-vrm-core/examples/expressions.html
+++ b/packages/three-vrm-core/examples/expressions.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.164.1/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.164.1/examples/jsm/",
 					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/examples/firstPerson.html
+++ b/packages/three-vrm-core/examples/firstPerson.html
@@ -28,8 +28,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.164.1/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.164.1/examples/jsm/",
 					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/examples/humanoid.html
+++ b/packages/three-vrm-core/examples/humanoid.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.164.1/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.164.1/examples/jsm/",
 					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/examples/humanoidAnimation/index.html
+++ b/packages/three-vrm-core/examples/humanoidAnimation/index.html
@@ -34,8 +34,8 @@
 			{
 				"imports": {
 					"fflate": "https://cdn.jsdelivr.net/npm/fflate@0.7.4/esm/browser.js",
-					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.164.1/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.164.1/examples/jsm/",
 					"@pixiv/three-vrm-core": "../../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/examples/lookAt.html
+++ b/packages/three-vrm-core/examples/lookAt.html
@@ -28,8 +28,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.164.1/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.164.1/examples/jsm/",
 					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/examples/meta.html
+++ b/packages/three-vrm-core/examples/meta.html
@@ -35,8 +35,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.164.1/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.164.1/examples/jsm/",
 					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/package.json
+++ b/packages/three-vrm-core/package.json
@@ -55,10 +55,10 @@
   },
   "devDependencies": {
     "@types/three": "^0.164.0",
-    "three": "^0.164.0"
+    "three": "^0.164.1"
   },
   "peerDependencies": {
     "@types/three": "^0.164.0",
-    "three": "^0.164.0"
+    "three": "^0.164.1"
   }
 }

--- a/packages/three-vrm-materials-hdr-emissive-multiplier/examples/loader-plugin.html
+++ b/packages/three-vrm-materials-hdr-emissive-multiplier/examples/loader-plugin.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.164.1/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.164.1/examples/jsm/",
 					"@pixiv/three-vrm-materials-hdr-emissive-multiplier": "../lib/three-vrm-materials-hdr-emissive-multiplier.module.js"
 				}
 			}

--- a/packages/three-vrm-materials-hdr-emissive-multiplier/package.json
+++ b/packages/three-vrm-materials-hdr-emissive-multiplier/package.json
@@ -53,10 +53,10 @@
   },
   "devDependencies": {
     "@types/three": "^0.164.0",
-    "three": "^0.164.0"
+    "three": "^0.164.1"
   },
   "peerDependencies": {
     "@types/three": "^0.164.0",
-    "three": "^0.164.0"
+    "three": "^0.164.1"
   }
 }

--- a/packages/three-vrm-materials-mtoon/examples/emissive-strength.html
+++ b/packages/three-vrm-materials-mtoon/examples/emissive-strength.html
@@ -24,8 +24,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.164.1/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.164.1/examples/jsm/",
 					"@pixiv/three-vrm-materials-mtoon": "../lib/three-vrm-materials-mtoon.module.js"
 				}
 			}

--- a/packages/three-vrm-materials-mtoon/examples/feature-test.html
+++ b/packages/three-vrm-materials-mtoon/examples/feature-test.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.164.1/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.164.1/examples/jsm/",
 					"@pixiv/three-vrm-materials-mtoon": "../lib/three-vrm-materials-mtoon.module.js"
 				}
 			}

--- a/packages/three-vrm-materials-mtoon/examples/loader-plugin.html
+++ b/packages/three-vrm-materials-mtoon/examples/loader-plugin.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.164.1/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.164.1/examples/jsm/",
 					"@pixiv/three-vrm-materials-mtoon": "../lib/three-vrm-materials-mtoon.module.js"
 				}
 			}

--- a/packages/three-vrm-materials-mtoon/package.json
+++ b/packages/three-vrm-materials-mtoon/package.json
@@ -54,10 +54,10 @@
   },
   "devDependencies": {
     "@types/three": "^0.164.0",
-    "three": "^0.164.0"
+    "three": "^0.164.1"
   },
   "peerDependencies": {
     "@types/three": "^0.164.0",
-    "three": "^0.164.0"
+    "three": "^0.164.1"
   }
 }

--- a/packages/three-vrm-materials-v0compat/package.json
+++ b/packages/three-vrm-materials-v0compat/package.json
@@ -50,10 +50,10 @@
   },
   "devDependencies": {
     "@types/three": "^0.164.0",
-    "three": "^0.164.0"
+    "three": "^0.164.1"
   },
   "peerDependencies": {
     "@types/three": "^0.164.0",
-    "three": "^0.164.0"
+    "three": "^0.164.1"
   }
 }

--- a/packages/three-vrm-node-constraint/examples/aim.html
+++ b/packages/three-vrm-node-constraint/examples/aim.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.164.1/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.164.1/examples/jsm/",
 					"tweakpane": "https://cdn.jsdelivr.net/npm/tweakpane@3.0",
 					"tweakpane-plugin-rotation": "https://cdn.jsdelivr.net/npm/@0b5vr/tweakpane-plugin-rotation@0.1",
 					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"

--- a/packages/three-vrm-node-constraint/examples/importer.html
+++ b/packages/three-vrm-node-constraint/examples/importer.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.164.1/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.164.1/examples/jsm/",
 					"tweakpane": "https://cdn.jsdelivr.net/npm/tweakpane@3.0",
 					"tweakpane-plugin-rotation": "https://cdn.jsdelivr.net/npm/@0b5vr/tweakpane-plugin-rotation@0.1",
 					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"

--- a/packages/three-vrm-node-constraint/examples/roll.html
+++ b/packages/three-vrm-node-constraint/examples/roll.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.164.1/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.164.1/examples/jsm/",
 					"tweakpane": "https://cdn.jsdelivr.net/npm/tweakpane@3.0",
 					"tweakpane-plugin-rotation": "https://cdn.jsdelivr.net/npm/@0b5vr/tweakpane-plugin-rotation@0.1",
 					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"

--- a/packages/three-vrm-node-constraint/examples/rotation.html
+++ b/packages/three-vrm-node-constraint/examples/rotation.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.164.1/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.164.1/examples/jsm/",
 					"tweakpane": "https://cdn.jsdelivr.net/npm/tweakpane@3.0",
 					"tweakpane-plugin-rotation": "https://cdn.jsdelivr.net/npm/@0b5vr/tweakpane-plugin-rotation@0.1",
 					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"

--- a/packages/three-vrm-node-constraint/examples/upper-arm.html
+++ b/packages/three-vrm-node-constraint/examples/upper-arm.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.164.1/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.164.1/examples/jsm/",
 					"tweakpane": "https://cdn.jsdelivr.net/npm/tweakpane@3.0",
 					"tweakpane-plugin-rotation": "https://cdn.jsdelivr.net/npm/@0b5vr/tweakpane-plugin-rotation@0.1",
 					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"

--- a/packages/three-vrm-node-constraint/package.json
+++ b/packages/three-vrm-node-constraint/package.json
@@ -54,10 +54,10 @@
   },
   "devDependencies": {
     "@types/three": "^0.164.0",
-    "three": "^0.164.0"
+    "three": "^0.164.1"
   },
   "peerDependencies": {
     "@types/three": "^0.164.0",
-    "three": "^0.164.0"
+    "three": "^0.164.1"
   }
 }

--- a/packages/three-vrm-springbone/examples/collider.html
+++ b/packages/three-vrm-springbone/examples/collider.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-				"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
-				"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
+				"three": "https://cdn.jsdelivr.net/npm/three@0.164.1/build/three.module.js",
+				"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.164.1/examples/jsm/",
 				"@pixiv/three-vrm-springbone": "../lib/three-vrm-springbone.module.js"
 			  }
 			}

--- a/packages/three-vrm-springbone/examples/loader-plugin.html
+++ b/packages/three-vrm-springbone/examples/loader-plugin.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-				"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
-				"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
+				"three": "https://cdn.jsdelivr.net/npm/three@0.164.1/build/three.module.js",
+				"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.164.1/examples/jsm/",
 				"@pixiv/three-vrm-springbone": "../lib/three-vrm-springbone.module.js"
 			  }
 			}

--- a/packages/three-vrm-springbone/examples/multiple.html
+++ b/packages/three-vrm-springbone/examples/multiple.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-				"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
-				"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
+				"three": "https://cdn.jsdelivr.net/npm/three@0.164.1/build/three.module.js",
+				"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.164.1/examples/jsm/",
 				"@pixiv/three-vrm-springbone": "../lib/three-vrm-springbone.module.js"
 			  }
 			}

--- a/packages/three-vrm-springbone/examples/single.html
+++ b/packages/three-vrm-springbone/examples/single.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-				"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
-				"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
+				"three": "https://cdn.jsdelivr.net/npm/three@0.164.1/build/three.module.js",
+				"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.164.1/examples/jsm/",
 				"@pixiv/three-vrm-springbone": "../lib/three-vrm-springbone.module.js"
 			  }
 			}

--- a/packages/three-vrm-springbone/package.json
+++ b/packages/three-vrm-springbone/package.json
@@ -54,9 +54,9 @@
     "@pixiv/types-vrmc-springbone-1.0": "2.1.1"
   },
   "devDependencies": {
-    "three": "^0.164.0"
+    "three": "^0.164.1"
   },
   "peerDependencies": {
-    "three": "^0.164.0"
+    "three": "^0.164.1"
   }
 }

--- a/packages/three-vrm/README.md
+++ b/packages/three-vrm/README.md
@@ -44,8 +44,8 @@ Code like this:
 <script type="importmap">
   {
     "imports": {
-      "three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
-      "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
+      "three": "https://cdn.jsdelivr.net/npm/three@0.164.1/build/three.module.js",
+      "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.164.1/examples/jsm/",
       "@pixiv/three-vrm": "three-vrm.module.js"
     }
   }

--- a/packages/three-vrm/examples/animations.html
+++ b/packages/three-vrm/examples/animations.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.164.1/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.164.1/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/basic.html
+++ b/packages/three-vrm/examples/basic.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.164.1/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.164.1/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/bones.html
+++ b/packages/three-vrm/examples/bones.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.164.1/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.164.1/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/debug.html
+++ b/packages/three-vrm/examples/debug.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.164.1/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.164.1/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/dnd.html
+++ b/packages/three-vrm/examples/dnd.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.164.1/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.164.1/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/expressions.html
+++ b/packages/three-vrm/examples/expressions.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.164.1/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.164.1/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/firstperson.html
+++ b/packages/three-vrm/examples/firstperson.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.164.1/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.164.1/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/humanoidAnimation/index.html
+++ b/packages/three-vrm/examples/humanoidAnimation/index.html
@@ -34,8 +34,8 @@
 			{
 				"imports": {
 					"fflate": "https://cdn.jsdelivr.net/npm/fflate@0.7.4/esm/browser.js",
-					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.164.1/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.164.1/examples/jsm/",
 					"@pixiv/three-vrm": "../../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/lookat-advanced.html
+++ b/packages/three-vrm/examples/lookat-advanced.html
@@ -24,8 +24,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.164.1/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.164.1/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/lookat.html
+++ b/packages/three-vrm/examples/lookat.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.164.1/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.164.1/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/meta.html
+++ b/packages/three-vrm/examples/meta.html
@@ -34,8 +34,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.164.1/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.164.1/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/mouse.html
+++ b/packages/three-vrm/examples/mouse.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.162.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.162.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.164.1/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.164.1/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/webgpu-dnd.html
+++ b/packages/three-vrm/examples/webgpu-dnd.html
@@ -11,6 +11,7 @@
 		<style>
 			body {
 				margin: 0;
+				background: #000;
 			}
 			canvas {
 				display: block;
@@ -33,10 +34,11 @@
 			import * as THREE from 'three';
 			import { GLTFLoader } from 'three/addons/loaders/GLTFLoader.js';
 			import { OrbitControls } from 'three/addons/controls/OrbitControls.js';
-			import { VRMLoaderPlugin, VRMUtils } from '@pixiv/three-vrm';
+			import WebGPURenderer from 'three/addons/renderers/webgpu/WebGPURenderer.js';
+			import { VRMLoaderPlugin, MToonNodeMaterialLoaderPlugin, VRMUtils } from '@pixiv/three-vrm';
 
 			// renderer
-			const renderer = new THREE.WebGLRenderer();
+			const renderer = new WebGPURenderer();
 			renderer.setSize( window.innerWidth, window.innerHeight );
 			renderer.setPixelRatio( window.devicePixelRatio );
 			document.body.appendChild( renderer.domElement );
@@ -66,41 +68,63 @@
 
 			loader.register( ( parser ) => {
 
-				return new VRMLoaderPlugin( parser );
+				const mtoonMaterialPlugin = new MToonNodeMaterialLoaderPlugin( parser );
+
+				return new VRMLoaderPlugin( parser, {
+
+					mtoonMaterialPlugin,
+
+				} );
 
 			} );
 
-			loader.load(
+			function load( url ) {
 
-				'./models/VRM1_Constraint_Twist_Sample.vrm',
+				loader.load(
 
-				( gltf ) => {
+					url,
 
-					const vrm = gltf.userData.vrm;
+					( gltf ) => {
 
-					// calling these functions greatly improves the performance
-					VRMUtils.removeUnnecessaryVertices( gltf.scene );
-					VRMUtils.removeUnnecessaryJoints( gltf.scene );
+						const vrm = gltf.userData.vrm;
 
-					// Disable frustum culling
-					vrm.scene.traverse( ( obj ) => {
+						// calling these functions greatly improves the performance
+						VRMUtils.removeUnnecessaryVertices( gltf.scene );
+						VRMUtils.removeUnnecessaryJoints( gltf.scene, { sameBoneCounts: true } );
 
-						obj.frustumCulled = false;
+						if ( currentVrm ) {
 
-					} );
+							scene.remove( currentVrm.scene );
+							VRMUtils.deepDispose( currentVrm.scene );
 
-					scene.add( vrm.scene );
-					currentVrm = vrm;
+						}
 
-					console.log( vrm );
+						// Disable frustum culling
+						vrm.scene.traverse( ( obj ) => {
 
-				},
+							obj.frustumCulled = false;
 
-				( progress ) => console.log( 'Loading model...', 100.0 * ( progress.loaded / progress.total ), '%' ),
+						} );
 
-				( error ) => console.error( error )
+						currentVrm = vrm;
+						scene.add( vrm.scene );
 
-			);
+						// rotate if the VRM is VRM0.0
+						VRMUtils.rotateVRM0( vrm );
+
+						console.log( vrm );
+
+					},
+
+					( progress ) => console.log( 'Loading model...', 100.0 * ( progress.loaded / progress.total ), '%' ),
+
+					( error ) => console.error( error )
+
+				);
+
+			}
+
+			load( './models/VRM1_Constraint_Twist_Sample.vrm' );
 
 			// helpers
 			const gridHelper = new THREE.GridHelper( 10, 10 );
@@ -111,68 +135,53 @@
 
 			// animate
 			const clock = new THREE.Clock();
+			clock.start();
 
 			function animate() {
 
 				requestAnimationFrame( animate );
 
-				const deltaTime = clock.getDelta();
-
 				if ( currentVrm ) {
 
-					// update vrm
-					currentVrm.update( deltaTime );
+					currentVrm.update( clock.getDelta() );
 
 				}
 
-				renderer.render( scene, camera );
+				renderer.renderAsync( scene, camera );
 
 			}
 
 			animate();
 
-			// keyboard listener
-			function setMToonDebugMode( material, mode ) {
+			// dnd handler
+			window.addEventListener( 'dragover', function ( event ) {
 
-				if ( material.isMToonMaterial ) {
+				event.preventDefault();
 
-					material.debugMode = mode;
+			} );
 
-				}
+			window.addEventListener( 'drop', function ( event ) {
 
-			}
+				event.preventDefault();
 
-			let debugModeIndex = 0;
-
-			window.addEventListener( 'keydown', () => {
-
-				if ( ! currentVrm ) {
+				// read given file then convert it to blob url
+				const files = event.dataTransfer.files;
+				if ( ! files ) {
 
 					return;
 
 				}
 
-				debugModeIndex = ( debugModeIndex + 1 ) % 4;
+				const file = files[ 0 ];
+				if ( ! file ) {
 
-				const debugMode = [ 'none', 'normal', 'litShadeRate', 'uv' ][ debugModeIndex ];
+					return;
 
-				currentVrm.scene.traverse( ( object ) => {
+				}
 
-					if ( object.material ) {
-
-						if ( Array.isArray( object.material ) ) {
-
-							object.material.forEach( ( material ) => setMToonDebugMode( material, debugMode ) );
-
-						} else {
-
-							setMToonDebugMode( object.material, debugMode );
-
-						}
-
-					}
-
-				} );
+				const blob = new Blob( [ file ], { type: "application/octet-stream" } );
+				const url = URL.createObjectURL( blob );
+				load( url );
 
 			} );
 		</script>

--- a/packages/three-vrm/package.json
+++ b/packages/three-vrm/package.json
@@ -60,10 +60,10 @@
   "devDependencies": {
     "@rollup/plugin-node-resolve": "^15.0.1",
     "@types/three": "^0.164.0",
-    "three": "^0.164.0"
+    "three": "^0.164.1"
   },
   "peerDependencies": {
     "@types/three": "^0.164.0",
-    "three": "^0.164.0"
+    "three": "^0.164.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7604,7 +7604,7 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
-three@^0.164.0:
+three@^0.164.1:
   version "0.164.1"
   resolved "https://registry.yarnpkg.com/three/-/three-0.164.1.tgz#b742f76bd8dfd3736ba0d86a12dfddb73c5cdcc0"
   integrity sha512-iC/hUBbl1vzFny7f5GtqzVXYjMJKaTPxiCxXfrvVdBi1Sf+jhd1CAkitiFwC7mIBFCo3MrDLJG97yisoaWig0w==


### PR DESCRIPTION
Sequel of #1399 

- Three.js version should be 0.164.1 instead of 0.164.0
- Forgot to bump versions in examples