### PR TITLE
examples: sameBoneCounts -> experimentalSameBoneCounts

### DIFF
--- a/packages/three-vrm/examples/webgpu-dnd.html
+++ b/packages/three-vrm/examples/webgpu-dnd.html
@@ -98,7 +98,7 @@
 
 						// calling these functions greatly improves the performance
 						VRMUtils.removeUnnecessaryVertices( gltf.scene );
-						VRMUtils.removeUnnecessaryJoints( gltf.scene, { sameBoneCounts: true } );
+						VRMUtils.removeUnnecessaryJoints( gltf.scene, { experimentalSameBoneCounts: true } );
 
 						if ( currentVrm ) {
 

--- a/packages/three-vrm/src/VRMUtils/removeUnnecessaryJoints.ts
+++ b/packages/three-vrm/src/VRMUtils/removeUnnecessaryJoints.ts
@@ -1,9 +1,13 @@
 import * as THREE from 'three';
 
 /**
- * Traverse given object and remove unnecessarily bound joints from every `THREE.SkinnedMesh`.
- * Some environments like mobile devices have a lower limit of bones and might be unable to perform mesh skinning, this function might resolve such an issue.
- * Also this function might greatly improve the performance of mesh skinning.
+ * Traverse the given object and remove unnecessarily bound joints from every `THREE.SkinnedMesh`.
+ *
+ * Some environments like mobile devices have a lower limit of bones
+ * and might be unable to perform mesh skinning with many bones.
+ * This function might resolve such an issue.
+ *
+ * Also, this function might significantly improve the performance of mesh skinning.
  *
  * @param root Root object that will be traversed
  */
@@ -13,8 +17,10 @@ export function removeUnnecessaryJoints(
     /**
      * If `true`, this function will compensate skeletons with dummy bones to keep the bone count same between skeletons.
      *
-     * This option might be effective for the shader compilation performance that matters to the initial rendering time,
+     * This option might be effective for the shader compilation performance that matters to the initial rendering time in WebGPURenderer,
      * especially when the model loaded has many materials and the dependent bone count is different between them.
+     *
+     * Consider this parameter as experimental. We might modify or delete this API without notice in the future.
      *
      * `false` by default.
      */


### PR DESCRIPTION
- The property name `sameBoneCounts` is wrong in the example `webgpu-dnd.html`, it should be `experimentalSameBoneCounts`
- docs: Reword and improve the doc comment of removeUnnecessaryJoints and its option `experimentalSameBoneCounts`
