### PR TITLE
fix: re-enable thumbnail loading in examples

### DIFF
--- a/packages/three-vrm-core/examples/meta.html
+++ b/packages/three-vrm-core/examples/meta.html
@@ -79,7 +79,10 @@
 
 			loader.register( ( parser ) => {
 
-				return new VRMCoreLoaderPlugin( parser );
+				// enable thumbnail loading
+				const plugin = new VRMCoreLoaderPlugin( parser );
+				plugin.metaPlugin.needThumbnailImage = true;
+				return plugin;
 
 			} );
 

--- a/packages/three-vrm/examples/meta.html
+++ b/packages/three-vrm/examples/meta.html
@@ -78,7 +78,10 @@
 
 			loader.register( ( parser ) => {
 
-				return new VRMLoaderPlugin( parser );
+				// enable thumbnail loading
+				const plugin = new VRMLoaderPlugin( parser );
+				plugin.metaPlugin.needThumbnailImage = true;
+				return plugin;
 
 			} );
 


### PR DESCRIPTION
ref: https://github.com/pixiv/three-vrm/pull/1415
re-enable thumbnail loading in examples 