### PR TITLE
fix: Remove build job from two type packages (2)

### DIFF
--- a/packages/types-vrm-0.0/package.json
+++ b/packages/types-vrm-0.0/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "version": "yarn all",
-    "all": "yarn lint && yarn clean && yarn build && yarn docs",
+    "all": "yarn lint && yarn clean && yarn docs",
     "clean": "rimraf docs/",
     "docs": "typedoc --entryPoints ./types/index.d.ts --out docs",
     "lint": "eslint \"types/**/*.{ts,tsx}\" && prettier \"types/**/*.{ts,tsx}\" --check",

--- a/packages/types-vrmc-vrm-animation-1.0/package.json
+++ b/packages/types-vrmc-vrm-animation-1.0/package.json
@@ -17,7 +17,7 @@
   },
   "scripts": {
     "version": "yarn all",
-    "all": "yarn lint && yarn clean && yarn build && yarn docs",
+    "all": "yarn lint && yarn clean && yarn docs",
     "clean": "rimraf docs/",
     "docs": "typedoc --entryPoints ./types/index.d.ts --out docs",
     "lint": "eslint \"types/**/*.{ts,tsx}\" && prettier \"types/**/*.{ts,tsx}\" --check",


### PR DESCRIPTION
Forgot to remove `yarn build` from `all` script

previous: 0e6cbf0aa80740c2fba38ad185ac6fbf2c7ab9e5