### PR TITLE
fix: SpringBone, forgot to add springBones to springBonesTried when sorting

### DIFF
--- a/packages/three-vrm-springbone/src/VRMSpringBoneManager.ts
+++ b/packages/three-vrm-springbone/src/VRMSpringBoneManager.ts
@@ -180,6 +180,8 @@ export class VRMSpringBoneManager {
       return;
     }
 
+    springBonesTried.add(springBone);
+
     const depObjects = springBone.dependencies;
     for (const depObject of depObjects) {
       let encounteredSpringBone = false;


### PR DESCRIPTION
This fixes the `Maximum call stack size exceeded` exception happens when we load a model with a circular dependency in the spring bone system.

See: https://github.com/pixiv/three-vrm/pull/1539#discussion_r1881647521