### PR TITLE
feat: put a deprecation warning to VRMUtils.removeUnnecessaryJoints

### DIFF
--- a/packages/three-vrm/src/VRMUtils/removeUnnecessaryJoints.ts
+++ b/packages/three-vrm/src/VRMUtils/removeUnnecessaryJoints.ts
@@ -10,6 +10,8 @@ import * as THREE from 'three';
  * Also, this function might significantly improve the performance of mesh skinning.
  *
  * @param root Root object that will be traversed
+ *
+ * @deprecated `removeUnnecessaryJoints` is deprecated. Use `combineSkeletons` instead. `combineSkeletons` contributes more to the performance improvement. This function will be removed in the next major version.
  */
 export function removeUnnecessaryJoints(
   root: THREE.Object3D,
@@ -27,6 +29,10 @@ export function removeUnnecessaryJoints(
     experimentalSameBoneCounts?: boolean;
   },
 ): void {
+  console.warn(
+    'VRMUtils.removeUnnecessaryJoints: removeUnnecessaryJoints is deprecated. Use combineSkeletons instead. combineSkeletons contributes more to the performance improvement. This function will be removed in the next major version.',
+  );
+
   const experimentalSameBoneCounts = options?.experimentalSameBoneCounts ?? false;
 
   // Traverse an entire tree, and collect all skinned meshes


### PR DESCRIPTION
This PR deprecates `VRMUtils.removeUnnecessaryJoints`.

In #1535, we got a superior function, `VRMUtils.combineSkeletons`, so we no longer have a purpose of using `removeUnnecessaryJoints`.

When using the function, it puts a warning that recommends the user to switch to `combineSkeletons`.
However, the implementation of `removeUnnecessaryJoints` is preserved in case the implementation of `combineSkeletons` causes a problem.
The function body will be removed in the next major version.
