### PR TITLE
fix: revert exports to unminified build

### DIFF
--- a/packages/three-vrm-animation/package.json
+++ b/packages/three-vrm-animation/package.json
@@ -23,8 +23,8 @@
   "exports": {
     ".": {
       "types": "./types/index.d.ts",
-      "import": "./lib/three-vrm-animation.module.min.js",
-      "require": "./lib/three-vrm-animation.min.cjs"
+      "import": "./lib/three-vrm-animation.module.js",
+      "require": "./lib/three-vrm-animation.cjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/three-vrm-core/package.json
+++ b/packages/three-vrm-core/package.json
@@ -23,8 +23,8 @@
   "exports": {
     ".": {
       "types": "./types/index.d.ts",
-      "import": "./lib/three-vrm-core.module.min.js",
-      "require": "./lib/three-vrm-core.min.cjs"
+      "import": "./lib/three-vrm-core.module.js",
+      "require": "./lib/three-vrm-core.cjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/three-vrm-materials-hdr-emissive-multiplier/package.json
+++ b/packages/three-vrm-materials-hdr-emissive-multiplier/package.json
@@ -23,8 +23,8 @@
   "exports": {
     ".": {
       "types": "./types/index.d.ts",
-      "import": "./lib/three-vrm-materials-hdr-emissive-multiplier.module.min.js",
-      "require": "./lib/three-vrm-materials-hdr-emissive-multiplier.min.cjs"
+      "import": "./lib/three-vrm-materials-hdr-emissive-multiplier.module.js",
+      "require": "./lib/three-vrm-materials-hdr-emissive-multiplier.cjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/three-vrm-materials-mtoon/package.json
+++ b/packages/three-vrm-materials-mtoon/package.json
@@ -23,8 +23,8 @@
   "exports": {
     ".": {
       "types": "./types/index.d.ts",
-      "import": "./lib/three-vrm-materials-mtoon.module.min.js",
-      "require": "./lib/three-vrm-materials-mtoon.min.cjs"
+      "import": "./lib/three-vrm-materials-mtoon.module.js",
+      "require": "./lib/three-vrm-materials-mtoon.cjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/three-vrm-materials-v0compat/package.json
+++ b/packages/three-vrm-materials-v0compat/package.json
@@ -23,8 +23,8 @@
   "exports": {
     ".": {
       "types": "./types/index.d.ts",
-      "import": "./lib/three-vrm-materials-v0compat.module.min.js",
-      "require": "./lib/three-vrm-materials-v0compat.min.cjs"
+      "import": "./lib/three-vrm-materials-v0compat.module.js",
+      "require": "./lib/three-vrm-materials-v0compat.cjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/three-vrm-node-constraint/package.json
+++ b/packages/three-vrm-node-constraint/package.json
@@ -23,8 +23,8 @@
   "exports": {
     ".": {
       "types": "./types/index.d.ts",
-      "import": "./lib/three-vrm-node-constraint.module.min.js",
-      "require": "./lib/three-vrm-node-constraint.min.cjs"
+      "import": "./lib/three-vrm-node-constraint.module.js",
+      "require": "./lib/three-vrm-node-constraint.cjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/three-vrm-springbone/package.json
+++ b/packages/three-vrm-springbone/package.json
@@ -23,8 +23,8 @@
   "exports": {
     ".": {
       "types": "./types/index.d.ts",
-      "import": "./lib/three-vrm-springbone.module.min.js",
-      "require": "./lib/three-vrm-springbone.min.cjs"
+      "import": "./lib/three-vrm-springbone.module.js",
+      "require": "./lib/three-vrm-springbone.cjs"
     },
     "./package.json": "./package.json"
   },

--- a/packages/three-vrm/package.json
+++ b/packages/three-vrm/package.json
@@ -23,8 +23,8 @@
   "exports": {
     ".": {
       "types": "./types/index.d.ts",
-      "import": "./lib/three-vrm.module.min.js",
-      "require": "./lib/three-vrm.min.cjs"
+      "import": "./lib/three-vrm.module.js",
+      "require": "./lib/three-vrm.cjs"
     },
     "./package.json": "./package.json"
   },


### PR DESCRIPTION
Revert exports to unminified build. 
By exporting minified build entries it may reduce bundle size and build speed for certain client setup, but it will drop sourcemap and break current dev flow.
For now `.min.{js,cjs}` files can only be consumed via CDN.
IMO, it's more common to avoid mutiple dev server but doing that is out-of-scope for v3.

