### PR TITLE
examples: examples: `sameBoneCounts` -> `experimentalSameBoneCounts`

### DIFF
--- a/packages/three-vrm/examples/webgpu-dnd.html
+++ b/packages/three-vrm/examples/webgpu-dnd.html
@@ -98,7 +98,7 @@
 
 						// calling these functions greatly improves the performance
 						VRMUtils.removeUnnecessaryVertices( gltf.scene );
-						VRMUtils.removeUnnecessaryJoints( gltf.scene, { sameBoneCounts: true } );
+						VRMUtils.removeUnnecessaryJoints( gltf.scene, { experimentalSameBoneCounts: true } );
 
 						if ( currentVrm ) {
 


### PR DESCRIPTION
redo of https://github.com/pixiv/three-vrm/pull/1438/commits/b4a3bb130ddcaafb899112866cd1c8a7a5b77c67, I don't know why the change reverted