### PR TITLE
deps: Bump Three.js to r169

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ You can import all the dependencies via CDN like [jsDelivr](https://www.jsdelivr
 <script type="importmap">
   {
     "imports": {
-      "three": "https://cdn.jsdelivr.net/npm/three@0.168.0/build/three.module.js",
-      "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.168.0/examples/jsm/",
+      "three": "https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.module.js",
+      "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.169.0/examples/jsm/",
       "@pixiv/three-vrm": "https://cdn.jsdelivr.net/npm/@pixiv/three-vrm@3/lib/three-vrm.module.min.js"
     }
   }

--- a/packages/three-vrm-animation/examples/dnd.html
+++ b/packages/three-vrm-animation/examples/dnd.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.168.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.168.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.169.0/examples/jsm/",
 					"@pixiv/three-vrm": "https://cdn.jsdelivr.net/npm/@pixiv/three-vrm@3/lib/three-vrm.module.js",
 					"@pixiv/three-vrm-animation": "../lib/three-vrm-animation.module.js"
 				}

--- a/packages/three-vrm-animation/examples/loader-plugin.html
+++ b/packages/three-vrm-animation/examples/loader-plugin.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.168.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.168.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.169.0/examples/jsm/",
 					"@pixiv/three-vrm": "https://cdn.jsdelivr.net/npm/@pixiv/three-vrm@3/lib/three-vrm.module.js",
 					"@pixiv/three-vrm-animation": "../lib/three-vrm-animation.module.js"
 				}

--- a/packages/three-vrm-animation/package.json
+++ b/packages/three-vrm-animation/package.json
@@ -52,9 +52,9 @@
     "@pixiv/types-vrmc-vrm-animation-1.0": "3.1.1"
   },
   "devDependencies": {
-    "@types/three": "^0.168.0",
+    "@types/three": "^0.169.0",
     "lint-staged": "15.2.10",
-    "three": "^0.168.0"
+    "three": "^0.169.0"
   },
   "peerDependencies": {
     "three": ">=0.137"

--- a/packages/three-vrm-core/examples/expressions.html
+++ b/packages/three-vrm-core/examples/expressions.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.168.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.168.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.169.0/examples/jsm/",
 					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/examples/firstPerson.html
+++ b/packages/three-vrm-core/examples/firstPerson.html
@@ -28,8 +28,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.168.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.168.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.169.0/examples/jsm/",
 					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/examples/humanoid.html
+++ b/packages/three-vrm-core/examples/humanoid.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.168.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.168.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.169.0/examples/jsm/",
 					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/examples/humanoidAnimation/index.html
+++ b/packages/three-vrm-core/examples/humanoidAnimation/index.html
@@ -34,8 +34,8 @@
 			{
 				"imports": {
 					"fflate": "https://cdn.jsdelivr.net/npm/fflate@0.7.4/esm/browser.js",
-					"three": "https://cdn.jsdelivr.net/npm/three@0.168.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.168.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.169.0/examples/jsm/",
 					"@pixiv/three-vrm-core": "../../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/examples/lookAt.html
+++ b/packages/three-vrm-core/examples/lookAt.html
@@ -28,8 +28,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.168.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.168.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.169.0/examples/jsm/",
 					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/examples/meta.html
+++ b/packages/three-vrm-core/examples/meta.html
@@ -35,8 +35,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.168.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.168.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.169.0/examples/jsm/",
 					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/package.json
+++ b/packages/three-vrm-core/package.json
@@ -55,8 +55,8 @@
     "@pixiv/types-vrmc-vrm-1.0": "3.1.1"
   },
   "devDependencies": {
-    "@types/three": "^0.168.0",
-    "three": "^0.168.0"
+    "@types/three": "^0.169.0",
+    "three": "^0.169.0"
   },
   "peerDependencies": {
     "three": ">=0.137"

--- a/packages/three-vrm-materials-hdr-emissive-multiplier/examples/loader-plugin.html
+++ b/packages/three-vrm-materials-hdr-emissive-multiplier/examples/loader-plugin.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.168.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.168.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.169.0/examples/jsm/",
 					"@pixiv/three-vrm-materials-hdr-emissive-multiplier": "../lib/three-vrm-materials-hdr-emissive-multiplier.module.js"
 				}
 			}

--- a/packages/three-vrm-materials-hdr-emissive-multiplier/package.json
+++ b/packages/three-vrm-materials-hdr-emissive-multiplier/package.json
@@ -53,8 +53,8 @@
     "@pixiv/types-vrmc-materials-hdr-emissive-multiplier-1.0": "3.1.1"
   },
   "devDependencies": {
-    "@types/three": "^0.168.0",
-    "three": "^0.168.0"
+    "@types/three": "^0.169.0",
+    "three": "^0.169.0"
   },
   "peerDependencies": {
     "three": ">=0.137"

--- a/packages/three-vrm-materials-mtoon/examples/emissive-strength.html
+++ b/packages/three-vrm-materials-mtoon/examples/emissive-strength.html
@@ -24,8 +24,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.168.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.168.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.169.0/examples/jsm/",
 					"@pixiv/three-vrm-materials-mtoon": "../lib/three-vrm-materials-mtoon.module.js"
 				}
 			}

--- a/packages/three-vrm-materials-mtoon/examples/feature-test.html
+++ b/packages/three-vrm-materials-mtoon/examples/feature-test.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.168.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.168.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.169.0/examples/jsm/",
 					"@pixiv/three-vrm-materials-mtoon": "../lib/three-vrm-materials-mtoon.module.js"
 				}
 			}

--- a/packages/three-vrm-materials-mtoon/examples/loader-plugin.html
+++ b/packages/three-vrm-materials-mtoon/examples/loader-plugin.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.168.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.168.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.169.0/examples/jsm/",
 					"@pixiv/three-vrm-materials-mtoon": "../lib/three-vrm-materials-mtoon.module.js"
 				}
 			}

--- a/packages/three-vrm-materials-mtoon/examples/webgpu-feature-test.html
+++ b/packages/three-vrm-materials-mtoon/examples/webgpu-feature-test.html
@@ -23,9 +23,9 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.168.0/build/three.webgpu.js",
-					"three/webgpu": "https://cdn.jsdelivr.net/npm/three@0.168.0/build/three.webgpu.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.168.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.webgpu.js",
+					"three/webgpu": "https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.webgpu.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.169.0/examples/jsm/",
 					"@pixiv/three-vrm-materials-mtoon": "../lib/three-vrm-materials-mtoon.module.js",
 					"@pixiv/three-vrm-materials-mtoon/nodes": "../lib/nodes/index.module.js"
 				}

--- a/packages/three-vrm-materials-mtoon/examples/webgpu-loader-plugin.html
+++ b/packages/three-vrm-materials-mtoon/examples/webgpu-loader-plugin.html
@@ -23,9 +23,9 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.168.0/build/three.webgpu.js",
-					"three/webgpu": "https://cdn.jsdelivr.net/npm/three@0.168.0/build/three.webgpu.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.168.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.webgpu.js",
+					"three/webgpu": "https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.webgpu.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.169.0/examples/jsm/",
 					"@pixiv/three-vrm-materials-mtoon": "../lib/three-vrm-materials-mtoon.module.js",
 					"@pixiv/three-vrm-materials-mtoon/nodes": "../lib/nodes/index.module.js"
 				}

--- a/packages/three-vrm-materials-mtoon/package.json
+++ b/packages/three-vrm-materials-mtoon/package.json
@@ -59,8 +59,8 @@
     "@pixiv/types-vrmc-materials-mtoon-1.0": "3.1.1"
   },
   "devDependencies": {
-    "@types/three": "^0.168.0",
-    "three": "^0.168.0"
+    "@types/three": "^0.169.0",
+    "three": "^0.169.0"
   },
   "peerDependencies": {
     "three": ">=0.137"

--- a/packages/three-vrm-materials-v0compat/package.json
+++ b/packages/three-vrm-materials-v0compat/package.json
@@ -50,8 +50,8 @@
     "@pixiv/types-vrmc-materials-mtoon-1.0": "3.1.1"
   },
   "devDependencies": {
-    "@types/three": "^0.168.0",
-    "three": "^0.168.0"
+    "@types/three": "^0.169.0",
+    "three": "^0.169.0"
   },
   "peerDependencies": {
     "three": ">=0.137"

--- a/packages/three-vrm-node-constraint/examples/aim.html
+++ b/packages/three-vrm-node-constraint/examples/aim.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.168.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.168.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.169.0/examples/jsm/",
 					"tweakpane": "https://cdn.jsdelivr.net/npm/tweakpane@3.0",
 					"tweakpane-plugin-rotation": "https://cdn.jsdelivr.net/npm/@0b5vr/tweakpane-plugin-rotation@0.1",
 					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"

--- a/packages/three-vrm-node-constraint/examples/importer.html
+++ b/packages/three-vrm-node-constraint/examples/importer.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.168.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.168.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.169.0/examples/jsm/",
 					"tweakpane": "https://cdn.jsdelivr.net/npm/tweakpane@3.0",
 					"tweakpane-plugin-rotation": "https://cdn.jsdelivr.net/npm/@0b5vr/tweakpane-plugin-rotation@0.1",
 					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"

--- a/packages/three-vrm-node-constraint/examples/roll.html
+++ b/packages/three-vrm-node-constraint/examples/roll.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.168.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.168.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.169.0/examples/jsm/",
 					"tweakpane": "https://cdn.jsdelivr.net/npm/tweakpane@3.0",
 					"tweakpane-plugin-rotation": "https://cdn.jsdelivr.net/npm/@0b5vr/tweakpane-plugin-rotation@0.1",
 					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"

--- a/packages/three-vrm-node-constraint/examples/rotation.html
+++ b/packages/three-vrm-node-constraint/examples/rotation.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.168.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.168.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.169.0/examples/jsm/",
 					"tweakpane": "https://cdn.jsdelivr.net/npm/tweakpane@3.0",
 					"tweakpane-plugin-rotation": "https://cdn.jsdelivr.net/npm/@0b5vr/tweakpane-plugin-rotation@0.1",
 					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"

--- a/packages/three-vrm-node-constraint/examples/upper-arm.html
+++ b/packages/three-vrm-node-constraint/examples/upper-arm.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.168.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.168.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.169.0/examples/jsm/",
 					"tweakpane": "https://cdn.jsdelivr.net/npm/tweakpane@3.0",
 					"tweakpane-plugin-rotation": "https://cdn.jsdelivr.net/npm/@0b5vr/tweakpane-plugin-rotation@0.1",
 					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"

--- a/packages/three-vrm-node-constraint/package.json
+++ b/packages/three-vrm-node-constraint/package.json
@@ -54,8 +54,8 @@
     "@pixiv/types-vrmc-node-constraint-1.0": "3.1.1"
   },
   "devDependencies": {
-    "@types/three": "^0.168.0",
-    "three": "^0.168.0"
+    "@types/three": "^0.169.0",
+    "three": "^0.169.0"
   },
   "peerDependencies": {
     "three": ">=0.137"

--- a/packages/three-vrm-springbone/examples/collider.html
+++ b/packages/three-vrm-springbone/examples/collider.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-				"three": "https://cdn.jsdelivr.net/npm/three@0.168.0/build/three.module.js",
-				"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.168.0/examples/jsm/",
+				"three": "https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.module.js",
+				"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.169.0/examples/jsm/",
 				"@pixiv/three-vrm-springbone": "../lib/three-vrm-springbone.module.js"
 			  }
 			}

--- a/packages/three-vrm-springbone/examples/loader-plugin.html
+++ b/packages/three-vrm-springbone/examples/loader-plugin.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-				"three": "https://cdn.jsdelivr.net/npm/three@0.168.0/build/three.module.js",
-				"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.168.0/examples/jsm/",
+				"three": "https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.module.js",
+				"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.169.0/examples/jsm/",
 				"@pixiv/three-vrm-springbone": "../lib/three-vrm-springbone.module.js"
 			  }
 			}

--- a/packages/three-vrm-springbone/examples/multiple.html
+++ b/packages/three-vrm-springbone/examples/multiple.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-				"three": "https://cdn.jsdelivr.net/npm/three@0.168.0/build/three.module.js",
-				"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.168.0/examples/jsm/",
+				"three": "https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.module.js",
+				"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.169.0/examples/jsm/",
 				"@pixiv/three-vrm-springbone": "../lib/three-vrm-springbone.module.js"
 			  }
 			}

--- a/packages/three-vrm-springbone/examples/single.html
+++ b/packages/three-vrm-springbone/examples/single.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-				"three": "https://cdn.jsdelivr.net/npm/three@0.168.0/build/three.module.js",
-				"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.168.0/examples/jsm/",
+				"three": "https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.module.js",
+				"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.169.0/examples/jsm/",
 				"@pixiv/three-vrm-springbone": "../lib/three-vrm-springbone.module.js"
 			  }
 			}

--- a/packages/three-vrm-springbone/package.json
+++ b/packages/three-vrm-springbone/package.json
@@ -56,8 +56,8 @@
     "@pixiv/types-vrmc-springbone-extended-collider-1.0": "3.1.1"
   },
   "devDependencies": {
-    "@types/three": "^0.168.0",
-    "three": "^0.168.0"
+    "@types/three": "^0.169.0",
+    "three": "^0.169.0"
   },
   "peerDependencies": {
     "three": ">=0.137"

--- a/packages/three-vrm/README.md
+++ b/packages/three-vrm/README.md
@@ -32,8 +32,8 @@ You can import all the dependencies via CDN like [jsDelivr](https://www.jsdelivr
 <script type="importmap">
   {
     "imports": {
-      "three": "https://cdn.jsdelivr.net/npm/three@0.168.0/build/three.module.js",
-      "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.168.0/examples/jsm/",
+      "three": "https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.module.js",
+      "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.169.0/examples/jsm/",
       "@pixiv/three-vrm": "https://cdn.jsdelivr.net/npm/@pixiv/three-vrm@3/lib/three-vrm.module.min.js"
     }
   }

--- a/packages/three-vrm/examples/animations.html
+++ b/packages/three-vrm/examples/animations.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.168.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.168.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.169.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/basic.html
+++ b/packages/three-vrm/examples/basic.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.168.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.168.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.169.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/bones.html
+++ b/packages/three-vrm/examples/bones.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.168.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.168.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.169.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/debug.html
+++ b/packages/three-vrm/examples/debug.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.168.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.168.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.169.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/dnd.html
+++ b/packages/three-vrm/examples/dnd.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.168.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.168.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.169.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/expressions.html
+++ b/packages/three-vrm/examples/expressions.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.168.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.168.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.169.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/firstperson.html
+++ b/packages/three-vrm/examples/firstperson.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.168.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.168.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.169.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/humanoidAnimation/index.html
+++ b/packages/three-vrm/examples/humanoidAnimation/index.html
@@ -34,8 +34,8 @@
 			{
 				"imports": {
 					"fflate": "https://cdn.jsdelivr.net/npm/fflate@0.7.4/esm/browser.js",
-					"three": "https://cdn.jsdelivr.net/npm/three@0.168.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.168.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.169.0/examples/jsm/",
 					"@pixiv/three-vrm": "../../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/lookat-advanced.html
+++ b/packages/three-vrm/examples/lookat-advanced.html
@@ -24,8 +24,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.168.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.168.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.169.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/lookat.html
+++ b/packages/three-vrm/examples/lookat.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.168.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.168.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.169.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/materials-debug.html
+++ b/packages/three-vrm/examples/materials-debug.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.168.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.168.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.169.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/meta.html
+++ b/packages/three-vrm/examples/meta.html
@@ -34,8 +34,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.168.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.168.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.169.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/mouse.html
+++ b/packages/three-vrm/examples/mouse.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.168.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.168.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.169.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/webgpu-dnd.html
+++ b/packages/three-vrm/examples/webgpu-dnd.html
@@ -23,9 +23,9 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.168.0/build/three.webgpu.js",
-					"three/webgpu": "https://cdn.jsdelivr.net/npm/three@0.168.0/build/three.webgpu.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.168.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.webgpu.js",
+					"three/webgpu": "https://cdn.jsdelivr.net/npm/three@0.169.0/build/three.webgpu.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.169.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js",
 					"@pixiv/three-vrm/nodes": "../lib/nodes/index.module.js"
 				}

--- a/packages/three-vrm/package.json
+++ b/packages/three-vrm/package.json
@@ -64,8 +64,8 @@
     "@pixiv/three-vrm-springbone": "3.1.1"
   },
   "devDependencies": {
-    "@types/three": "^0.168.0",
-    "three": "^0.168.0"
+    "@types/three": "^0.169.0",
+    "three": "^0.169.0"
   },
   "peerDependencies": {
     "three": ">=0.137"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1617,10 +1617,10 @@
   resolved "https://registry.yarnpkg.com/@types/stats.js/-/stats.js-0.17.0.tgz#0ed81d48e03b590c24da85540c1d952077a9fe20"
   integrity sha512-9w+a7bR8PeB0dCT/HBULU2fMqf6BAzvKbxFboYhmDtDkKPiyXYbjoe2auwsXlEFI7CFNMF1dCv3dFH5Poy9R1w==
 
-"@types/three@^0.168.0":
-  version "0.168.0"
-  resolved "https://registry.yarnpkg.com/@types/three/-/three-0.168.0.tgz#510420c4bbee7937bbbcdfbc5dc31160771eaef8"
-  integrity sha512-qAGLGzbaYgkkonOBfwOr+TZpOskPfFjrDAj801WQSVkUz0/D9zwir4vhruJ/CC/GteywzR9pqeVVfs5th/2oKw==
+"@types/three@^0.169.0":
+  version "0.169.0"
+  resolved "https://registry.yarnpkg.com/@types/three/-/three-0.169.0.tgz#9cf4c33575721669d88846f22b265696d2c2e7a6"
+  integrity sha512-oan7qCgJBt03wIaK+4xPWclYRPG9wzcg7Z2f5T8xYTNEF95kh0t0lklxLLYBDo7gQiGLYzE6iF4ta7nXF2bcsw==
   dependencies:
     "@tweenjs/tween.js" "~23.1.3"
     "@types/stats.js" "*"
@@ -6438,10 +6438,10 @@ text-table@^0.2.0:
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"
   integrity sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
 
-three@^0.168.0:
-  version "0.168.0"
-  resolved "https://registry.yarnpkg.com/three/-/three-0.168.0.tgz#3e33101d91e3e9716f5c610ea9a7b3b8423c242d"
-  integrity sha512-6m6jXtDwMJEK/GGMbAOTSAmxNdzKvvBzgd7q8bE/7Tr6m7PaBh5kKLrN7faWtlglXbzj7sVba48Idwx+NRsZXw==
+three@^0.169.0:
+  version "0.169.0"
+  resolved "https://registry.yarnpkg.com/three/-/three-0.169.0.tgz#4a62114988ad9728d73526d1f1de6760c56b4adc"
+  integrity sha512-Ed906MA3dR4TS5riErd4QBsRGPcx+HBDX2O5yYE5GqJeFQTPU+M56Va/f/Oph9X7uZo3W3o4l2ZhBZ6f6qUv0w==
 
 through2@^2.0.0:
   version "2.0.5"


### PR DESCRIPTION
This PR bumps Three.js to r169.

Release: https://github.com/mrdoob/three.js/releases/tag/r169