### PR TITLE
fix: restore alpha test workaround

### DIFF
--- a/packages/three-vrm-materials-mtoon/src/MToonMaterial.ts
+++ b/packages/three-vrm-materials-mtoon/src/MToonMaterial.ts
@@ -540,6 +540,13 @@ export class MToonMaterial extends THREE.ShaderMaterial {
     this.uniforms.uvAnimationScrollYOffset.value += delta * this.uvAnimationScrollYSpeedFactor;
     this.uniforms.uvAnimationRotationPhase.value += delta * this.uvAnimationRotationSpeedFactor;
 
+    // COMPAT workaround: starting from r132, alphaTest becomes a uniform instead of preprocessor value
+    const threeRevision = parseInt(THREE.REVISION, 10);
+
+    if (threeRevision >= 132) {
+      this.uniforms.alphaTest.value = this.alphaTest;
+    }
+
     this.uniformsNeedUpdate = true;
   }
 

--- a/packages/three-vrm-materials-mtoon/src/MToonMaterial.ts
+++ b/packages/three-vrm-materials-mtoon/src/MToonMaterial.ts
@@ -539,13 +539,7 @@ export class MToonMaterial extends THREE.ShaderMaterial {
     this.uniforms.uvAnimationScrollXOffset.value += delta * this.uvAnimationScrollXSpeedFactor;
     this.uniforms.uvAnimationScrollYOffset.value += delta * this.uvAnimationScrollYSpeedFactor;
     this.uniforms.uvAnimationRotationPhase.value += delta * this.uvAnimationRotationSpeedFactor;
-
-    // COMPAT workaround: starting from r132, alphaTest becomes a uniform instead of preprocessor value
-    const threeRevision = parseInt(THREE.REVISION, 10);
-
-    if (threeRevision >= 132) {
-      this.uniforms.alphaTest.value = this.alphaTest;
-    }
+    this.uniforms.alphaTest.value = this.alphaTest;
 
     this.uniformsNeedUpdate = true;
   }


### PR DESCRIPTION
Revert changes in https://github.com/pixiv/three-vrm/pull/1428/files#diff-e2dae1fd189076ccced184108018ba54632410b52ef00fe0f6bbc43673ef6733L590-L596

Since we only supports r137+ so the version check is redundant.