### PR TITLE
examples: Fix jsdelivr three-vrm version on three-vrm-animation examples

### DIFF
--- a/packages/three-vrm-animation/examples/dnd.html
+++ b/packages/three-vrm-animation/examples/dnd.html
@@ -24,7 +24,7 @@
 				"imports": {
 					"three": "https://cdn.jsdelivr.net/npm/three@0.167.0/build/three.module.js",
 					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.167.0/examples/jsm/",
-					"@pixiv/three-vrm": "https://cdn.jsdelivr.net/npm/@pixiv/three-vrm@2.1.0/lib/three-vrm.module.js",
+					"@pixiv/three-vrm": "https://cdn.jsdelivr.net/npm/@pixiv/three-vrm@3/lib/three-vrm.module.js",
 					"@pixiv/three-vrm-animation": "../lib/three-vrm-animation.module.js"
 				}
 			}

--- a/packages/three-vrm-animation/examples/loader-plugin.html
+++ b/packages/three-vrm-animation/examples/loader-plugin.html
@@ -24,7 +24,7 @@
 				"imports": {
 					"three": "https://cdn.jsdelivr.net/npm/three@0.167.0/build/three.module.js",
 					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.167.0/examples/jsm/",
-					"@pixiv/three-vrm": "https://cdn.jsdelivr.net/npm/@pixiv/three-vrm@2.1.0/lib/three-vrm.module.js",
+					"@pixiv/three-vrm": "https://cdn.jsdelivr.net/npm/@pixiv/three-vrm@3/lib/three-vrm.module.js",
 					"@pixiv/three-vrm-animation": "../lib/three-vrm-animation.module.js"
 				}
 			}


### PR DESCRIPTION
Following the README.md code, changed from `2.1.0` to `3`
