### PR TITLE
Minor update of docs

### DIFF
--- a/packages/three-vrm-core/src/VRMCore.ts
+++ b/packages/three-vrm-core/src/VRMCore.ts
@@ -51,7 +51,7 @@ export class VRMCore {
   /**
    * Create a new VRM instance.
    *
-   * @param params [[VRMParameters]] that represents components of the VRM
+   * @param params {@link VRMParameters} that represents components of the VRM
    */
   public constructor(params: VRMCoreParameters) {
     this.scene = params.scene;

--- a/packages/three-vrm-core/src/firstPerson/VRMFirstPerson.ts
+++ b/packages/three-vrm-core/src/firstPerson/VRMFirstPerson.ts
@@ -6,14 +6,14 @@ export class VRMFirstPerson {
   /**
    * A default camera layer for `FirstPersonOnly` layer.
    *
-   * @see [[getFirstPersonOnlyLayer]]
+   * @see {@link firstPersonOnlyLayer}
    */
   public static readonly DEFAULT_FIRSTPERSON_ONLY_LAYER = 9;
 
   /**
    * A default camera layer for `ThirdPersonOnly` layer.
    *
-   * @see [[getThirdPersonOnlyLayer]]
+   * @see {@link thirdPersonOnlyLayer}
    */
   public static readonly DEFAULT_THIRDPERSON_ONLY_LAYER = 10;
 
@@ -32,7 +32,7 @@ export class VRMFirstPerson {
    * Create a new VRMFirstPerson object.
    *
    * @param humanoid A {@link VRMHumanoid}
-   * @param meshAnnotations A renderer settings. See the description of [[RendererFirstPersonFlags]] for more info
+   * @param meshAnnotations A {@link VRMFirstPersonMeshAnnotation}
    */
   public constructor(humanoid: VRMHumanoid, meshAnnotations: VRMFirstPersonMeshAnnotation[]) {
     this.humanoid = humanoid;

--- a/packages/three-vrm-core/src/humanoid/VRMPoseTransform.ts
+++ b/packages/three-vrm-core/src/humanoid/VRMPoseTransform.ts
@@ -1,5 +1,7 @@
+import type { VRMPose } from './VRMPose';
+
 /**
- * Represents a transform of a single bone of [[VRMPose]].
+ * Represents a transform of a single bone of {@link VRMPose}.
  * Both `position` and `rotation` are optional.
  */
 export interface VRMPoseTransform {

--- a/packages/three-vrm-core/src/humanoid/VRMRig.ts
+++ b/packages/three-vrm-core/src/humanoid/VRMRig.ts
@@ -114,7 +114,7 @@ export class VRMRig {
    * Each transform have to be a local transform relative from rest pose (T-pose).
    * You can pass what you got from {@link getPose}.
    *
-   * @param poseObject A [[VRMPose]] that represents a single pose
+   * @param poseObject A {@link VRMPose} that represents a single pose
    */
   public setPose(poseObject: VRMPose): void {
     Object.entries(poseObject).forEach(([boneNameString, state]) => {

--- a/packages/three-vrm-materials-mtoon/src/MToonMaterial.ts
+++ b/packages/three-vrm-materials-mtoon/src/MToonMaterial.ts
@@ -368,7 +368,7 @@ export class MToonMaterial extends THREE.ShaderMaterial {
   }
 
   /**
-   * Readonly boolean that indicates this is a [[MToonMaterial]].
+   * Readonly boolean that indicates this is a {@link MToonMaterial}.
    */
   public get isMToonMaterial(): true {
     return true;

--- a/packages/three-vrm-springbone/src/VRMSpringBoneCollider.ts
+++ b/packages/three-vrm-springbone/src/VRMSpringBoneCollider.ts
@@ -2,7 +2,7 @@ import * as THREE from 'three';
 import type { VRMSpringBoneColliderShape } from './VRMSpringBoneColliderShape';
 
 /**
- * Represents a collider of a VRM.
+ * Represents a collider of a spring bone.
  */
 export class VRMSpringBoneCollider extends THREE.Object3D {
   /**

--- a/packages/three-vrm-springbone/src/VRMSpringBoneJoint.ts
+++ b/packages/three-vrm-springbone/src/VRMSpringBoneJoint.ts
@@ -2,6 +2,7 @@ import * as THREE from 'three';
 import { Matrix4InverseCache } from './utils/Matrix4InverseCache';
 import type { VRMSpringBoneColliderGroup } from './VRMSpringBoneColliderGroup';
 import type { VRMSpringBoneJointSettings } from './VRMSpringBoneJointSettings';
+import type { VRMSpringBoneManager } from './VRMSpringBoneManager';
 
 // based on
 // http://rocketjump.skr.jp/unity3d/109/
@@ -27,7 +28,7 @@ const _matA = new THREE.Matrix4();
 
 /**
  * A class represents a single joint of a spring bone.
- * It should be managed by a [[VRMSpringBoneManager]].
+ * It should be managed by a {@link VRMSpringBoneManager}.
  */
 export class VRMSpringBoneJoint {
   /**
@@ -205,7 +206,7 @@ export class VRMSpringBoneJoint {
 
   /**
    * Reset the state of this bone.
-   * You might want to call [[VRMSpringBoneManager.reset]] instead.
+   * You might want to call {@link VRMSpringBoneManager.reset} instead.
    */
   public reset(): void {
     this.bone.quaternion.copy(this._initialLocalRotation);
@@ -222,7 +223,7 @@ export class VRMSpringBoneJoint {
 
   /**
    * Update the state of this bone.
-   * You might want to call [[VRMSpringBoneManager.update]] instead.
+   * You might want to call {@link VRMSpringBoneManager.update} instead.
    *
    * @param delta deltaTime
    */

--- a/packages/three-vrm/src/VRM.ts
+++ b/packages/three-vrm/src/VRM.ts
@@ -29,7 +29,7 @@ export class VRM extends VRMCore {
   /**
    * Create a new VRM instance.
    *
-   * @param params [[VRMParameters]] that represents components of the VRM
+   * @param params {@link VRMParameters} that represents components of the VRM
    */
   public constructor(params: VRMParameters) {
     super(params);


### PR DESCRIPTION
- VRMSpringBoneCollider: "Represents a collider of a VRM." -> "Represents a collider of a spring bone."
- links, use @link tag instaed of double bracket
  - `@link` has more compatibility over double bracket
