### PR TITLE
feat: Make it able to load VRMA without specVersion

### DIFF
--- a/packages/three-vrm-animation/src/VRMAnimationLoaderPlugin.ts
+++ b/packages/three-vrm-animation/src/VRMAnimationLoaderPlugin.ts
@@ -58,14 +58,20 @@ export class VRMAnimationLoaderPlugin implements GLTFLoaderPlugin {
     }
 
     const specVersion = defExtension.specVersion;
-    if (!POSSIBLE_SPEC_VERSIONS.has(specVersion)) {
-      console.warn(`VRMAnimationLoaderPlugin: Unknown VRMC_vrm_animation spec version: ${specVersion}`);
-      return;
-    }
-    if (specVersion === '1.0-draft') {
+    if (specVersion == null) {
       console.warn(
-        'VRMAnimationLoaderPlugin: Using a draft spec version: 1.0-draft. Some behaviors may be different. Consider updating the animation file.',
+        'VRMAnimationLoaderPlugin: specVersion of the VRMA is not defined. Consider updating the animation file. Assuming the spec version is 1.0.',
       );
+    } else {
+      if (!POSSIBLE_SPEC_VERSIONS.has(specVersion)) {
+        console.warn(`VRMAnimationLoaderPlugin: Unknown VRMC_vrm_animation spec version: ${specVersion}`);
+        return;
+      }
+      if (specVersion === '1.0-draft') {
+        console.warn(
+          'VRMAnimationLoaderPlugin: Using a draft spec version: 1.0-draft. Some behaviors may be different. Consider updating the animation file.',
+        );
+      }
     }
 
     const nodeMap = this._createNodeMap(defExtension);


### PR DESCRIPTION
VRMAs exported from UniVRM prior to v0.120 doesn't have specVersion

See: https://github.com/vrm-c/UniVRM/pull/2251

Original discussion: https://github.com/pixiv/three-vrm/discussions/1563
