### PR TITLE
Add `VRMUtils.combineSkeletons` for reducing the number of `THREE.Skeleton`

### DIFF
--- a/packages/three-vrm/examples/animations.html
+++ b/packages/three-vrm/examples/animations.html
@@ -81,7 +81,7 @@
 
 					// calling these functions greatly improves the performance
 					VRMUtils.removeUnnecessaryVertices( gltf.scene );
-					VRMUtils.removeUnnecessaryJoints( gltf.scene );
+					VRMUtils.combineSkeletons( gltf.scene );
 
 					// Disable frustum culling
 					vrm.scene.traverse( ( obj ) => {

--- a/packages/three-vrm/examples/basic.html
+++ b/packages/three-vrm/examples/basic.html
@@ -82,7 +82,7 @@
 
 					// calling these functions greatly improves the performance
 					VRMUtils.removeUnnecessaryVertices( gltf.scene );
-					VRMUtils.removeUnnecessaryJoints( gltf.scene );
+					VRMUtils.combineSkeletons( gltf.scene );
 
 					// Disable frustum culling
 					vrm.scene.traverse( ( obj ) => {

--- a/packages/three-vrm/examples/bones.html
+++ b/packages/three-vrm/examples/bones.html
@@ -80,7 +80,7 @@
 
 					// calling these functions greatly improves the performance
 					VRMUtils.removeUnnecessaryVertices( gltf.scene );
-					VRMUtils.removeUnnecessaryJoints( gltf.scene );
+					VRMUtils.combineSkeletons( gltf.scene );
 
 					// Disable frustum culling
 					vrm.scene.traverse( ( obj ) => {

--- a/packages/three-vrm/examples/debug.html
+++ b/packages/three-vrm/examples/debug.html
@@ -88,7 +88,7 @@
 
 					// calling this function greatly improves the performance
 					VRMUtils.removeUnnecessaryVertices( gltf.scene );
-					VRMUtils.removeUnnecessaryJoints( gltf.scene );
+					VRMUtils.combineSkeletons( gltf.scene );
 
 					// Disable frustum culling
 					vrm.scene.traverse( ( obj ) => {

--- a/packages/three-vrm/examples/dnd.html
+++ b/packages/three-vrm/examples/dnd.html
@@ -82,7 +82,7 @@
 
 						// calling these functions greatly improves the performance
 						VRMUtils.removeUnnecessaryVertices( gltf.scene );
-						VRMUtils.removeUnnecessaryJoints( gltf.scene );
+						VRMUtils.combineSkeletons( gltf.scene );
 
 						if ( currentVrm ) {
 

--- a/packages/three-vrm/examples/expressions.html
+++ b/packages/three-vrm/examples/expressions.html
@@ -80,7 +80,7 @@
 			
 					// calling these functions greatly improves the performance
 					VRMUtils.removeUnnecessaryVertices( gltf.scene );
-					VRMUtils.removeUnnecessaryJoints( gltf.scene );
+					VRMUtils.combineSkeletons( gltf.scene );
 
 					// Disable frustum culling
 					vrm.scene.traverse( ( obj ) => {

--- a/packages/three-vrm/examples/firstperson.html
+++ b/packages/three-vrm/examples/firstperson.html
@@ -80,7 +80,7 @@
 
 					// calling these functions greatly improves the performance
 					VRMUtils.removeUnnecessaryVertices( gltf.scene );
-					VRMUtils.removeUnnecessaryJoints( gltf.scene );
+					VRMUtils.combineSkeletons( gltf.scene );
 
 					// Disable frustum culling
 					vrm.scene.traverse( ( obj ) => {

--- a/packages/three-vrm/examples/lookat-advanced.html
+++ b/packages/three-vrm/examples/lookat-advanced.html
@@ -151,7 +151,7 @@
 
 					// calling these functions greatly improves the performance
 					VRMUtils.removeUnnecessaryVertices( gltf.scene );
-					VRMUtils.removeUnnecessaryJoints( gltf.scene );
+					VRMUtils.combineSkeletons( gltf.scene );
 
 					// Disable frustum culling
 					vrm.scene.traverse( ( obj ) => {

--- a/packages/three-vrm/examples/lookat.html
+++ b/packages/three-vrm/examples/lookat.html
@@ -84,7 +84,7 @@
 
 					// calling these functions greatly improves the performance
 					VRMUtils.removeUnnecessaryVertices( gltf.scene );
-					VRMUtils.removeUnnecessaryJoints( gltf.scene );
+					VRMUtils.combineSkeletons( gltf.scene );
 
 					// Disable frustum culling
 					vrm.scene.traverse( ( obj ) => {

--- a/packages/three-vrm/examples/materials-debug.html
+++ b/packages/three-vrm/examples/materials-debug.html
@@ -80,7 +80,7 @@
 
 					// calling these functions greatly improves the performance
 					VRMUtils.removeUnnecessaryVertices( gltf.scene );
-					VRMUtils.removeUnnecessaryJoints( gltf.scene );
+					VRMUtils.combineSkeletons( gltf.scene );
 
 					// Disable frustum culling
 					vrm.scene.traverse( ( obj ) => {

--- a/packages/three-vrm/examples/meta.html
+++ b/packages/three-vrm/examples/meta.html
@@ -97,7 +97,7 @@
 
 					// calling these functions greatly improves the performance
 					VRMUtils.removeUnnecessaryVertices( gltf.scene );
-					VRMUtils.removeUnnecessaryJoints( gltf.scene );
+					VRMUtils.combineSkeletons( gltf.scene );
 
 					// Disable frustum culling
 					vrm.scene.traverse( ( obj ) => {

--- a/packages/three-vrm/examples/mouse.html
+++ b/packages/three-vrm/examples/mouse.html
@@ -75,7 +75,7 @@
 
 					// calling these functions greatly improves the performance
 					VRMUtils.removeUnnecessaryVertices( gltf.scene );
-					VRMUtils.removeUnnecessaryJoints( gltf.scene );
+					VRMUtils.combineSkeletons( gltf.scene );
 
 					// Disable frustum culling
 					vrm.scene.traverse( ( obj ) => {

--- a/packages/three-vrm/examples/webgpu-dnd.html
+++ b/packages/three-vrm/examples/webgpu-dnd.html
@@ -98,7 +98,7 @@
 
 						// calling these functions greatly improves the performance
 						VRMUtils.removeUnnecessaryVertices( gltf.scene );
-						VRMUtils.removeUnnecessaryJoints( gltf.scene, { experimentalSameBoneCounts: true } );
+						VRMUtils.combineSkeletons( gltf.scene );
 
 						if ( currentVrm ) {
 

--- a/packages/three-vrm/src/VRMUtils/combineSkeletons.ts
+++ b/packages/three-vrm/src/VRMUtils/combineSkeletons.ts
@@ -1,0 +1,121 @@
+import * as THREE from 'three';
+
+/**
+ * Traverses the given object and combines the skeletons of skinned meshes.
+ *
+ * Each frame the bone matrices are computed for every skeleton. Combining skeletons
+ * reduces the number of calculations needed, improving performance.
+ *
+ * @param root Root object that will be traversed
+ */
+export function combineSkeletons(root: THREE.Object3D): void {
+  const skinnedMeshes = new Set<THREE.SkinnedMesh>();
+  const geometryToSkinnedMesh = new Map<THREE.BufferGeometry, THREE.SkinnedMesh>();
+
+  // Traverse entire tree and collect skinned meshes
+  root.traverse((obj) => {
+    if (obj.type !== 'SkinnedMesh') {
+      return;
+    }
+
+    const skinnedMesh = obj as THREE.SkinnedMesh;
+
+    // Check if the geometry has already been encountered
+    const previousSkinnedMesh = geometryToSkinnedMesh.get(skinnedMesh.geometry);
+    if (previousSkinnedMesh) {
+      // Skinned meshes that share their geometry with other skinned meshes can't be processed.
+      // The skinnedMeshes already contain previousSkinnedMesh, so remove it now.
+      skinnedMeshes.delete(previousSkinnedMesh);
+    } else {
+      geometryToSkinnedMesh.set(skinnedMesh.geometry, skinnedMesh);
+      skinnedMeshes.add(skinnedMesh);
+    }
+  });
+
+  // Prepare new skeletons for the skinned meshes
+  const newSkeletons: Array<{ bones: THREE.Bone[]; boneInverses: THREE.Matrix4[]; meshes: THREE.SkinnedMesh[] }> = [];
+  skinnedMeshes.forEach((skinnedMesh) => {
+    const skeleton = skinnedMesh.skeleton;
+
+    // Find suitable skeleton
+    let newSkeleton = newSkeletons.find((candidate) => skeletonMatches(skeleton, candidate));
+    if (!newSkeleton) {
+      newSkeleton = { bones: [], boneInverses: [], meshes: [] };
+      newSkeletons.push(newSkeleton);
+    }
+
+    // Add skinned mesh to the new skeleton
+    newSkeleton.meshes.push(skinnedMesh);
+
+    // Determine bone index mapping from skeleton -> newSkeleton
+    const boneIndexMap: number[] = skeleton.bones.map((bone) => newSkeleton.bones.indexOf(bone));
+
+    // Update skinIndex attribute
+    const geometry = skinnedMesh.geometry;
+    const attribute = geometry.getAttribute('skinIndex');
+    const weightAttribute = geometry.getAttribute('skinWeight');
+
+    for (let i = 0; i < attribute.count; i++) {
+      for (let j = 0; j < attribute.itemSize; j++) {
+        // check bone weight
+        const weight = weightAttribute.getComponent(i, j);
+        if (weight === 0) {
+          continue;
+        }
+
+        const index = attribute.getComponent(i, j);
+
+        // new skinIndex buffer
+        if (boneIndexMap[index] === -1) {
+          boneIndexMap[index] = newSkeleton.bones.length;
+          newSkeleton.bones.push(skeleton.bones[index]);
+          newSkeleton.boneInverses.push(skeleton.boneInverses[index]);
+        }
+
+        attribute.setComponent(i, j, boneIndexMap[index]);
+      }
+    }
+
+    attribute.needsUpdate = true;
+  });
+
+  // Bind new skeleton to the meshes
+  for (const { bones, boneInverses, meshes } of newSkeletons) {
+    const newSkeleton = new THREE.Skeleton(bones, boneInverses);
+    meshes.forEach((mesh) => mesh.bind(newSkeleton, new THREE.Matrix4()));
+  }
+}
+
+/**
+ * Checks if a given skeleton matches a candidate skeleton. For the skeletons to match,
+ * all bones must either be in the candidate skeleton with the same boneInverse OR
+ * not part of the candidate skeleton (as it can be added to it).
+ * @param skeleton The skeleton to check.
+ * @param candidate The candidate skeleton to match against.
+ */
+function skeletonMatches(skeleton: THREE.Skeleton, candidate: { bones: THREE.Bone[]; boneInverses: THREE.Matrix4[] }) {
+  return skeleton.bones.every((bone, index) => {
+    const candidateIndex = candidate.bones.indexOf(bone);
+    if (candidateIndex !== -1) {
+      return matrixEquals(skeleton.boneInverses[index], candidate.boneInverses[candidateIndex]);
+    }
+    return true;
+  });
+}
+
+// https://github.com/mrdoob/three.js/blob/r170/test/unit/src/math/Matrix4.tests.js#L12
+function matrixEquals(a: THREE.Matrix4, b: THREE.Matrix4, tolerance?: number) {
+  tolerance = tolerance || 0.0001;
+  if (a.elements.length != b.elements.length) {
+    return false;
+  }
+
+  for (let i = 0, il = a.elements.length; i < il; i++) {
+    const delta = Math.abs(a.elements[i] - b.elements[i]);
+    if (delta > tolerance) {
+      return false;
+    }
+  }
+
+  return true;
+}

--- a/packages/three-vrm/src/VRMUtils/index.ts
+++ b/packages/three-vrm/src/VRMUtils/index.ts
@@ -1,3 +1,4 @@
+import { combineSkeletons } from './combineSkeletons';
 import { deepDispose } from './deepDispose';
 import { removeUnnecessaryJoints } from './removeUnnecessaryJoints';
 import { removeUnnecessaryVertices } from './removeUnnecessaryVertices';
@@ -8,6 +9,7 @@ export class VRMUtils {
     // this class is not meant to be instantiated
   }
 
+  public static combineSkeletons = combineSkeletons;
   public static deepDispose = deepDispose;
   public static removeUnnecessaryJoints = removeUnnecessaryJoints;
   public static removeUnnecessaryVertices = removeUnnecessaryVertices;


### PR DESCRIPTION
As mentioned in #1532, here's a PR that introduces a utility combining `THREE.Skeleton` instances. The `combineSkeletons` function attempts to combine the skeletons of skinned meshes where possible. The fewer skeletons there are, the fewer computations have to be performed to compute and upload the bone matrices (see [Skeleton.js#L127-L153](https://github.com/mrdoob/three.js/blob/dev/src/objects/Skeleton.js#L127-L153)).

The following table shows the number of bones and the number of skeletons. For example, the `VRM1_Constraint_Twist_Sample.vrm` has 3 Skeletons, one with 83 bones and two with 137, so 357 bones (3 skeletons).
| Avatar | Number of bones (# skeletons) | After `removeUnnecessaryJoints` | After `combineSkeletons` |
|-----------|:-------------------------:|:-----------------------------------------------:|:------------------------------------:|
|VRM1_Constraint_Twist_Sample.vrm | 357 (3) | 174 (13) | 130 (2) |
|AvatarSample_C.vrm| 339 (3) | 132 (12) | 71 (1)|
|Zonko_VRM_221128_ps.vrm| 1647 (9) | 291 (21) | 133 (1) |
|AKAI Original VRM by Shugan.vrm| 3179 (17) | 376 (18) | 141 (1) |

As can be seen the `removeUnnecessaryJoints` can greatly reduce the number of bones, but does so by creating a unique `Skeleton` per skinned mesh. With `combineSkeletons` it instead tries to create as few skeletons as possible for all the skinned meshes.

Only one of the two utilities will be needed, so if accepted it's probably a good idea to remove (or deprecate) `removeUnnecessaryJoints`. There might be users who depend on the fact that each `SkinnedMesh` had its own `Skeleton` instance when using `removeUnnecessaryJoints`.