### PR TITLE
deps: Bump prettier to v3.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "jest": "^29.7.0",
     "lerna": "^6.6.2",
     "lint-staged": "^15.1.0",
-    "prettier": "^2.1.2",
+    "prettier": "^3.3.3",
     "rimraf": "^6.0.1",
     "ts-jest": "^29.1.2",
     "ts-node": "^10.9.2",

--- a/packages/three-vrm-core/src/expressions/VRMExpressionMaterialColorType.ts
+++ b/packages/three-vrm-core/src/expressions/VRMExpressionMaterialColorType.ts
@@ -10,7 +10,7 @@ export const VRMExpressionMaterialColorType = {
 } as const;
 
 export type VRMExpressionMaterialColorType =
-  typeof VRMExpressionMaterialColorType[keyof typeof VRMExpressionMaterialColorType];
+  (typeof VRMExpressionMaterialColorType)[keyof typeof VRMExpressionMaterialColorType];
 
 export const v0ExpressionMaterialColorMap: { [key: string]: VRMExpressionMaterialColorType | undefined } = {
   _Color: VRMExpressionMaterialColorType.Color,

--- a/packages/three-vrm-core/src/expressions/VRMExpressionOverrideType.ts
+++ b/packages/three-vrm-core/src/expressions/VRMExpressionOverrideType.ts
@@ -6,4 +6,4 @@ export const VRMExpressionOverrideType = {
   Blend: 'blend',
 } as const;
 
-export type VRMExpressionOverrideType = typeof VRMExpressionOverrideType[keyof typeof VRMExpressionOverrideType];
+export type VRMExpressionOverrideType = (typeof VRMExpressionOverrideType)[keyof typeof VRMExpressionOverrideType];

--- a/packages/three-vrm-core/src/expressions/VRMExpressionPresetName.ts
+++ b/packages/three-vrm-core/src/expressions/VRMExpressionPresetName.ts
@@ -21,4 +21,4 @@ export const VRMExpressionPresetName = {
   Neutral: 'neutral',
 } as const;
 
-export type VRMExpressionPresetName = typeof VRMExpressionPresetName[keyof typeof VRMExpressionPresetName];
+export type VRMExpressionPresetName = (typeof VRMExpressionPresetName)[keyof typeof VRMExpressionPresetName];

--- a/packages/three-vrm-core/src/firstPerson/VRMFirstPersonMeshAnnotationType.ts
+++ b/packages/three-vrm-core/src/firstPerson/VRMFirstPersonMeshAnnotationType.ts
@@ -8,4 +8,4 @@ export const VRMFirstPersonMeshAnnotationType = {
 } as const;
 
 export type VRMFirstPersonMeshAnnotationType =
-  typeof VRMFirstPersonMeshAnnotationType[keyof typeof VRMFirstPersonMeshAnnotationType];
+  (typeof VRMFirstPersonMeshAnnotationType)[keyof typeof VRMFirstPersonMeshAnnotationType];

--- a/packages/three-vrm-core/src/humanoid/VRMHumanBoneName.ts
+++ b/packages/three-vrm-core/src/humanoid/VRMHumanBoneName.ts
@@ -70,4 +70,4 @@ export const VRMHumanBoneName = {
   RightLittleDistal: 'rightLittleDistal',
 } as const;
 
-export type VRMHumanBoneName = typeof VRMHumanBoneName[keyof typeof VRMHumanBoneName];
+export type VRMHumanBoneName = (typeof VRMHumanBoneName)[keyof typeof VRMHumanBoneName];

--- a/packages/three-vrm-core/src/humanoid/VRMRequiredHumanBoneName.ts
+++ b/packages/three-vrm-core/src/humanoid/VRMRequiredHumanBoneName.ts
@@ -18,4 +18,4 @@ export const VRMRequiredHumanBoneName = {
   RightHand: 'rightHand',
 } as const;
 
-export type VRMRequiredHumanBoneName = typeof VRMRequiredHumanBoneName[keyof typeof VRMRequiredHumanBoneName];
+export type VRMRequiredHumanBoneName = (typeof VRMRequiredHumanBoneName)[keyof typeof VRMRequiredHumanBoneName];

--- a/packages/three-vrm-core/src/lookAt/VRMLookAtTypeName.ts
+++ b/packages/three-vrm-core/src/lookAt/VRMLookAtTypeName.ts
@@ -8,4 +8,4 @@ export const VRMLookAtTypeName = {
   Expression: 'expression',
 };
 
-export type VRMLookAtTypeName = typeof VRMLookAtTypeName[keyof typeof VRMLookAtTypeName];
+export type VRMLookAtTypeName = (typeof VRMLookAtTypeName)[keyof typeof VRMLookAtTypeName];

--- a/packages/three-vrm-materials-mtoon/src/MToonMaterialDebugMode.ts
+++ b/packages/three-vrm-materials-mtoon/src/MToonMaterialDebugMode.ts
@@ -27,4 +27,4 @@ export const MToonMaterialDebugMode = {
   UV: 'uv',
 } as const;
 
-export type MToonMaterialDebugMode = typeof MToonMaterialDebugMode[keyof typeof MToonMaterialDebugMode];
+export type MToonMaterialDebugMode = (typeof MToonMaterialDebugMode)[keyof typeof MToonMaterialDebugMode];

--- a/packages/three-vrm-materials-mtoon/src/MToonMaterialOutlineWidthMode.ts
+++ b/packages/three-vrm-materials-mtoon/src/MToonMaterialOutlineWidthMode.ts
@@ -7,4 +7,4 @@ export const MToonMaterialOutlineWidthMode = {
 } as const;
 
 export type MToonMaterialOutlineWidthMode =
-  typeof MToonMaterialOutlineWidthMode[keyof typeof MToonMaterialOutlineWidthMode];
+  (typeof MToonMaterialOutlineWidthMode)[keyof typeof MToonMaterialOutlineWidthMode];

--- a/packages/three-vrm-materials-v0compat/src/VRMMaterialsV0CompatPlugin.ts
+++ b/packages/three-vrm-materials-v0compat/src/VRMMaterialsV0CompatPlugin.ts
@@ -88,7 +88,7 @@ export class VRMMaterialsV0CompatPlugin implements GLTFLoaderPlugin {
 
     const isCutoff = materialProperties.keywordMap?.['_ALPHATEST_ON'] ?? false;
     const alphaMode = isTransparent ? 'BLEND' : isCutoff ? 'MASK' : 'OPAQUE';
-    const alphaCutoff = isCutoff ? materialProperties.floatProperties?.['_Cutoff'] ?? 0.5 : undefined;
+    const alphaCutoff = isCutoff ? (materialProperties.floatProperties?.['_Cutoff'] ?? 0.5) : undefined;
 
     const cullMode = materialProperties.floatProperties?.['_CullMode'] ?? 2; // enum, { Off, Front, Back }
     const doubleSided = cullMode === 0;
@@ -210,7 +210,7 @@ export class VRMMaterialsV0CompatPlugin implements GLTFLoaderPlugin {
     );
     const outlineColorMode = materialProperties.floatProperties?.['_OutlineColorMode'] ?? 0; // enum, { Fixed, Mixed }
     const outlineLightingMixFactor =
-      outlineColorMode === 1 ? materialProperties.floatProperties?.['_OutlineLightingMix'] ?? 1.0 : 0.0;
+      outlineColorMode === 1 ? (materialProperties.floatProperties?.['_OutlineLightingMix'] ?? 1.0) : 0.0;
 
     const uvAnimationMaskTextureIndex = materialProperties.textureProperties?.['_UvAnimMaskTexture'];
     const uvAnimationMaskTexture =
@@ -291,7 +291,7 @@ export class VRMMaterialsV0CompatPlugin implements GLTFLoaderPlugin {
 
     const isCutoff = materialProperties.shader === 'VRM/UnlitCutout';
     const alphaMode = isTransparent ? 'BLEND' : isCutoff ? 'MASK' : 'OPAQUE';
-    const alphaCutoff = isCutoff ? materialProperties.floatProperties?.['_Cutoff'] ?? 0.5 : undefined;
+    const alphaCutoff = isCutoff ? (materialProperties.floatProperties?.['_Cutoff'] ?? 0.5) : undefined;
 
     const textureTransformExt = this._portTextureTransform(materialProperties);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5967,10 +5967,10 @@ prelude-ls@^1.2.1:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.2.1.tgz#debc6489d7a6e6b0e7611888cec880337d316396"
   integrity sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
 
-prettier@^2.1.2:
-  version "2.7.1"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.7.1.tgz#e235806850d057f97bb08368a4f7d899f7760c64"
-  integrity sha512-ujppO+MkdPqoVINuDFDRLClm7D78qbDt0/NR+wp5FqEZOoTNAjPHWj17QRhu7geIHJfcNhRk1XVQmF8Bp3ye+g==
+prettier@^3.3.3:
+  version "3.3.3"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.3.3.tgz#30c54fe0be0d8d12e6ae61dbb10109ea00d53105"
+  integrity sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==
 
 pretty-format@29.4.3:
   version "29.4.3"


### PR DESCRIPTION
This PR bumps prettier to v3.3.3.

This makes the existing code fail the lint so I also did `yarn lint-fix`

I'm happy with the new lint result; clarifying operator precedence by parenthesis is always good