### PR TITLE
fix: Remove build job from two type packages

### DIFF
--- a/packages/types-vrm-0.0/package.json
+++ b/packages/types-vrm-0.0/package.json
@@ -19,7 +19,6 @@
     "version": "yarn all",
     "all": "yarn lint && yarn clean && yarn build && yarn docs",
     "clean": "rimraf docs/",
-    "build": "tsc --declaration --declarationDir ./types --emitDeclarationOnly",
     "docs": "typedoc --entryPoints ./types/index.d.ts --out docs",
     "lint": "eslint \"types/**/*.{ts,tsx}\" && prettier \"types/**/*.{ts,tsx}\" --check",
     "lint-fix": "eslint \"types/**/*.{ts,tsx}\" --fix && prettier \"types/**/*.{ts,tsx}\" --write"

--- a/packages/types-vrmc-vrm-animation-1.0/package.json
+++ b/packages/types-vrmc-vrm-animation-1.0/package.json
@@ -19,7 +19,6 @@
     "version": "yarn all",
     "all": "yarn lint && yarn clean && yarn build && yarn docs",
     "clean": "rimraf docs/",
-    "build": "tsc --declaration --declarationDir ./types --emitDeclarationOnly",
     "docs": "typedoc --entryPoints ./types/index.d.ts --out docs",
     "lint": "eslint \"types/**/*.{ts,tsx}\" && prettier \"types/**/*.{ts,tsx}\" --check",
     "lint-fix": "eslint \"types/**/*.{ts,tsx}\" --fix && prettier \"types/**/*.{ts,tsx}\" --write"


### PR DESCRIPTION
We no longer build type packages

See: https://github.com/pixiv/three-vrm/pull/1302

Context: https://github.com/pixiv/three-vrm/pull/1521#issuecomment-2469753054
