### PR TITLE
fix: Consider array format materials

### DIFF
--- a/packages/three-vrm-core/src/expressions/VRMExpressionLoaderPlugin.ts
+++ b/packages/three-vrm-core/src/expressions/VRMExpressionLoaderPlugin.ts
@@ -183,9 +183,13 @@ export class VRMExpressionLoaderPlugin implements GLTFLoaderPlugin {
           // list up every material in `gltf.scene`
           const gltfMaterials: THREE.Material[] = [];
           gltf.scene.traverse((object) => {
-            const material = (object as any).material as THREE.Material | undefined;
+            const material = (object as any).material as THREE.Material | THREE.Material[] | undefined;
             if (material) {
-              gltfMaterials.push(material);
+              if (Array.isArray(material)) {
+                gltfMaterials.push(...material);
+              } else {
+                gltfMaterials.push(material);
+              }
             }
           });
 


### PR DESCRIPTION
materialColorBindsやtextureTransformBindsで参照しているmaterialの抽出で、scene.materialが配列であるケースを考慮する実装を追加しました。既存のコードでの挙動では各利用箇所でmaterialが取れていないだけなので、既存への影響はないかと思います。

[追記]
もう少し詳細を追ってみました。
発生するケースは「MToon Materialでoutlineモードを使ったものに、`materialColorBinds`,`textureTransformBinds`を適用した場合」のように見えます。
https://github.com/pixiv/three-vrm/blob/6e5a70a45b85041ad1d87552d2975b24129e68ff/packages/three-vrm-materials-mtoon/src/MToonMaterialLoaderPlugin.ts#L307 でのcopyによって配列形式になっているのではないかと。
上記copy対応の経緯を追うのは難しそうなのでここまでを取り急ぎ。

VRMファイル準備できましたが、容量で添付できないので修正前後での挙動を以下に貼っておきます。
左側のrobo faceにoutlineを適用しています。



## 修正前
https://github.com/user-attachments/assets/88e5c246-29bd-4996-9a3b-c2c7ade15dda

## 修正後

https://github.com/user-attachments/assets/6db399a6-280f-4af2-a302-7330503832d5

