### PR TITLE
fix: MToon, Fix normal mapping when other textures are not specified

### DIFF
--- a/packages/three-vrm-materials-mtoon/src/MToonMaterial.ts
+++ b/packages/three-vrm-materials-mtoon/src/MToonMaterial.ts
@@ -606,6 +606,7 @@ export class MToonMaterial extends THREE.ShaderMaterial {
     const useUvInVert = this.outlineWidthMultiplyTexture !== null;
     const useUvInFrag =
       this.map !== null ||
+      this.normalMap !== null ||
       this.emissiveMap !== null ||
       this.shadeMultiplyTexture !== null ||
       this.shadingShiftTexture !== null ||


### PR DESCRIPTION
See: https://github.com/pixiv/three-vrm/pull/1384#issuecomment-2117311809

Fix normal mapping when other textures are not specified.

This is because `this.normalMap !== null` did not perticipate in the condition of the `MTOON_USE_UV` flag.

Below is the screenshot of `feature-test.html`. Note that the blue ball that only specifies normal map has bumps correctly.

![image](https://github.com/pixiv/three-vrm/assets/7824814/29ddc6bb-2a3e-4606-9cda-e63cf641c6be)


