### PR TITLE
feat: `VRMUtils.precompileShaders`

### DIFF
--- a/packages/three-vrm/examples/dnd.html
+++ b/packages/three-vrm/examples/dnd.html
@@ -76,7 +76,7 @@
 
 					url,
 
-					( gltf ) => {
+					async ( gltf ) => {
 
 						const vrm = gltf.userData.vrm;
 
@@ -96,6 +96,13 @@
 						vrm.scene.traverse( ( obj ) => {
 
 							obj.frustumCulled = false;
+
+						} );
+
+						// Precompile shaders to prevent the main thread from being blocked
+						await VRMUtils.precompileShaders( scene, camera, renderer, vrm.scene, ( progress ) => {
+
+							console.log( 'Compiling shaders...', 100.0 * ( progress.compiled / progress.total ), '%' );
 
 						} );
 

--- a/packages/three-vrm/examples/humanoidAnimation/main.js
+++ b/packages/three-vrm/examples/humanoidAnimation/main.js
@@ -58,7 +58,7 @@ function loadVRM( modelUrl ) {
 		modelUrl,
 
 		// called when the resource is loaded
-		( gltf ) => {
+		async ( gltf ) => {
 
 			const vrm = gltf.userData.vrm;
 
@@ -83,6 +83,13 @@ function loadVRM( modelUrl ) {
 			vrm.scene.traverse( ( obj ) => {
 
 				obj.frustumCulled = false;
+
+			} );
+
+			// Precompile shaders to prevent the main thread from being blocked
+			await VRMUtils.precompileShaders( scene, camera, renderer, vrm.scene, ( progress ) => {
+
+				console.log( 'Compiling shaders...', 100.0 * ( progress.compiled / progress.total ), '%' );
 
 			} );
 

--- a/packages/three-vrm/examples/humanoidAnimation/main.js
+++ b/packages/three-vrm/examples/humanoidAnimation/main.js
@@ -49,7 +49,7 @@ function loadVRM( modelUrl ) {
 
 	loader.register( ( parser ) => {
 
-		return new VRMLoaderPlugin( parser, { helperRoot: helperRoot, autoUpdateHumanBones: true } );
+		return new VRMLoaderPlugin( parser, { autoUpdateHumanBones: true } );
 
 	} );
 
@@ -75,10 +75,6 @@ function loadVRM( modelUrl ) {
 
 			}
 
-			// put the model to the scene
-			currentVrm = vrm;
-			scene.add( vrm.scene );
-
 			// Disable frustum culling
 			vrm.scene.traverse( ( obj ) => {
 
@@ -92,6 +88,10 @@ function loadVRM( modelUrl ) {
 				console.log( 'Compiling shaders...', 100.0 * ( progress.compiled / progress.total ), '%' );
 
 			} );
+
+			// put the model to the scene
+			currentVrm = vrm;
+			scene.add( vrm.scene );
 
 			if ( currentAnimationUrl ) {
 

--- a/packages/three-vrm/src/VRMUtils/index.ts
+++ b/packages/three-vrm/src/VRMUtils/index.ts
@@ -1,6 +1,7 @@
 import { combineMorphs } from './combineMorphs';
 import { combineSkeletons } from './combineSkeletons';
 import { deepDispose } from './deepDispose';
+import { precompileShaders } from './precompileShaders';
 import { removeUnnecessaryJoints } from './removeUnnecessaryJoints';
 import { removeUnnecessaryVertices } from './removeUnnecessaryVertices';
 import { rotateVRM0 } from './rotateVRM0';
@@ -13,6 +14,7 @@ export class VRMUtils {
   public static combineMorphs = combineMorphs;
   public static combineSkeletons = combineSkeletons;
   public static deepDispose = deepDispose;
+  public static precompileShaders = precompileShaders;
   public static removeUnnecessaryJoints = removeUnnecessaryJoints;
   public static removeUnnecessaryVertices = removeUnnecessaryVertices;
   public static rotateVRM0 = rotateVRM0;

--- a/packages/three-vrm/src/VRMUtils/precompileShaders.ts
+++ b/packages/three-vrm/src/VRMUtils/precompileShaders.ts
@@ -27,6 +27,17 @@ async function timeSlice(generator: Generator<void>, budgetMs: number): Promise<
   }
 }
 
+function* generatorAwait(promise: Promise<unknown>) {
+  let finished = false;
+  promise.then(() => {
+    finished = true;
+  });
+
+  while (!finished) {
+    yield;
+  }
+}
+
 function* generatorInitMeshTexturesWebGL(renderer: THREE.WebGLRenderer, mesh: THREE.Mesh) {
   const textures: THREE.Texture[] = [];
 
@@ -108,11 +119,12 @@ function* generatorPrecompileShadersWebGL(
     const mesh = meshes[i];
 
     // Initialize textures
-    for (const _ of generatorInitMeshTexturesWebGL(renderer, mesh)) {
-      yield;
-    }
+    yield* generatorInitMeshTexturesWebGL(renderer, mesh);
 
-    // Precompile shaders
+    // Compile shaders with `KHR_parallel_shader_compile`
+    yield* generatorAwait(renderer.compileAsync(mesh, camera, scene));
+
+    // Draw once to compile the shader on the graphics API
     precompileMeshShadersWebGL(scene, camera, renderer, mesh);
 
     // Report the progress

--- a/packages/three-vrm/src/VRMUtils/precompileShaders.ts
+++ b/packages/three-vrm/src/VRMUtils/precompileShaders.ts
@@ -81,10 +81,12 @@ function precompileMeshShadersWebGL(
   // We will render each mesh onto the current render target
   const tempViewport = renderer.getViewport(_v4A);
   const tempAutoClear = renderer.autoClear;
+  const tempBackground = scene.background;
 
   // Set the viewport to zero to not draw anything on the target
   renderer.setViewport(0, 0, 0, 0);
   renderer.autoClear = false;
+  scene.background = null;
 
   // Clone the mesh, put it into the scene, and render it
   const meshClone = mesh.clone();
@@ -95,6 +97,7 @@ function precompileMeshShadersWebGL(
   // Restore the viewport and autoClear
   renderer.setViewport(tempViewport);
   renderer.autoClear = tempAutoClear;
+  scene.background = tempBackground;
 }
 
 function* generatorPrecompileShadersWebGL(

--- a/packages/three-vrm/src/VRMUtils/precompileShaders.ts
+++ b/packages/three-vrm/src/VRMUtils/precompileShaders.ts
@@ -1,0 +1,174 @@
+import * as THREE from 'three';
+
+const _v4A = new THREE.Vector4();
+
+/**
+ * Resolves after the next frame.
+ */
+function sleepFrame(): Promise<void> {
+  return new Promise((resolve) => {
+    requestAnimationFrame(() => {
+      resolve();
+    });
+  });
+}
+
+/**
+ * Time slice the given generator to prevent the main thread from being blocked.
+ */
+async function timeSlice(generator: Generator<void>, budgetMs: number): Promise<void> {
+  let pauseTime = performance.now() + budgetMs;
+
+  for (const _ of generator) {
+    if (performance.now() > pauseTime) {
+      await sleepFrame();
+      pauseTime = performance.now() + budgetMs;
+    }
+  }
+}
+
+function* generatorInitMeshTexturesWebGL(renderer: THREE.WebGLRenderer, mesh: THREE.Mesh) {
+  const textures: THREE.Texture[] = [];
+
+  // Collect textures from the material
+  const materials = Array.isArray(mesh.material) ? mesh.material : [mesh.material];
+  for (const material of materials) {
+    for (const key in material) {
+      const prop = (material as any)[key];
+      if (prop?.isTexture) {
+        textures.push(prop);
+      }
+    }
+
+    // Also check the uniforms (MToon stores all textures in the uniforms)
+    if ((material as any).uniforms) {
+      for (const key in (material as any).uniforms) {
+        const prop = (material as any).uniforms[key];
+        if (prop?.value?.isTexture) {
+          textures.push(prop.value);
+        }
+      }
+    }
+  }
+
+  // Initialize textures
+  for (const texture of textures) {
+    if (texture.image) {
+      renderer.initTexture(texture);
+    }
+
+    yield;
+  }
+}
+
+function precompileMeshShadersWebGL(
+  scene: THREE.Scene,
+  camera: THREE.Camera,
+  renderer: THREE.WebGLRenderer,
+  mesh: THREE.Mesh,
+) {
+  // We will render each mesh onto the current render target
+  const tempViewport = renderer.getViewport(_v4A);
+  const tempAutoClear = renderer.autoClear;
+
+  // Set the viewport to zero to not draw anything on the target
+  renderer.setViewport(0, 0, 0, 0);
+  renderer.autoClear = false;
+
+  // Clone the mesh, put it into the scene, and render it
+  const meshClone = mesh.clone();
+  scene.add(meshClone);
+  renderer.render(scene, camera);
+  scene.remove(meshClone);
+
+  // Restore the viewport and autoClear
+  renderer.setViewport(tempViewport);
+  renderer.autoClear = tempAutoClear;
+}
+
+function* generatorPrecompileShadersWebGL(
+  scene: THREE.Scene,
+  camera: THREE.Camera,
+  renderer: THREE.WebGLRenderer,
+  root: THREE.Object3D,
+  onProgress?: (progress: { compiled: number; total: number }) => void,
+) {
+  const meshes: THREE.Mesh[] = [];
+
+  // Traverse the root and collect meshes
+  root.traverse((ob) => {
+    if ((ob as any).isMesh) {
+      meshes.push(ob as THREE.Mesh);
+    }
+  });
+
+  // for each meshes...
+  const nMeshes = meshes.length;
+  for (let i = 0; i < nMeshes; i++) {
+    const mesh = meshes[i];
+
+    // Initialize textures
+    for (const _ of generatorInitMeshTexturesWebGL(renderer, mesh)) {
+      yield;
+    }
+
+    // Precompile shaders
+    precompileMeshShadersWebGL(scene, camera, renderer, mesh);
+
+    // Report the progress
+    onProgress?.({
+      compiled: i + 1,
+      total: nMeshes,
+    });
+
+    yield;
+  }
+}
+
+async function precompileShadersWebGL(
+  scene: THREE.Scene,
+  camera: THREE.Camera,
+  renderer: THREE.WebGLRenderer,
+  root: THREE.Object3D,
+  onProgress?: (progress: { compiled: number; total: number }) => void,
+): Promise<void> {
+  await timeSlice(generatorPrecompileShadersWebGL(scene, camera, renderer, root, onProgress), 1.0);
+}
+
+/**
+ * Precompile shaders for all mesh materials in the given root.
+ * The shader compilation will be time sliced to prevent the main thread from being blocked.
+ *
+ * Call this function before adding the root to the scene.
+ *
+ * ```js
+ * await precompileShaders(scene, camera, renderer, vrm.scene);
+ * scene.add(vrm.scene);
+ * ```
+ *
+ * This function compiles shaders by rendering meshes once to the current render target (not visible on the render target).
+ * The shader variant on the graphics API might be different depending on the format of the render target.
+ * Make sure to attach the render target you will use (or null if you want to render onto the canvas) to the renderer before calling this function.
+ * Otherwise, this function will not make any benefits.
+ *
+ * This function only supports WebGLRenderer at the moment.
+ *
+ * @param scene The scene to render.
+ * @param camera The camera to render.
+ * @param renderer The renderer to render.
+ * @param root The root object to precompile shaders.
+ * @param onProgress A function to be called when the precompilation progresses.
+ */
+export async function precompileShaders(
+  scene: THREE.Scene,
+  camera: THREE.Camera,
+  renderer: THREE.Renderer,
+  root: THREE.Object3D,
+  onProgress?: (progress: { compiled: number; total: number }) => void,
+): Promise<void> {
+  if ((renderer as any).isWebGLRenderer) {
+    return precompileShadersWebGL(scene, camera, renderer as THREE.WebGLRenderer, root, onProgress);
+  } else {
+    throw new Error('Unsupported renderer');
+  }
+}


### PR DESCRIPTION
This PR introduces `VRMUtils.precompileShaders`.

`precompileShaders` is a function to time slice the shader compilations to prevent the main thread from being blocked.

This function only supports WebGLRenderer at the moment.

### Points need review

- [ ] Is it nice to have in three-vrm?
    - We have a lot of stuff inside `VRMUtils` lately,,,
- [ ] Is the signature name appropriate?
    - Related APIs: `WebGLRenderer.compile()`, `WebGLRenderer.compileAsync()`, `WebGLRenderer.initTexture()`
    - Candidates: `precompileShaders`, `compileShaders`, `compileShadersAsync`, `precompile`, `compile`, `timeslicedCompile`, `timeslicedCompileAsync`, `prepareMaterials`, `prepareMaterialsAsync`, ...
        - It seems this is the first time we expose functions or methods that return `Promise` other than loader plugins.