### PR TITLE
VRMUtils.combineMorphs

### DIFF
--- a/packages/three-vrm-core/src/expressions/VRMExpression.ts
+++ b/packages/three-vrm-core/src/expressions/VRMExpression.ts
@@ -122,10 +122,20 @@ export class VRMExpression extends THREE.Object3D {
     this.visible = false;
   }
 
+  /**
+   * Add an expression bind to the expression.
+   *
+   * @param bind A bind to add
+   */
   public addBind(bind: VRMExpressionBind): void {
     this._binds.push(bind);
   }
 
+  /**
+   * Delete an expression bind from the expression.
+   *
+   * @param bind A bind to delete
+   */
   public deleteBind(bind: VRMExpressionBind): void {
     const index = this._binds.indexOf(bind);
     if (index >= 0) {

--- a/packages/three-vrm-core/src/expressions/VRMExpression.ts
+++ b/packages/three-vrm-core/src/expressions/VRMExpression.ts
@@ -41,7 +41,17 @@ export class VRMExpression extends THREE.Object3D {
    */
   public overrideMouth: VRMExpressionOverrideType = 'none';
 
+  /**
+   * Binds that this expression influences.
+   */
   private _binds: VRMExpressionBind[] = [];
+
+  /**
+   * Binds that this expression influences.
+   */
+  public get binds(): readonly VRMExpressionBind[] {
+    return this._binds;
+  }
 
   override readonly type: string | 'VRMExpression';
 
@@ -114,6 +124,13 @@ export class VRMExpression extends THREE.Object3D {
 
   public addBind(bind: VRMExpressionBind): void {
     this._binds.push(bind);
+  }
+
+  public deleteBind(bind: VRMExpressionBind): void {
+    const index = this._binds.indexOf(bind);
+    if (index >= 0) {
+      this._binds.splice(index, 1);
+    }
   }
 
   /**

--- a/packages/three-vrm/examples/animations.html
+++ b/packages/three-vrm/examples/animations.html
@@ -82,6 +82,7 @@
 					// calling these functions greatly improves the performance
 					VRMUtils.removeUnnecessaryVertices( gltf.scene );
 					VRMUtils.combineSkeletons( gltf.scene );
+					VRMUtils.combineMorphs( vrm );
 
 					// Disable frustum culling
 					vrm.scene.traverse( ( obj ) => {

--- a/packages/three-vrm/examples/basic.html
+++ b/packages/three-vrm/examples/basic.html
@@ -83,6 +83,7 @@
 					// calling these functions greatly improves the performance
 					VRMUtils.removeUnnecessaryVertices( gltf.scene );
 					VRMUtils.combineSkeletons( gltf.scene );
+					VRMUtils.combineMorphs( vrm );
 
 					// Disable frustum culling
 					vrm.scene.traverse( ( obj ) => {

--- a/packages/three-vrm/examples/bones.html
+++ b/packages/three-vrm/examples/bones.html
@@ -81,6 +81,7 @@
 					// calling these functions greatly improves the performance
 					VRMUtils.removeUnnecessaryVertices( gltf.scene );
 					VRMUtils.combineSkeletons( gltf.scene );
+					VRMUtils.combineMorphs( vrm );
 
 					// Disable frustum culling
 					vrm.scene.traverse( ( obj ) => {

--- a/packages/three-vrm/examples/debug.html
+++ b/packages/three-vrm/examples/debug.html
@@ -89,6 +89,7 @@
 					// calling this function greatly improves the performance
 					VRMUtils.removeUnnecessaryVertices( gltf.scene );
 					VRMUtils.combineSkeletons( gltf.scene );
+					VRMUtils.combineMorphs( vrm );
 
 					// Disable frustum culling
 					vrm.scene.traverse( ( obj ) => {

--- a/packages/three-vrm/examples/dnd.html
+++ b/packages/three-vrm/examples/dnd.html
@@ -83,6 +83,7 @@
 						// calling these functions greatly improves the performance
 						VRMUtils.removeUnnecessaryVertices( gltf.scene );
 						VRMUtils.combineSkeletons( gltf.scene );
+						VRMUtils.combineMorphs( vrm );
 
 						if ( currentVrm ) {
 

--- a/packages/three-vrm/examples/expressions.html
+++ b/packages/three-vrm/examples/expressions.html
@@ -77,10 +77,11 @@
 				( gltf ) => {
 
 					const vrm = gltf.userData.vrm;
-			
+
 					// calling these functions greatly improves the performance
 					VRMUtils.removeUnnecessaryVertices( gltf.scene );
 					VRMUtils.combineSkeletons( gltf.scene );
+					VRMUtils.combineMorphs( vrm );
 
 					// Disable frustum culling
 					vrm.scene.traverse( ( obj ) => {

--- a/packages/three-vrm/examples/firstperson.html
+++ b/packages/three-vrm/examples/firstperson.html
@@ -81,6 +81,7 @@
 					// calling these functions greatly improves the performance
 					VRMUtils.removeUnnecessaryVertices( gltf.scene );
 					VRMUtils.combineSkeletons( gltf.scene );
+					VRMUtils.combineMorphs( vrm );
 
 					// Disable frustum culling
 					vrm.scene.traverse( ( obj ) => {

--- a/packages/three-vrm/examples/humanoidAnimation/main.js
+++ b/packages/three-vrm/examples/humanoidAnimation/main.js
@@ -62,6 +62,11 @@ function loadVRM( modelUrl ) {
 
 			const vrm = gltf.userData.vrm;
 
+			// calling this function greatly improves the performance
+			VRMUtils.removeUnnecessaryVertices( gltf.scene );
+			VRMUtils.combineSkeletons( gltf.scene );
+			VRMUtils.combineMorphs( vrm );
+
 			if ( currentVrm ) {
 
 				scene.remove( currentVrm.scene );

--- a/packages/three-vrm/examples/lookat-advanced.html
+++ b/packages/three-vrm/examples/lookat-advanced.html
@@ -152,6 +152,7 @@
 					// calling these functions greatly improves the performance
 					VRMUtils.removeUnnecessaryVertices( gltf.scene );
 					VRMUtils.combineSkeletons( gltf.scene );
+					VRMUtils.combineMorphs( vrm );
 
 					// Disable frustum culling
 					vrm.scene.traverse( ( obj ) => {

--- a/packages/three-vrm/examples/lookat.html
+++ b/packages/three-vrm/examples/lookat.html
@@ -85,6 +85,7 @@
 					// calling these functions greatly improves the performance
 					VRMUtils.removeUnnecessaryVertices( gltf.scene );
 					VRMUtils.combineSkeletons( gltf.scene );
+					VRMUtils.combineMorphs( vrm );
 
 					// Disable frustum culling
 					vrm.scene.traverse( ( obj ) => {

--- a/packages/three-vrm/examples/materials-debug.html
+++ b/packages/three-vrm/examples/materials-debug.html
@@ -81,6 +81,7 @@
 					// calling these functions greatly improves the performance
 					VRMUtils.removeUnnecessaryVertices( gltf.scene );
 					VRMUtils.combineSkeletons( gltf.scene );
+					VRMUtils.combineMorphs( vrm );
 
 					// Disable frustum culling
 					vrm.scene.traverse( ( obj ) => {

--- a/packages/three-vrm/examples/meta.html
+++ b/packages/three-vrm/examples/meta.html
@@ -98,6 +98,7 @@
 					// calling these functions greatly improves the performance
 					VRMUtils.removeUnnecessaryVertices( gltf.scene );
 					VRMUtils.combineSkeletons( gltf.scene );
+					VRMUtils.combineMorphs( vrm );
 
 					// Disable frustum culling
 					vrm.scene.traverse( ( obj ) => {

--- a/packages/three-vrm/examples/mouse.html
+++ b/packages/three-vrm/examples/mouse.html
@@ -76,6 +76,7 @@
 					// calling these functions greatly improves the performance
 					VRMUtils.removeUnnecessaryVertices( gltf.scene );
 					VRMUtils.combineSkeletons( gltf.scene );
+					VRMUtils.combineMorphs( vrm );
 
 					// Disable frustum culling
 					vrm.scene.traverse( ( obj ) => {

--- a/packages/three-vrm/examples/webgpu-dnd.html
+++ b/packages/three-vrm/examples/webgpu-dnd.html
@@ -99,6 +99,7 @@
 						// calling these functions greatly improves the performance
 						VRMUtils.removeUnnecessaryVertices( gltf.scene );
 						VRMUtils.combineSkeletons( gltf.scene );
+						VRMUtils.combineMorphs( vrm );
 
 						if ( currentVrm ) {
 

--- a/packages/three-vrm/src/VRMUtils/combineMorphs.ts
+++ b/packages/three-vrm/src/VRMUtils/combineMorphs.ts
@@ -1,0 +1,140 @@
+import * as THREE from 'three';
+import { VRMCore, VRMExpressionMorphTargetBind } from '@pixiv/three-vrm-core';
+import { temp } from 'three/webgpu';
+
+/**
+ * Traverse an entire tree and collect meshes.
+ */
+function collectMeshes(scene: THREE.Group): Set<THREE.Mesh> {
+  const meshes = new Set<THREE.Mesh>();
+
+  scene.traverse((obj) => {
+    if (!(obj as any).isMesh) {
+      return;
+    }
+
+    const mesh = obj as THREE.Mesh;
+    meshes.add(mesh);
+  });
+
+  return meshes;
+}
+
+function combineMorph(
+  geometry: THREE.BufferGeometry,
+  binds: Iterable<VRMExpressionMorphTargetBind>,
+): [THREE.BufferAttribute, THREE.BufferAttribute] {
+  const newPArr = new Float32Array(geometry.attributes.position.count * 3);
+  const newNArr = new Float32Array(geometry.attributes.normal.count * 3);
+  for (const bind of binds) {
+    const srcP = geometry.morphAttributes.position[bind.index];
+    for (let i = 0; i < srcP.count; i++) {
+      newPArr[i * 3 + 0] += srcP.getX(i) * bind.weight;
+      newPArr[i * 3 + 1] += srcP.getY(i) * bind.weight;
+      newPArr[i * 3 + 2] += srcP.getZ(i) * bind.weight;
+    }
+
+    const srcN = geometry.morphAttributes.normal?.[bind.index];
+    if (srcN != null) {
+      for (let i = 0; i < srcN.count; i++) {
+        newNArr[i * 3 + 0] += srcN.getX(i) * bind.weight;
+        newNArr[i * 3 + 1] += srcN.getY(i) * bind.weight;
+        newNArr[i * 3 + 2] += srcN.getZ(i) * bind.weight;
+      }
+    }
+  }
+
+  const newP = new THREE.BufferAttribute(newPArr, 3);
+  const newN = new THREE.BufferAttribute(newNArr, 3);
+  return [newP, newN];
+}
+
+/**
+ * Combine morph targets by VRM expressions.
+ *
+ * This function prevents crashes caused by the limitation of the number of morph targets, especially on mobile devices.
+ *
+ * @param vrm The VRM instance
+ */
+export function combineMorphs(vrm: VRMCore): void {
+  const meshes = collectMeshes(vrm.scene);
+
+  // Iterate over all expressions and check which morph targets are used
+  const meshBindListMap = new Map<THREE.Mesh, [string, VRMExpressionMorphTargetBind][]>();
+
+  const expressionMap = vrm.expressionManager?.expressionMap;
+  if (expressionMap != null) {
+    for (const [expressionName, expression] of Object.entries(expressionMap)) {
+      const bindsToDeleteSet = new Set<VRMExpressionMorphTargetBind>();
+      for (const bind of expression.binds) {
+        if (bind instanceof VRMExpressionMorphTargetBind) {
+          if (bind.weight !== 0.0) {
+            for (const mesh of bind.primitives) {
+              const bindList = meshBindListMap.get(mesh) ?? [];
+              bindList.push([expressionName, bind]);
+              meshBindListMap.set(mesh, bindList);
+            }
+          }
+          bindsToDeleteSet.add(bind);
+        }
+      }
+
+      for (const bind of bindsToDeleteSet) {
+        expression.deleteBind(bind);
+      }
+    }
+  }
+
+  // Combine morphs
+  for (const mesh of meshes) {
+    const bindList = meshBindListMap.get(mesh);
+    if (bindList == null) {
+      continue;
+    }
+
+    const geometry = mesh.geometry.clone();
+    mesh.geometry = geometry;
+
+    const morphAttributes: typeof geometry.morphAttributes = {
+      position: [],
+      normal: [],
+    };
+
+    const morphTargetDictionary: typeof mesh.morphTargetDictionary = {};
+    const morphTargetInfluences: typeof mesh.morphTargetInfluences = [];
+
+    const nameBindSetMap = new Map<string, Set<VRMExpressionMorphTargetBind>>();
+    for (const [name, bind] of bindList) {
+      let set = nameBindSetMap.get(name);
+      if (set == null) {
+        set = new Set<VRMExpressionMorphTargetBind>();
+        nameBindSetMap.set(name, set);
+      }
+      set.add(bind);
+    }
+
+    let i = 0;
+    for (const [name, bindSet] of nameBindSetMap) {
+      const [newP, newN] = combineMorph(geometry, bindSet);
+      morphAttributes.position[i] = newP;
+      morphAttributes.normal[i] = newN;
+
+      expressionMap?.[name].addBind(
+        new VRMExpressionMorphTargetBind({
+          index: i,
+          weight: 1.0,
+          primitives: [mesh],
+        }),
+      );
+
+      morphTargetDictionary[name] = i;
+      morphTargetInfluences.push(0.0);
+
+      i++;
+    }
+
+    geometry.morphAttributes = morphAttributes;
+    mesh.morphTargetDictionary = morphTargetDictionary;
+    mesh.morphTargetInfluences = morphTargetInfluences;
+  }
+}

--- a/packages/three-vrm/src/VRMUtils/index.ts
+++ b/packages/three-vrm/src/VRMUtils/index.ts
@@ -1,3 +1,4 @@
+import { combineMorphs } from './combineMorphs';
 import { combineSkeletons } from './combineSkeletons';
 import { deepDispose } from './deepDispose';
 import { removeUnnecessaryJoints } from './removeUnnecessaryJoints';
@@ -9,6 +10,7 @@ export class VRMUtils {
     // this class is not meant to be instantiated
   }
 
+  public static combineMorphs = combineMorphs;
   public static combineSkeletons = combineSkeletons;
   public static deepDispose = deepDispose;
   public static removeUnnecessaryJoints = removeUnnecessaryJoints;


### PR DESCRIPTION
This will resolve https://github.com/pixiv/three-vrm/issues/1369

This PR will add `VRMUtils.combineMorphs`.

This function will prevent shader errors caused by the limitation of the number of morph targets, especially on mobile devices.
This might potentially improve the performance when using models with a lot of unnecessary morphs.

This PR also exposes `VRMExpression.binds` and adds `VRMExpression.deleteBind()`.
These were required to implement `VRMUtils.combineMorphs`.
