### PR TITLE
fix: Fallback to 'auto' instead of 'both' for MeshAnnotation

### DIFF
--- a/packages/three-vrm-core/src/firstPerson/VRMFirstPersonLoaderPlugin.ts
+++ b/packages/three-vrm-core/src/firstPerson/VRMFirstPersonLoaderPlugin.ts
@@ -90,20 +90,15 @@ export class VRMFirstPersonLoaderPlugin implements GLTFLoaderPlugin {
     }
 
     const schemaFirstPerson = extension.firstPerson;
-    if (!schemaFirstPerson) {
-      return null;
-    }
 
     const meshAnnotations: VRMFirstPersonMeshAnnotation[] = [];
     const nodePrimitivesMap = await gltfExtractPrimitivesFromNodes(gltf);
     Array.from(nodePrimitivesMap.entries()).forEach(([nodeIndex, primitives]) => {
-      const annotation = schemaFirstPerson.meshAnnotations
-        ? schemaFirstPerson.meshAnnotations.find((a) => a.node === nodeIndex)
-        : undefined;
+      const annotation = schemaFirstPerson?.meshAnnotations?.find((a) => a.node === nodeIndex);
 
       meshAnnotations.push({
         meshes: primitives,
-        type: annotation?.type ?? 'both',
+        type: annotation?.type ?? 'auto',
       });
     });
 


### PR DESCRIPTION
The [specification](https://github.com/vrm-c/vrm-specification/blob/master/specification/VRMC_vrm-1.0/firstPerson.md#when-meshannotation-does-not-exist) states that the fallback value for mesh annotations should be `auto`. In case there is no `firstPerson` property, it should still be treated as `auto`. I noticed three-vrm instead used `both` as fallback. This PR changes the fallback value from `both` to `auto` and ensures this is done whether or not there is a `firstPerson` property.

I could not find out if this applies to VRM0 as well, so I've left `_v0Import` unchanged.