### PR TITLE
Optimize spring bones computations

### DIFF
--- a/packages/three-vrm-springbone/src/VRMSpringBoneCollider.ts
+++ b/packages/three-vrm-springbone/src/VRMSpringBoneCollider.ts
@@ -10,9 +10,43 @@ export class VRMSpringBoneCollider extends THREE.Object3D {
    */
   public readonly shape: VRMSpringBoneColliderShape;
 
+  /**
+   * World space matrix for the collider shape used in collision calculations.
+   */
+  public readonly colliderMatrix = new THREE.Matrix4();
+
   public constructor(shape: VRMSpringBoneColliderShape) {
     super();
 
     this.shape = shape;
+  }
+
+  public updateWorldMatrix(updateParents: boolean, updateChildren: boolean): void {
+    super.updateWorldMatrix(updateParents, updateChildren);
+
+    updateColliderMatrix(this.colliderMatrix, this.matrixWorld, this.shape.offset);
+  }
+}
+
+/**
+ * Computes the colliderMatrix based on an offset and a world matrix.
+ * Equivalent to the following code when matrixWorld is an affine matrix:
+ * ```js
+ * out.makeTranslation(offset).premultiply(matrixWorld)
+ * ```
+ *
+ * @param colliderMatrix The target matrix to store the result in.
+ * @param matrixWorld The world matrix fo the collider object.
+ * @param offset Optional offset to the collider shape.
+ */
+function updateColliderMatrix(colliderMatrix: THREE.Matrix4, matrixWorld: THREE.Matrix4, offset?: THREE.Vector3) {
+  const me = matrixWorld.elements;
+
+  colliderMatrix.copy(matrixWorld);
+
+  if (offset) {
+    colliderMatrix.elements[12] = me[0] * offset.x + me[4] * offset.y + me[8] * offset.z + me[12];
+    colliderMatrix.elements[13] = me[1] * offset.x + me[5] * offset.y + me[9] * offset.z + me[13];
+    colliderMatrix.elements[14] = me[2] * offset.x + me[6] * offset.y + me[10] * offset.z + me[14];
   }
 }

--- a/packages/three-vrm-springbone/src/VRMSpringBoneColliderShape.ts
+++ b/packages/three-vrm-springbone/src/VRMSpringBoneColliderShape.ts
@@ -10,6 +10,11 @@ export abstract class VRMSpringBoneColliderShape {
   public abstract get type(): string;
 
   /**
+   * The offset to the shape.
+   */
+  public offset?: THREE.Vector3;
+
+  /**
    * Calculate a distance and a direction from the collider to a target object.
    * It's hit if the distance is negative.
    * The direction will be contained in the given target vector.

--- a/packages/three-vrm-springbone/src/VRMSpringBoneColliderShapeCapsule.ts
+++ b/packages/three-vrm-springbone/src/VRMSpringBoneColliderShapeCapsule.ts
@@ -44,8 +44,8 @@ export class VRMSpringBoneColliderShapeCapsule extends VRMSpringBoneColliderShap
     objectRadius: number,
     target: THREE.Vector3,
   ): number {
-    _v3A.copy(this.offset).applyMatrix4(colliderMatrix); // transformed head
-    _v3B.copy(this.tail).applyMatrix4(colliderMatrix); // transformed tail
+    _v3A.setFromMatrixPosition(colliderMatrix); // transformed head
+    _v3B.subVectors(this.tail, this.offset).applyMatrix4(colliderMatrix); // transformed tail
     _v3B.sub(_v3A); // from head to tail
     const lengthSqCapsule = _v3B.lengthSq();
 
@@ -64,13 +64,14 @@ export class VRMSpringBoneColliderShapeCapsule extends VRMSpringBoneColliderShap
       target.sub(_v3B); // from the shaft point to object
     }
 
-    const distance = this.inside
-      ? this.radius - objectRadius - target.length()
-      : target.length() - objectRadius - this.radius;
+    const length = target.length();
+    const distance = this.inside ? this.radius - objectRadius - length : length - objectRadius - this.radius;
 
-    target.normalize(); // convert the delta to the direction
-    if (this.inside) {
-      target.negate(); // if inside, reverse the direction
+    if (distance < 0) {
+      target.multiplyScalar(1 / length); // convert the delta to the direction
+      if (this.inside) {
+        target.negate(); // if inside, reverse the direction
+      }
     }
 
     return distance;

--- a/packages/three-vrm-springbone/src/VRMSpringBoneColliderShapePlane.ts
+++ b/packages/three-vrm-springbone/src/VRMSpringBoneColliderShapePlane.ts
@@ -32,7 +32,7 @@ export class VRMSpringBoneColliderShapePlane extends VRMSpringBoneColliderShape 
     objectRadius: number,
     target: THREE.Vector3,
   ): number {
-    target.copy(this.offset).applyMatrix4(colliderMatrix); // transformed offset
+    target.setFromMatrixPosition(colliderMatrix); // transformed offset
     target.negate().add(objectPosition); // a vector from collider center to object position
 
     _mat3A.getNormalMatrix(colliderMatrix); // convert the collider matrix to the normal matrix

--- a/packages/three-vrm-springbone/src/VRMSpringBoneColliderShapeSphere.ts
+++ b/packages/three-vrm-springbone/src/VRMSpringBoneColliderShapeSphere.ts
@@ -1,6 +1,8 @@
 import * as THREE from 'three';
 import { VRMSpringBoneColliderShape } from './VRMSpringBoneColliderShape';
 
+const _v3A = new THREE.Vector3();
+
 export class VRMSpringBoneColliderShapeSphere extends VRMSpringBoneColliderShape {
   public get type(): 'sphere' {
     return 'sphere';
@@ -35,16 +37,16 @@ export class VRMSpringBoneColliderShapeSphere extends VRMSpringBoneColliderShape
     objectRadius: number,
     target: THREE.Vector3,
   ): number {
-    target.copy(this.offset).applyMatrix4(colliderMatrix); // transformed offset
-    target.negate().add(objectPosition); // a vector from collider center to object position
+    target.subVectors(objectPosition, _v3A.setFromMatrixPosition(colliderMatrix));
 
-    const distance = this.inside
-      ? this.radius - objectRadius - target.length()
-      : target.length() - objectRadius - this.radius;
+    const length = target.length();
+    const distance = this.inside ? this.radius - objectRadius - length : length - objectRadius - this.radius;
 
-    target.normalize(); // convert the delta to the direction
-    if (this.inside) {
-      target.negate(); // if inside, reverse the direction
+    if (distance < 0) {
+      target.multiplyScalar(1 / length); // convert the delta to the direction
+      if (this.inside) {
+        target.negate(); // if inside, reverse the direction
+      }
     }
 
     return distance;

--- a/packages/three-vrm-springbone/src/VRMSpringBoneJoint.ts
+++ b/packages/three-vrm-springbone/src/VRMSpringBoneJoint.ts
@@ -84,6 +84,26 @@ export class VRMSpringBoneJoint {
   private _worldSpaceBoneLength = 0.0;
 
   /**
+   * Set of dependencies that need to be updated before this joint.
+   */
+  public get dependencies(): Set<THREE.Object3D> {
+    const set = new Set<THREE.Object3D>();
+
+    const parent = this.bone.parent;
+    if (parent) {
+      set.add(parent);
+    }
+
+    for (let cg = 0; cg < this.colliderGroups.length; cg++) {
+      for (let c = 0; c < this.colliderGroups[cg].colliders.length; c++) {
+        set.add(this.colliderGroups[cg].colliders[c]);
+      }
+    }
+
+    return set;
+  }
+
+  /**
    * This springbone will be calculated based on the space relative from this object.
    * If this is `null`, springbone will be calculated in world space.
    */

--- a/packages/three-vrm-springbone/src/VRMSpringBoneJoint.ts
+++ b/packages/three-vrm-springbone/src/VRMSpringBoneJoint.ts
@@ -1,5 +1,4 @@
 import * as THREE from 'three';
-import { mat4InvertCompat } from './utils/mat4InvertCompat';
 import { Matrix4InverseCache } from './utils/Matrix4InverseCache';
 import type { VRMSpringBoneColliderGroup } from './VRMSpringBoneColliderGroup';
 import type { VRMSpringBoneJointSettings } from './VRMSpringBoneJointSettings';
@@ -13,7 +12,6 @@ const IDENTITY_MATRIX4 = new THREE.Matrix4();
 // 計算中の一時保存用変数（一度インスタンスを作ったらあとは使い回す）
 const _v3A = new THREE.Vector3();
 const _v3B = new THREE.Vector3();
-const _v3C = new THREE.Vector3();
 
 /**
  * A temporary variable which is used in `update`
@@ -23,16 +21,9 @@ const _worldSpacePosition = new THREE.Vector3();
 /**
  * A temporary variable which is used in `update`
  */
-const _centerSpacePosition = new THREE.Vector3();
-
-/**
- * A temporary variable which is used in `update`
- */
 const _nextTail = new THREE.Vector3();
 
-const _quatA = new THREE.Quaternion();
 const _matA = new THREE.Matrix4();
-const _matB = new THREE.Matrix4();
 
 /**
  * A class represents a single joint of a spring bone.
@@ -204,7 +195,7 @@ export class VRMSpringBoneJoint {
     }
 
     // copy the child position to tails
-    const matrixWorldToCenter = this._getMatrixWorldToCenter(_matA);
+    const matrixWorldToCenter = this._getMatrixWorldToCenter();
     this.bone.localToWorld(this._currentTail.copy(this._initialLocalChildPosition)).applyMatrix4(matrixWorldToCenter);
     this._prevTail.copy(this._currentTail);
 
@@ -224,7 +215,7 @@ export class VRMSpringBoneJoint {
     this.bone.matrixWorld.multiplyMatrices(this._parentMatrixWorld, this.bone.matrix);
 
     // Apply updated position to tail states
-    const matrixWorldToCenter = this._getMatrixWorldToCenter(_matA);
+    const matrixWorldToCenter = this._getMatrixWorldToCenter();
     this.bone.localToWorld(this._currentTail.copy(this._initialLocalChildPosition)).applyMatrix4(matrixWorldToCenter);
     this._prevTail.copy(this._currentTail);
   }
@@ -241,64 +232,42 @@ export class VRMSpringBoneJoint {
     // Update the _worldSpaceBoneLength
     this._calcWorldSpaceBoneLength();
 
-    // Get bone position in center space
-    _worldSpacePosition.setFromMatrixPosition(this.bone.matrixWorld);
-    let matrixWorldToCenter = this._getMatrixWorldToCenter(_matA);
-    _centerSpacePosition.copy(_worldSpacePosition).applyMatrix4(matrixWorldToCenter);
-    const quatWorldToCenter = _quatA.setFromRotationMatrix(matrixWorldToCenter);
-
-    // Get parent matrix in center space
-    const centerSpaceParentMatrix = _matB.copy(matrixWorldToCenter).multiply(this._parentMatrixWorld);
-
-    // Get boneAxis in center space
-    const centerSpaceBoneAxis = _v3B
+    // Get boneAxis in world space
+    const worldSpaceBoneAxis = _v3B
       .copy(this._boneAxis)
-      .applyMatrix4(this._initialLocalMatrix)
-      .applyMatrix4(centerSpaceParentMatrix)
-      .sub(_centerSpacePosition)
-      .normalize();
-
-    // gravity in center space
-    const centerSpaceGravity = _v3C.copy(this.settings.gravityDir).applyQuaternion(quatWorldToCenter).normalize();
-
-    const matrixCenterToWorld = this._getMatrixCenterToWorld(_matA);
+      .transformDirection(this._initialLocalMatrix)
+      .transformDirection(this._parentMatrixWorld);
 
     // verlet積分で次の位置を計算
     _nextTail
+      // Determine inertia in center space
       .copy(this._currentTail)
-      .add(
-        _v3A
-          .copy(this._currentTail)
-          .sub(this._prevTail)
-          .multiplyScalar(1 - this.settings.dragForce),
-      ) // 前フレームの移動を継続する(減衰もあるよ)
-      .add(_v3A.copy(centerSpaceBoneAxis).multiplyScalar(this.settings.stiffness * delta)) // 親の回転による子ボーンの移動目標
-      .add(_v3A.copy(centerSpaceGravity).multiplyScalar(this.settings.gravityPower * delta)) // 外力による移動量
-      .applyMatrix4(matrixCenterToWorld); // tailをworld spaceに戻す
+      .add(_v3A.subVectors(this._currentTail, this._prevTail).multiplyScalar(1 - this.settings.dragForce)) // 前フレームの移動を継続する(減衰もあるよ)
+      // Convert center space to world space
+      .applyMatrix4(this._getMatrixCenterToWorld()) // tailをworld spaceに戻す
+      // Apply stiffness and gravity in world space
+      .addScaledVector(worldSpaceBoneAxis, this.settings.stiffness * delta) // 親の回転による子ボーンの移動目標
+      .addScaledVector(this.settings.gravityDir, this.settings.gravityPower * delta); // 外力による移動量
 
     // normalize bone length
+    _worldSpacePosition.setFromMatrixPosition(this.bone.matrixWorld);
     _nextTail.sub(_worldSpacePosition).normalize().multiplyScalar(this._worldSpaceBoneLength).add(_worldSpacePosition);
 
     // Collisionで移動
     this._collision(_nextTail);
 
     // update prevTail and currentTail
-    matrixWorldToCenter = this._getMatrixWorldToCenter(_matA);
-
     this._prevTail.copy(this._currentTail);
-    this._currentTail.copy(_v3A.copy(_nextTail).applyMatrix4(matrixWorldToCenter));
+    this._currentTail.copy(_nextTail).applyMatrix4(this._getMatrixWorldToCenter());
 
     // Apply rotation, convert vector3 thing into actual quaternion
     // Original UniVRM is doing center unit calculus at here but we're gonna do this on local unit
-    const worldSpaceInitialMatrixInv = mat4InvertCompat(
-      _matA.copy(this._parentMatrixWorld).multiply(this._initialLocalMatrix),
-    );
-    const applyRotation = _quatA.setFromUnitVectors(
-      this._boneAxis,
-      _v3A.copy(_nextTail).applyMatrix4(worldSpaceInitialMatrixInv).normalize(),
-    );
-
-    this.bone.quaternion.copy(this._initialLocalRotation).multiply(applyRotation);
+    const worldSpaceInitialMatrixInv = _matA
+      .multiplyMatrices(this._parentMatrixWorld, this._initialLocalMatrix)
+      .invert();
+    this.bone.quaternion
+      .setFromUnitVectors(this._boneAxis, _v3A.copy(_nextTail).applyMatrix4(worldSpaceInitialMatrixInv).normalize())
+      .premultiply(this._initialLocalRotation);
 
     // We need to update its matrixWorld manually, since we tweaked the bone by our hand
     this.bone.updateMatrix();
@@ -311,19 +280,22 @@ export class VRMSpringBoneJoint {
    * @param tail The tail you want to process
    */
   private _collision(tail: THREE.Vector3): void {
-    this.colliderGroups.forEach((colliderGroup) => {
-      colliderGroup.colliders.forEach((collider) => {
+    for (let cg = 0; cg < this.colliderGroups.length; cg++) {
+      for (let c = 0; c < this.colliderGroups[cg].colliders.length; c++) {
+        const collider = this.colliderGroups[cg].colliders[c];
         const dist = collider.shape.calculateCollision(collider.matrixWorld, tail, this.settings.hitRadius, _v3A);
 
         if (dist < 0.0) {
           // hit
-          tail.add(_v3A.multiplyScalar(-dist));
+          tail.addScaledVector(_v3A, -dist);
 
           // normalize bone length
-          tail.sub(_worldSpacePosition).normalize().multiplyScalar(this._worldSpaceBoneLength).add(_worldSpacePosition);
+          tail.sub(_worldSpacePosition);
+          const length = tail.length();
+          tail.multiplyScalar(this._worldSpaceBoneLength / length).add(_worldSpacePosition);
         }
-      });
-    });
+      }
+    }
   }
 
   /**
@@ -345,29 +317,15 @@ export class VRMSpringBoneJoint {
 
   /**
    * Create a matrix that converts center space into world space.
-   * @param target Target matrix
    */
-  private _getMatrixCenterToWorld(target: THREE.Matrix4): THREE.Matrix4 {
-    if (this._center) {
-      target.copy(this._center.matrixWorld);
-    } else {
-      target.identity();
-    }
-
-    return target;
+  private _getMatrixCenterToWorld(): THREE.Matrix4 {
+    return this._center ? this._center.matrixWorld : IDENTITY_MATRIX4;
   }
 
   /**
    * Create a matrix that converts world space into center space.
-   * @param target Target matrix
    */
-  private _getMatrixWorldToCenter(target: THREE.Matrix4): THREE.Matrix4 {
-    if (this._center) {
-      target.copy((this._center.userData.inverseCacheProxy as Matrix4InverseCache).inverse);
-    } else {
-      target.identity();
-    }
-
-    return target;
+  private _getMatrixWorldToCenter(): THREE.Matrix4 {
+    return this._center ? (this._center.userData.inverseCacheProxy as Matrix4InverseCache).inverse : IDENTITY_MATRIX4;
   }
 }

--- a/packages/three-vrm-springbone/src/VRMSpringBoneJoint.ts
+++ b/packages/three-vrm-springbone/src/VRMSpringBoneJoint.ts
@@ -283,7 +283,7 @@ export class VRMSpringBoneJoint {
     for (let cg = 0; cg < this.colliderGroups.length; cg++) {
       for (let c = 0; c < this.colliderGroups[cg].colliders.length; c++) {
         const collider = this.colliderGroups[cg].colliders[c];
-        const dist = collider.shape.calculateCollision(collider.matrixWorld, tail, this.settings.hitRadius, _v3A);
+        const dist = collider.shape.calculateCollision(collider.colliderMatrix, tail, this.settings.hitRadius, _v3A);
 
         if (dist < 0.0) {
           // hit

--- a/packages/three-vrm-springbone/src/tests/VRMSpringBoneColliderShapeCapsule.test.ts
+++ b/packages/three-vrm-springbone/src/tests/VRMSpringBoneColliderShapeCapsule.test.ts
@@ -75,7 +75,7 @@ describe('VRMSpringBoneColliderShapeCapsule', () => {
       });
 
       it('must calculate a collision properly, object is near the head', () => {
-        const colliderMatrix = new THREE.Matrix4();
+        const colliderMatrix = new THREE.Matrix4().makeTranslation(shape.offset);
         const objectPosition = new THREE.Vector3(-2.0, 0.0, 1.0);
         const objectRadius = 1.0;
 
@@ -87,19 +87,19 @@ describe('VRMSpringBoneColliderShapeCapsule', () => {
       });
 
       it('must calculate a collision properly, object is near the tail', () => {
-        const colliderMatrix = new THREE.Matrix4();
+        const colliderMatrix = new THREE.Matrix4().makeTranslation(shape.offset);
         const objectPosition = new THREE.Vector3(3.0, 0.0, 0.0);
-        const objectRadius = 1.0;
+        const objectRadius = 2.0;
 
         const dir = new THREE.Vector3();
         const distSq = shape.calculateCollision(colliderMatrix, objectPosition, objectRadius, dir);
 
-        expect(distSq).toBeCloseTo(0.44949); // sqrt(6) - 2
+        expect(distSq).toBeCloseTo(-0.55051); // sqrt(6) - 3
         expect(dir).toBeCloseToVector3(new THREE.Vector3(2.0, -1.0, -1.0).normalize());
       });
 
       it('must calculate a collision properly, object is between two ends', () => {
-        const colliderMatrix = new THREE.Matrix4();
+        const colliderMatrix = new THREE.Matrix4().makeTranslation(shape.offset);
         const objectPosition = new THREE.Vector3(0.0, 0.0, 0.0);
         const objectRadius = 1.0;
 

--- a/packages/three-vrm-springbone/src/tests/VRMSpringBoneColliderShapeSphere.test.ts
+++ b/packages/three-vrm-springbone/src/tests/VRMSpringBoneColliderShapeSphere.test.ts
@@ -64,7 +64,9 @@ describe('VRMSpringBoneColliderShapeSphere', () => {
         offset: new THREE.Vector3(0.0, 0.0, -1.0),
       });
 
-      const colliderMatrix = new THREE.Matrix4().makeTranslation(1.0, 0.0, 0.0);
+      const colliderMatrix = new THREE.Matrix4()
+        .makeTranslation(1.0, 0.0, 0.0)
+        .multiply(new THREE.Matrix4().makeTranslation(shape.offset));
       const objectPosition = new THREE.Vector3(2.0, 1.0, 0.0);
       const objectRadius = 1.0;
 
@@ -81,7 +83,9 @@ describe('VRMSpringBoneColliderShapeSphere', () => {
         offset: new THREE.Vector3(0.0, 1.0, 1.0),
       });
 
-      const colliderMatrix = new THREE.Matrix4().makeRotationX(-0.5 * Math.PI);
+      const colliderMatrix = new THREE.Matrix4()
+        .makeRotationX(-0.5 * Math.PI)
+        .multiply(new THREE.Matrix4().makeTranslation(shape.offset));
       const objectPosition = new THREE.Vector3(-1.0, 1.0, -1.0);
       const objectRadius = 1.0;
 

--- a/packages/three-vrm-springbone/src/utils/lowestCommonAncestor.ts
+++ b/packages/three-vrm-springbone/src/utils/lowestCommonAncestor.ts
@@ -1,0 +1,21 @@
+import type * as THREE from 'three';
+
+/**
+ * Finds the lowest common ancestors of the given objects, if it exists.
+ * @param objects The objects to find the lowest common ancestor for.
+ */
+export function lowestCommonAncestor(objects: Set<THREE.Object3D>): THREE.Object3D | null {
+  const sharedAncestors = new Map<THREE.Object3D, number>();
+  for (const object of objects) {
+    let current: THREE.Object3D | null = object;
+    do {
+      const newValue = (sharedAncestors.get(current) ?? 0) + 1;
+      if (newValue === objects.size) {
+        return current;
+      }
+      sharedAncestors.set(current, newValue);
+      current = current.parent;
+    } while (current !== null);
+  }
+  return null;
+}


### PR DESCRIPTION
Spring bones tend to be quite performance intensive on the CPU side. I looked into ways to optimize them, while retaining their original behaviour. This PR consists of three commits each focussing on a different area. 

See the following table which shows the average duration a call to `vrm.update` took. The changes are stacked, so the `Collider shape offset` column contains all three optimizations.
| **Avatar**                       | **Before PR** | **Pre-compute order** | **World space computations** | **Collider shape offset** |
|----------------------------------|:----------:|:--------------------:|:----------------------------:|:-------------------------:|
| VRM1_Constraint_Twist_Sample.vrm |  658.0 µs  |       179.1 µs       |           164.3 µs           |          145.7 µs         |
| AvatarSample_C.vrm               |   1.0 ms   |       615.3 µs       |           473.8 µs           |          415.2 µs         |
| Zonko_VRM_221128_ps.vrm          |   3.2 ms   |       318.0 µs       |           269.1 µs           |          200.1 µs         |
| AKAI Original VRM by Shugan.vrm  |  161.7 µs  |       105.8 µs       |            92.4 µs           |          95.1 µs          |

### Pre-computing spring joint update order (a21e474893b917d0d96bfe3e69de66224c357ea4)
The order in which spring bones need to be updated can be pre-computed making the actual `update` a lot more straightforward and performant. Whenever a spring bone is added or removed, the order is recomputed. The following things are precomputed:

- The order in which the spring bones should be updated when taking all dependencies into account (`_sortedJoints`)
- The ancestors from the [lowest common ancestor](https://en.wikipedia.org/wiki/Lowest_common_ancestor) of all the spring bone roots to the spring bone roots (`_ancestors`)

### Computing stiffness and gravity in world space (2e147298e7ff9fa66035890f0e87ab5da2c3489a)
The `VRMSpringBoneJoint.update` method converted all forces into center space. This is required for inertia, but for both stiffness and gravity this isn't strictly needed. It saves a couple of matrix multiplications by handling these in world space instead.

Additionally some of the vector math could be simplified (e.g. `.add(v3.multiplyScalar(scalar))` -> `.addScaledVector(v3, scalar)`) slightly reducing the amount of operations required.

### Aligning collider position with collider shape offset (7449a0ddff4fda636ee4a834c6afc956b8d6b476)
The `VRMSpringBoneCollider` is a `THREE.Object3D` with an identity transform. The collision shapes contain an `offset`, which is used to compute the world position of the collider shape. But this is done each time `calculateCollision` is called, which can be many times per-frame, despite the actual world position of the collider not changing in between.

By setting the position of `VRMSpringBoneCollider` to the offset, the world position can be retrieved from the `worldMatrix` instead, ensuring it's only calculated once per collider per update. To further reduce the number of calculations done, the output vector (`target`) is now only updated in case the distance is negative. 

This did require some changes to the unit tests, as they don't use `VRMSpringBoneCollider` but test against the `VRMSpringBoneColliderShape` directly.

### Notes
For benchmarking and testing I created a setup where I loaded the VRM, called `vrm.update(FIXED_DELTA)` and compared the world positions and rotations of all joints to reference values based on running the same on `dev`. So for the cases and VRM models tested above, the output after one update was identical (with EPSILON=0.0001).