### PR TITLE
fix: add undefined check.

### DIFF
--- a/packages/three-vrm-materials-mtoon/src/GLTFMToonMaterialParamsAssignHelper.ts
+++ b/packages/three-vrm-materials-mtoon/src/GLTFMToonMaterialParamsAssignHelper.ts
@@ -52,7 +52,7 @@ export class GLTFMToonMaterialParamsAssignHelper {
       if (texture != null) {
         await this._parser.assignTexture(this._materialParams, key, texture);
 
-        if (isColorTexture) {
+        if (isColorTexture && this._materialParams[key] != null) {
           setTextureColorSpace(this._materialParams[key], 'srgb');
         }
       }


### PR DESCRIPTION
I get the following error when reading a VRM file.

![CleanShot 2025-04-02 at 09 34 44](https://github.com/user-attachments/assets/2031bdab-977b-4221-81ee-5b59b6c9d02e)

The caller is only from the GLTFMTonMaterialParamsAssignHelper and is passed undefined.
The type of this._materialParams is [MToonMaterialParameters](https://github.com/pixiv/three-vrm/blob/9b3bd2c536d168fe2873e7b613817a9ebce0ab31/packages/three-vrm-materials-mtoon/src/MToonMaterialParameters.ts#L5), but Texture-related properties are optional.

In this PR, I added a check for undefined assuming it is optional. (use "! = null" to match the surrounding implementations)
