### PR TITLE
chore: promote extended collider specVersion from `1.0-draft` to `1.0`

### DIFF
--- a/packages/three-vrm-springbone/examples/models/inside-collider.gltf
+++ b/packages/three-vrm-springbone/examples/models/inside-collider.gltf
@@ -304,7 +304,7 @@
           },
           "extensions": {
             "VRMC_springBone_extended_collider": {
-              "specVersion": "1.0-draft",
+              "specVersion": "1.0",
               "shape": {
                 "sphere": {
                   "radius": 1.25,

--- a/packages/three-vrm-springbone/examples/models/plane-collider.gltf
+++ b/packages/three-vrm-springbone/examples/models/plane-collider.gltf
@@ -374,7 +374,7 @@
           },
           "extensions": {
             "VRMC_springBone_extended_collider": {
-              "specVersion": "1.0-draft",
+              "specVersion": "1.0",
               "shape": {
                 "plane": {
                   "normal": [

--- a/packages/three-vrm-springbone/src/VRMSpringBoneLoaderPlugin.ts
+++ b/packages/three-vrm-springbone/src/VRMSpringBoneLoaderPlugin.ts
@@ -25,7 +25,7 @@ const POSSIBLE_SPEC_VERSIONS = new Set(['1.0', '1.0-beta']);
 /**
  * Possible spec versions of `VRMC_springBone_extended_collider` it recognizes.
  */
-const POSSIBLE_SPEC_VERSIONS_EXTENDED_COLLIDERS = new Set(['1.0-draft']);
+const POSSIBLE_SPEC_VERSIONS_EXTENDED_COLLIDERS = new Set(['1.0']);
 
 export class VRMSpringBoneLoaderPlugin implements GLTFLoaderPlugin {
   public static readonly EXTENSION_NAME = 'VRMC_springBone';

--- a/packages/types-vrmc-springbone-extended-collider-1.0/types/VRMCSpringBoneExtendedCollider.d.ts
+++ b/packages/types-vrmc-springbone-extended-collider-1.0/types/VRMCSpringBoneExtendedCollider.d.ts
@@ -7,7 +7,7 @@ export interface VRMCSpringBoneExtendedCollider {
   /**
    * Specification version of VRMC_springBone_extended_collider.
    */
-  specVersion: '1.0-draft';
+  specVersion: '1.0';
 
   /**
    * The shape of the collider.


### PR DESCRIPTION
This PR applies the promotion of `VRMC_springBone_extended_collider` from `1.0-draft` to `1.0`.

See: https://github.com/vrm-c/vrm-specification/pull/482