### PR TITLE
fix: Correct humanoid FBX root motion retargeting

### DIFF
--- a/packages/three-vrm-core/examples/humanoidAnimation/loadMixamoAnimation.js
+++ b/packages/three-vrm-core/examples/humanoidAnimation/loadMixamoAnimation.js
@@ -25,9 +25,7 @@ export function loadMixamoAnimation( url, vrm ) {
 
 		// Adjust with reference to hips height.
 		const motionHipsHeight = asset.getObjectByName( 'mixamorigHips' ).position.y;
-		const vrmHipsY = vrm.humanoid?.getNormalizedBoneNode( 'hips' ).getWorldPosition( _vec3 ).y;
-		const vrmRootY = vrm.scene.getWorldPosition( _vec3 ).y;
-		const vrmHipsHeight = Math.abs( vrmHipsY - vrmRootY );
+		const vrmHipsHeight = vrm.humanoid.normalizedRestPose.hips.position[ 1 ];
 		const hipsPositionScale = vrmHipsHeight / motionHipsHeight;
 
 		clip.tracks.forEach( ( track ) => {

--- a/packages/three-vrm/examples/humanoidAnimation/loadMixamoAnimation.js
+++ b/packages/three-vrm/examples/humanoidAnimation/loadMixamoAnimation.js
@@ -25,9 +25,7 @@ export function loadMixamoAnimation( url, vrm ) {
 
 		// Adjust with reference to hips height.
 		const motionHipsHeight = asset.getObjectByName( 'mixamorigHips' ).position.y;
-		const vrmHipsY = vrm.humanoid?.getNormalizedBoneNode( 'hips' ).getWorldPosition( _vec3 ).y;
-		const vrmRootY = vrm.scene.getWorldPosition( _vec3 ).y;
-		const vrmHipsHeight = Math.abs( vrmHipsY - vrmRootY );
+		const vrmHipsHeight = vrm.humanoid.normalizedRestPose.hips.position[ 1 ];
 		const hipsPositionScale = vrmHipsHeight / motionHipsHeight;
 
 		clip.tracks.forEach( ( track ) => {

--- a/packages/three-vrm/examples/humanoidAnimation/main.js
+++ b/packages/three-vrm/examples/humanoidAnimation/main.js
@@ -35,6 +35,7 @@ const defaultModelUrl = '../models/VRM1_Constraint_Twist_Sample.vrm';
 let currentVrm = undefined;
 let currentAnimationUrl = undefined;
 let currentMixer = undefined;
+let currentAction = undefined;
 
 const helperRoot = new THREE.Group();
 helperRoot.renderOrder = 10000;
@@ -79,6 +80,9 @@ function loadVRM( modelUrl ) {
 			currentVrm = vrm;
 			scene.add( vrm.scene );
 
+			// create AnimationMixer for VRM
+			currentMixer = new THREE.AnimationMixer( currentVrm.scene );
+
 			// Disable frustum culling
 			vrm.scene.traverse( ( obj ) => {
 
@@ -111,21 +115,27 @@ function loadVRM( modelUrl ) {
 loadVRM( defaultModelUrl );
 
 // mixamo animation
-function loadFBX( animationUrl ) {
+async function loadFBX( animationUrl ) {
 
 	currentAnimationUrl = animationUrl;
 
-	// create AnimationMixer for VRM
-	currentMixer = new THREE.AnimationMixer( currentVrm.scene );
+	if ( currentMixer ) {
 
-	// Load animation
-	loadMixamoAnimation( animationUrl, currentVrm ).then( ( clip ) => {
+		// Load animation
+		const clip = await loadMixamoAnimation( animationUrl, currentVrm );
 
-		// Apply the loaded animation to mixer and play
-		currentMixer.clipAction( clip ).play();
-		currentMixer.timeScale = params.timeScale;
+		const newAction = currentMixer.clipAction( clip );
+		newAction.reset().play();
 
-	} );
+		if ( currentAction && currentAction !== newAction ) {
+
+			currentAction.crossFadeTo( newAction, 0.5, false );
+
+		}
+
+		currentAction = newAction;
+
+	}
 
 }
 

--- a/packages/three-vrm/examples/humanoidAnimation/main.js
+++ b/packages/three-vrm/examples/humanoidAnimation/main.js
@@ -115,7 +115,6 @@ function loadFBX( animationUrl ) {
 
 	currentAnimationUrl = animationUrl;
 
-	currentVrm.humanoid.resetNormalizedPose();
 	// create AnimationMixer for VRM
 	currentMixer = new THREE.AnimationMixer( currentVrm.scene );
 


### PR DESCRIPTION
Fix #1643.

Root motion retargeting was affected by current Hips world position. Modified to reference Humanoid.NormalizedRestPose, similar to VRMAnimation.