### PR TITLE
docs: Add doc comments and README descriptions about WebGPU MToon stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,9 @@ loader.load(
 Starting from v3, we provide [WebGPURenderer](https://github.com/mrdoob/three.js/blob/master/examples/jsm/renderers/webgpu/WebGPURenderer.js) compatibility.
 To use three-vrm with WebGPURenderer, specify the WebGPU-compatible `MToonNodeMaterialLoaderPlugin` for the `mtoonMaterialPlugin` option of `VRMLoaderPlugin`.
 
+`MToonNodeMaterial` only supports Three.js r161 or later.
+The NodeMaterial system of Three.js is still under development, so we may break compatibility with older versions of Three.js more frequently than other parts of three-vrm.
+
 ```js
 import { VRMLoaderPlugin, MToonNodeMaterialLoaderPlugin } from '@pixiv/three-vrm';
 

--- a/README.md
+++ b/README.md
@@ -14,16 +14,6 @@ Use [VRM](https://vrm.dev/) on [three.js](https://threejs.org/)
 
 [API Reference](https://pixiv.github.io/three-vrm/packages/three-vrm/docs)
 
-## v1
-
-**three-vrm v1 has been released!**
-
-three-vrm v1 supports [VRM1.0](https://vrm.dev/vrm1/), which is a new version of VRM format (the previous version of VRM is also supported, don't worry!).
-It also adopts the GLTFLoader plugin system which is a relatively new feature of GLTFLoader.
-
-There are a lot of breaking changes!
-See [the migration guide](https://github.com/pixiv/three-vrm/blob/dev/docs/migration-guide-1.0.md) for more info.
-
 ## How to Use
 
 ### from HTML
@@ -136,6 +126,32 @@ loader.load(
   // called when loading has errors
   (error) => console.error(error),
 );
+```
+
+### Use with WebGPURenderer
+
+Starting from v3, we provide a WebGPURenderer compatibility.
+For now, in order to use with WebGPURenderer, you need to specify a WebGPU compatible MToon loader plugin to the option `mtoonMaterialPlugin` of `VRMLoaderPlugin`.
+
+```js
+import { VRMLoaderPlugin, MToonNodeMaterialLoaderPlugin } from '@pixiv/three-vrm';
+
+// ...
+
+// Register a VRMLoaderPlugin
+loader.register((parser) => {
+
+  // create a WebGPU compatible MToon loader plugin
+  const mtoonMaterialPlugin = new MToonNodeMaterialLoaderPlugin(parser);
+
+  return new VRMLoaderPlugin(parser, {
+
+    // Specify the MToon loader plugin to use in the VRMLoaderPlugin instance
+    mtoonMaterialPlugin,
+
+  });
+
+});
 ```
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -130,8 +130,8 @@ loader.load(
 
 ### Use with WebGPURenderer
 
-Starting from v3, we provide a WebGPURenderer compatibility.
-For now, in order to use with WebGPURenderer, you need to specify a WebGPU compatible MToon loader plugin to the option `mtoonMaterialPlugin` of `VRMLoaderPlugin`.
+Starting from v3, we provide [WebGPURenderer](https://github.com/mrdoob/three.js/blob/master/examples/jsm/renderers/webgpu/WebGPURenderer.js) compatibility.
+To use three-vrm with WebGPURenderer, specify the WebGPU-compatible `MToonNodeMaterialLoaderPlugin` for the `mtoonMaterialPlugin` option of `VRMLoaderPlugin`.
 
 ```js
 import { VRMLoaderPlugin, MToonNodeMaterialLoaderPlugin } from '@pixiv/three-vrm';

--- a/packages/three-vrm-materials-mtoon/README.md
+++ b/packages/three-vrm-materials-mtoon/README.md
@@ -10,9 +10,11 @@ MToon (toon material) module for @pixiv/three-vrm
 
 ## WebGPU Support
 
-This module supports [WebGPURenderer](https://github.com/mrdoob/three.js/blob/master/examples/jsm/renderers/webgpu/WebGPURenderer.js).
+Starting from v3, we provide [WebGPURenderer](https://github.com/mrdoob/three.js/blob/master/examples/jsm/renderers/webgpu/WebGPURenderer.js) compatibility.
+To use three-vrm with WebGPURenderer, specify the WebGPU-compatible `MToonNodeMaterialLoaderPlugin` for the `mtoonMaterialPlugin` option of `VRMLoaderPlugin`.
 
-To use MToon with `VRMLoaderPlugin` in WebGPURenderer, specify the WebGPU-compatible `MToonNodeMaterialLoaderPlugin` for the `mtoonMaterialPlugin` option of `VRMLoaderPlugin`.
+`MToonNodeMaterial` only supports Three.js r161 or later.
+The NodeMaterial system of Three.js is still under development, so we may break compatibility with older versions of Three.js more frequently than other parts of three-vrm.
 
 ```js
 import { VRMLoaderPlugin, MToonNodeMaterialLoaderPlugin } from '@pixiv/three-vrm';

--- a/packages/three-vrm-materials-mtoon/README.md
+++ b/packages/three-vrm-materials-mtoon/README.md
@@ -12,7 +12,7 @@ MToon (toon material) module for @pixiv/three-vrm
 
 This module supports [WebGPURenderer](https://github.com/mrdoob/three.js/blob/master/examples/jsm/renderers/webgpu/WebGPURenderer.js).
 
-To use with `VRMLoaderPlugin`, you need to specify a `MToonNodeMaterialLoaderPlugin` to the option `mtoonMaterialPlugin` of `VRMLoaderPlugin`.
+To use MToon with `VRMLoaderPlugin` in WebGPURenderer, specify the WebGPU-compatible `MToonNodeMaterialLoaderPlugin` for the `mtoonMaterialPlugin` option of `VRMLoaderPlugin`.
 
 ```js
 import { VRMLoaderPlugin, MToonNodeMaterialLoaderPlugin } from '@pixiv/three-vrm';

--- a/packages/three-vrm-materials-mtoon/README.md
+++ b/packages/three-vrm-materials-mtoon/README.md
@@ -7,3 +7,30 @@ MToon (toon material) module for @pixiv/three-vrm
 [Examples](https://pixiv.github.io/three-vrm/packages/three-vrm-materials-mtoon/examples)
 
 [Documentation](https://pixiv.github.io/three-vrm/packages/three-vrm-materials-mtoon/docs)
+
+## WebGPU Support
+
+This module supports [WebGPURenderer](https://github.com/mrdoob/three.js/blob/master/examples/jsm/renderers/webgpu/WebGPURenderer.js).
+
+To use with `VRMLoaderPlugin`, you need to specify a `MToonNodeMaterialLoaderPlugin` to the option `mtoonMaterialPlugin` of `VRMLoaderPlugin`.
+
+```js
+import { VRMLoaderPlugin, MToonNodeMaterialLoaderPlugin } from '@pixiv/three-vrm';
+
+// ...
+
+// Register a VRMLoaderPlugin
+loader.register((parser) => {
+
+  // create a WebGPU compatible MToon loader plugin
+  const mtoonMaterialPlugin = new MToonNodeMaterialLoaderPlugin(parser);
+
+  return new VRMLoaderPlugin(parser, {
+
+    // Specify the MToon loader plugin to use in the VRMLoaderPlugin instance
+    mtoonMaterialPlugin,
+
+  });
+
+});
+```

--- a/packages/three-vrm-materials-mtoon/src/MToonMaterialLoaderPlugin.ts
+++ b/packages/three-vrm-materials-mtoon/src/MToonMaterialLoaderPlugin.ts
@@ -8,7 +8,7 @@ import { MToonMaterialLoaderPluginOptions } from './MToonMaterialLoaderPluginOpt
 import type { MToonMaterialDebugMode } from './MToonMaterialDebugMode';
 import { GLTF as GLTFSchema } from '@gltf-transform/core';
 import { MToonMaterial } from './MToonMaterial';
-import { MToonNodeMaterialLoaderPlugin } from './nodes/MToonNodeMaterialLoaderPlugin';
+import type { MToonNodeMaterialLoaderPlugin } from './nodes/MToonNodeMaterialLoaderPlugin';
 
 /**
  * Possible spec versions it recognizes.

--- a/packages/three-vrm-materials-mtoon/src/MToonMaterialLoaderPlugin.ts
+++ b/packages/three-vrm-materials-mtoon/src/MToonMaterialLoaderPlugin.ts
@@ -1,6 +1,6 @@
 import * as THREE from 'three';
 import * as V1MToonSchema from '@pixiv/types-vrmc-materials-mtoon-1.0';
-import type { GLTF, GLTFLoaderPlugin, GLTFParser } from 'three/examples/jsm/loaders/GLTFLoader.js';
+import type { GLTF, GLTFLoader, GLTFLoaderPlugin, GLTFParser } from 'three/examples/jsm/loaders/GLTFLoader.js';
 import type { MToonMaterialParameters } from './MToonMaterialParameters';
 import { MToonMaterialOutlineWidthMode } from './MToonMaterialOutlineWidthMode';
 import { GLTFMToonMaterialParamsAssignHelper } from './GLTFMToonMaterialParamsAssignHelper';
@@ -8,12 +8,19 @@ import { MToonMaterialLoaderPluginOptions } from './MToonMaterialLoaderPluginOpt
 import type { MToonMaterialDebugMode } from './MToonMaterialDebugMode';
 import { GLTF as GLTFSchema } from '@gltf-transform/core';
 import { MToonMaterial } from './MToonMaterial';
+import { MToonNodeMaterialLoaderPlugin } from './nodes/MToonNodeMaterialLoaderPlugin';
 
 /**
  * Possible spec versions it recognizes.
  */
 const POSSIBLE_SPEC_VERSIONS = new Set(['1.0', '1.0-beta']);
 
+/**
+ * A loader plugin of {@link GLTFLoader} for the extension `VRMC_materials_mtoon`.
+ *
+ * This plugin is for uses with WebGLRenderer.
+ * To use MToon in WebGPURenderer, use {@link MToonNodeMaterialLoaderPlugin} instead.
+ */
 export class MToonMaterialLoaderPlugin implements GLTFLoaderPlugin {
   public static EXTENSION_NAME = 'VRMC_materials_mtoon';
 

--- a/packages/three-vrm-materials-mtoon/src/MToonMaterialLoaderPluginOptions.ts
+++ b/packages/three-vrm-materials-mtoon/src/MToonMaterialLoaderPluginOptions.ts
@@ -2,8 +2,8 @@ import type { MToonMaterialDebugMode } from './MToonMaterialDebugMode';
 
 export interface MToonMaterialLoaderPluginOptions {
   /**
-   * This value will be added to every meshes who have MaterialsMToon.
-   * The final renderOrder will be sum of this `renderOrderOffset` and `renderQueueOffsetNumber` for each materials.
+   * This value will be added to `renderOrder` of every meshes who have MToonMaterial.
+   * The final `renderOrder` will be sum of this `renderOrderOffset` and `renderQueueOffsetNumber` for each materials.
    * `0` by default.
    */
   renderOrderOffset?: number;

--- a/packages/three-vrm-materials-mtoon/src/nodes/MToonNodeMaterial.ts
+++ b/packages/three-vrm-materials-mtoon/src/nodes/MToonNodeMaterial.ts
@@ -1,6 +1,7 @@
 import * as THREE from 'three';
 import * as Nodes from 'three/addons/nodes/Nodes.js';
 
+import type { MToonMaterial } from '../MToonMaterial';
 import { MToonLightingModel } from './MToonLightingModel';
 import {
   rimLightingMix,
@@ -43,6 +44,14 @@ import { mtoonParametricRim } from './mtoonParametricRim';
 // import phongLightingModel from 'three/addons/nodes/functions/PhongLightingModel.js';
 // import { float } from '../shadernode/ShaderNode.js';
 
+/**
+ * MToon is a material specification that has various features.
+ * The spec and implementation are originally founded for Unity engine and this is a port of the material.
+ *
+ * This material is a NodeMaterial variant of {@link MToonMaterial}.
+ *
+ * See: https://github.com/Santarh/MToon
+ */
 export class MToonNodeMaterial extends Nodes.NodeMaterial {
   public emissiveNode: Nodes.ShaderNodeObject<Nodes.Node> | null;
 

--- a/packages/three-vrm-materials-mtoon/src/nodes/MToonNodeMaterialLoaderPlugin.ts
+++ b/packages/three-vrm-materials-mtoon/src/nodes/MToonNodeMaterialLoaderPlugin.ts
@@ -1,11 +1,40 @@
-import * as THREE from 'three';
+import type * as THREE from 'three';
 import type { GLTFParser } from 'three/examples/jsm/loaders/GLTFLoader';
 import { MToonMaterialLoaderPlugin } from '../MToonMaterialLoaderPlugin';
-import type { MToonMaterialLoaderPluginOptions } from '../MToonMaterialLoaderPluginOptions';
 import { MToonNodeMaterial } from './MToonNodeMaterial';
+import type { MToonNodeMaterialLoaderPluginOptions } from './MToonNodeMaterialLoaderPluginOptions';
 
+/**
+ * A loader plugin of {@link GLTFLoader} for the extension `VRMC_materials_mtoon`.
+ *
+ * This plugin is for uses with WebGPURenderer.
+ * To use MToon in WebGLRenderer, use {@link MToonMaterialLoaderPlugin} instead.
+ *
+ * @example Usage with VRMLoaderPlugin
+ *
+ * ```js
+ * import { VRMLoaderPlugin, MToonNodeMaterialLoaderPlugin } from '@pixiv/three-vrm';
+ *
+ * // ...
+ *
+ * // Register a VRMLoaderPlugin
+ * loader.register((parser) => {
+ *
+ *   // create a WebGPU compatible MToon loader plugin
+ *   const mtoonMaterialPlugin = new MToonNodeMaterialLoaderPlugin(parser);
+ *
+ *   return new VRMLoaderPlugin(parser, {
+ *
+ *     // Specify the MToon loader plugin to use in the VRMLoaderPlugin instance
+ *     mtoonMaterialPlugin,
+ *
+ *   });
+ *
+ * });
+ * ```
+ */
 export class MToonNodeMaterialLoaderPlugin extends MToonMaterialLoaderPlugin {
-  public constructor(parser: GLTFParser, options: MToonMaterialLoaderPluginOptions = {}) {
+  public constructor(parser: GLTFParser, options: MToonNodeMaterialLoaderPluginOptions = {}) {
     super(parser, options);
   }
 

--- a/packages/three-vrm-materials-mtoon/src/nodes/MToonNodeMaterialLoaderPluginOptions.ts
+++ b/packages/three-vrm-materials-mtoon/src/nodes/MToonNodeMaterialLoaderPluginOptions.ts
@@ -1,0 +1,8 @@
+export interface MToonNodeMaterialLoaderPluginOptions {
+  /**
+   * This value will be added to `renderOrder` of every meshes who have MToonNodeMaterial.
+   * The final `renderOrder` will be sum of this `renderOrderOffset` and `renderQueueOffsetNumber` for each materials.
+   * `0` by default.
+   */
+  renderOrderOffset?: number;
+}

--- a/packages/three-vrm/README.md
+++ b/packages/three-vrm/README.md
@@ -133,6 +133,9 @@ loader.load(
 Starting from v3, we provide [WebGPURenderer](https://github.com/mrdoob/three.js/blob/master/examples/jsm/renderers/webgpu/WebGPURenderer.js) compatibility.
 To use three-vrm with WebGPURenderer, specify the WebGPU-compatible `MToonNodeMaterialLoaderPlugin` for the `mtoonMaterialPlugin` option of `VRMLoaderPlugin`.
 
+`MToonNodeMaterial` only supports Three.js r161 or later.
+The NodeMaterial system of Three.js is still under development, so we may break compatibility with older versions of Three.js more frequently than other parts of three-vrm.
+
 ```js
 import { VRMLoaderPlugin, MToonNodeMaterialLoaderPlugin } from '@pixiv/three-vrm';
 

--- a/packages/three-vrm/README.md
+++ b/packages/three-vrm/README.md
@@ -14,16 +14,6 @@ Use [VRM](https://vrm.dev/) on [three.js](https://threejs.org/)
 
 [API Reference](https://pixiv.github.io/three-vrm/packages/three-vrm/docs)
 
-## v1
-
-**three-vrm v1 has been released!**
-
-three-vrm v1 supports [VRM1.0](https://vrm.dev/vrm1/), which is a new version of VRM format (the previous version of VRM is also supported, don't worry!).
-It also adopts the GLTFLoader plugin system which is a relatively new feature of GLTFLoader.
-
-There are a lot of breaking changes!
-See [the migration guide](https://github.com/pixiv/three-vrm/blob/dev/docs/migration-guide-1.0.md) for more info.
-
 ## How to Use
 
 ### from HTML
@@ -136,6 +126,32 @@ loader.load(
   // called when loading has errors
   (error) => console.error(error),
 );
+```
+
+### Use with WebGPURenderer
+
+Starting from v3, we provide a WebGPURenderer compatibility.
+For now, in order to use with WebGPURenderer, you need to specify a WebGPU compatible MToon loader plugin to the option `mtoonMaterialPlugin` of `VRMLoaderPlugin`.
+
+```js
+import { VRMLoaderPlugin, MToonNodeMaterialLoaderPlugin } from '@pixiv/three-vrm';
+
+// ...
+
+// Register a VRMLoaderPlugin
+loader.register((parser) => {
+
+  // create a WebGPU compatible MToon loader plugin
+  const mtoonMaterialPlugin = new MToonNodeMaterialLoaderPlugin(parser);
+
+  return new VRMLoaderPlugin(parser, {
+
+    // Specify the MToon loader plugin to use in the VRMLoaderPlugin instance
+    mtoonMaterialPlugin,
+
+  });
+
+});
 ```
 
 ## Contributing

--- a/packages/three-vrm/README.md
+++ b/packages/three-vrm/README.md
@@ -130,8 +130,8 @@ loader.load(
 
 ### Use with WebGPURenderer
 
-Starting from v3, we provide a WebGPURenderer compatibility.
-For now, in order to use with WebGPURenderer, you need to specify a WebGPU compatible MToon loader plugin to the option `mtoonMaterialPlugin` of `VRMLoaderPlugin`.
+Starting from v3, we provide [WebGPURenderer](https://github.com/mrdoob/three.js/blob/master/examples/jsm/renderers/webgpu/WebGPURenderer.js) compatibility.
+To use three-vrm with WebGPURenderer, specify the WebGPU-compatible `MToonNodeMaterialLoaderPlugin` for the `mtoonMaterialPlugin` option of `VRMLoaderPlugin`.
 
 ```js
 import { VRMLoaderPlugin, MToonNodeMaterialLoaderPlugin } from '@pixiv/three-vrm';


### PR DESCRIPTION
Changes of imports in this PR are all type imports and only used for doc comments

I have to add support for v0CompatShade to the WebGPU one later

I think it's high time to remove the v1 notice on the root README

I thought that we could specify more simpler option like `nodeMaterial: true` to the option of `VRMLoaderPlugin` while writing these docs

### Points need review

- [ ] Do you think it's easy to follow when you try to use three-vrm in WebGPURenderer?
