### PR TITLE
Fix humanoidAnimation example

### DIFF
--- a/packages/three-vrm/examples/humanoidAnimation/main.js
+++ b/packages/three-vrm/examples/humanoidAnimation/main.js
@@ -110,6 +110,7 @@ function loadFBX( animationUrl ) {
 
 	currentAnimationUrl = animationUrl;
 
+	currentVrm.humanoid.resetNormalizedPose();
 	// create AnimationMixer for VRM
 	currentMixer = new THREE.AnimationMixer( currentVrm.scene );
 


### PR DESCRIPTION
Fix issue #1447.

When additional motion was loaded, the root motion was out of alignment.