### PR TITLE
fix: NodeMaterials, `.temp()` -> `.toVar()`

### DIFF
--- a/packages/three-vrm-materials-mtoon/src/nodes/MToonAnimatedUVNode.ts
+++ b/packages/three-vrm-materials-mtoon/src/nodes/MToonAnimatedUVNode.ts
@@ -41,6 +41,6 @@ export class MToonAnimatedUVNode extends THREE.TempNode {
     const scroll = THREE.vec2(refUVAnimationScrollXOffset, refUVAnimationScrollYOffset).mul(uvAnimationMask);
     uv = uv.add(scroll);
 
-    return uv.temp('AnimatedUV');
+    return uv.toVar('AnimatedUV');
   }
 }

--- a/packages/three-vrm-materials-mtoon/src/nodes/immutableNodes.ts
+++ b/packages/three-vrm-materials-mtoon/src/nodes/immutableNodes.ts
@@ -1,9 +1,9 @@
 import * as THREE from 'three/webgpu';
 
-export const shadeColor = THREE.nodeImmutable(THREE.PropertyNode, 'vec3').temp('ShadeColor');
-export const shadingShift = THREE.nodeImmutable(THREE.PropertyNode, 'float').temp('ShadingShift');
-export const shadingToony = THREE.nodeImmutable(THREE.PropertyNode, 'float').temp('ShadingToony');
-export const rimLightingMix = THREE.nodeImmutable(THREE.PropertyNode, 'float').temp('RimLightingMix');
-export const rimMultiply = THREE.nodeImmutable(THREE.PropertyNode, 'vec3').temp('RimMultiply');
-export const matcap = THREE.nodeImmutable(THREE.PropertyNode, 'vec3').temp('matcap');
-export const parametricRim = THREE.nodeImmutable(THREE.PropertyNode, 'vec3').temp('ParametricRim');
+export const shadeColor = THREE.nodeImmutable(THREE.PropertyNode, 'vec3').toVar('ShadeColor');
+export const shadingShift = THREE.nodeImmutable(THREE.PropertyNode, 'float').toVar('ShadingShift');
+export const shadingToony = THREE.nodeImmutable(THREE.PropertyNode, 'float').toVar('ShadingToony');
+export const rimLightingMix = THREE.nodeImmutable(THREE.PropertyNode, 'float').toVar('RimLightingMix');
+export const rimMultiply = THREE.nodeImmutable(THREE.PropertyNode, 'vec3').toVar('RimMultiply');
+export const matcap = THREE.nodeImmutable(THREE.PropertyNode, 'vec3').toVar('matcap');
+export const parametricRim = THREE.nodeImmutable(THREE.PropertyNode, 'vec3').toVar('ParametricRim');


### PR DESCRIPTION
This PR update the method `.temp()` of NodeMaterial nodes to `.toVar()`.

`.temp()` is deprecated in r170.  
See: https://github.com/mrdoob/three.js/pull/29516

examples are working even in r167.
