### PR TITLE
feat: VRMAnimation, emit a warning if the rest hips potision is approximately zero

### DIFF
--- a/packages/three-vrm-animation/src/VRMAnimationLoaderPlugin.ts
+++ b/packages/three-vrm-animation/src/VRMAnimationLoaderPlugin.ts
@@ -77,6 +77,14 @@ export class VRMAnimationLoaderPlugin implements GLTFLoaderPlugin {
     const restHipsPosition = new THREE.Vector3();
     hips?.getWorldPosition(restHipsPosition);
 
+    // If the rest hips position is approximately zero,
+    // it is considered that the animation violates the VRM T-pose
+    if (restHipsPosition.lengthSq() < 1e-6) {
+      console.warn(
+        'VRMAnimationLoaderPlugin: The loaded VRM Animation violates the VRM T-pose (The rest hips position is approximately zero.)',
+      );
+    }
+
     const clips = gltf.animations;
     const animations: VRMAnimation[] = clips.map((clip, iAnimation) => {
       const defAnimation = defGltf.animations![iAnimation];


### PR DESCRIPTION
VRMAnimationLoaderPlugin now emits a warning if the rest hips potision is approximately zero.

The animation violates the VRM T-pose the hips potision is approximately zero.

Based on the spec: https://github.com/vrm-c/vrm-specification/tree/master/specification/VRMC_vrm_animation-1.0#humanoid