### PR TITLE
Support InterleavedBufferAttributes in VRMUtils

### DIFF
--- a/packages/three-vrm/src/VRMUtils/removeUnnecessaryJoints.ts
+++ b/packages/three-vrm/src/VRMUtils/removeUnnecessaryJoints.ts
@@ -56,29 +56,29 @@ export function removeUnnecessaryJoints(
   // Iterate over all skinned meshes and collect bones and boneInverses
   for (const mesh of skinnedMeshes) {
     const geometry = mesh.geometry;
-    const attribute = geometry.getAttribute('skinIndex') as THREE.BufferAttribute;
+    const attribute = geometry.getAttribute('skinIndex');
 
     const bones: THREE.Bone[] = []; // new list of bone
     const boneInverses: THREE.Matrix4[] = []; // new list of boneInverse
     const boneIndexMap: { [index: number]: number } = {}; // map of old bone index vs. new bone index
 
     // create a new bone map
-    const array = attribute.array;
-    for (let i = 0; i < array.length; i++) {
-      const index = array[i];
+    for (let i = 0; i < attribute.count; i++) {
+      for (let j = 0; j < attribute.itemSize; j++) {
+        const index = attribute.getComponent(i, j);
 
-      // new skinIndex buffer
-      if (boneIndexMap[index] == null) {
-        boneIndexMap[index] = bones.length;
-        bones.push(mesh.skeleton.bones[index]);
-        boneInverses.push(mesh.skeleton.boneInverses[index]);
+        // new skinIndex buffer
+        if (boneIndexMap[index] == null) {
+          boneIndexMap[index] = bones.length;
+          bones.push(mesh.skeleton.bones[index]);
+          boneInverses.push(mesh.skeleton.boneInverses[index]);
+        }
+
+        attribute.setComponent(i, j, boneIndexMap[index]);
       }
-
-      array[i] = boneIndexMap[index];
     }
 
     // replace with new indices
-    attribute.copyArray(array);
     attribute.needsUpdate = true;
 
     // update boneList


### PR DESCRIPTION
Loading a VRM file with interleaved vertex attributes works for the most part, but the `VRMUtils` `removeUnnecessaryVertices` and `removeUnnecessaryJoints` did not support it.

For `removeUnnecessaryJoints` the code is changed to use `setComponent` and `getComponent` which handle indexing into the array internally. The function now works with both `BufferAttribute` and `InterleavedBufferAttribute`

For `removeUnnecessaryVertices` an additional step is added at the start. It iterates over the index attribute and keeps track of which vertices are used by the geometry. In case _all_ vertices are used, further processing is skipped as there are no unnecessary vertices. This can save quite a bit of processing time :-)

In case not all vertices are used, it builds the index mappings (`originalIndexNewIndexMap`/`newIndexOriginalIndexMap`) based on the order the vertices appear in the _vertex_ buffers. This should preserve any optimizations done to the vertex buffers for cache/fetching efficiency.

Interleaved buffers with unnecessary vertices is NOT supported by this PR. I have a working implementation, but it comes at a performance cost (~30-40% slower), so decided to not include it. 