### PR TITLE
Bump Three.js to r176

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ You can import all the dependencies via CDN like [jsDelivr](https://www.jsdelivr
 <script type="importmap">
   {
     "imports": {
-      "three": "https://cdn.jsdelivr.net/npm/three@0.171.0/build/three.module.js",
-      "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.171.0/examples/jsm/",
+      "three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
+      "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
       "@pixiv/three-vrm": "https://cdn.jsdelivr.net/npm/@pixiv/three-vrm@3/lib/three-vrm.module.min.js"
     }
   }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "lint-fix": "lerna run lint-fix",
     "docs": "typedoc",
     "docs-legacy": "lerna run docs-legacy",
-    "prepare": "husky"
+    "prepare": "husky",
+    "postinstall": "patch-package"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3.2.0",
@@ -35,6 +36,7 @@
     "jest": "^29.7.0",
     "lerna": "^8.1.8",
     "lint-staged": "^15.1.0",
+    "patch-package": "^8.0.0",
     "prettier": "^3.3.3",
     "rimraf": "^6.0.1",
     "ts-jest": "^29.1.2",

--- a/packages/three-vrm-animation/examples/dnd.html
+++ b/packages/three-vrm-animation/examples/dnd.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.171.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.171.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
 					"@pixiv/three-vrm": "https://cdn.jsdelivr.net/npm/@pixiv/three-vrm@3/lib/three-vrm.module.js",
 					"@pixiv/three-vrm-animation": "../lib/three-vrm-animation.module.js"
 				}

--- a/packages/three-vrm-animation/examples/loader-plugin.html
+++ b/packages/three-vrm-animation/examples/loader-plugin.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.171.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.171.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
 					"@pixiv/three-vrm": "https://cdn.jsdelivr.net/npm/@pixiv/three-vrm@3/lib/three-vrm.module.js",
 					"@pixiv/three-vrm-animation": "../lib/three-vrm-animation.module.js"
 				}

--- a/packages/three-vrm-animation/package.json
+++ b/packages/three-vrm-animation/package.json
@@ -51,9 +51,9 @@
     "@pixiv/types-vrmc-vrm-animation-1.0": "3.4.0"
   },
   "devDependencies": {
-    "@types/three": "^0.170.0",
+    "@types/three": "^0.176.0",
     "lint-staged": "15.2.10",
-    "three": "^0.171.0"
+    "three": "^0.176.0"
   },
   "peerDependencies": {
     "three": ">=0.137"

--- a/packages/three-vrm-core/examples/expressions.html
+++ b/packages/three-vrm-core/examples/expressions.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.171.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.171.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
 					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/examples/firstPerson.html
+++ b/packages/three-vrm-core/examples/firstPerson.html
@@ -28,8 +28,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.171.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.171.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
 					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/examples/humanoid.html
+++ b/packages/three-vrm-core/examples/humanoid.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.171.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.171.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
 					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/examples/humanoidAnimation/index.html
+++ b/packages/three-vrm-core/examples/humanoidAnimation/index.html
@@ -34,8 +34,8 @@
 			{
 				"imports": {
 					"fflate": "https://cdn.jsdelivr.net/npm/fflate@0.7.4/esm/browser.js",
-					"three": "https://cdn.jsdelivr.net/npm/three@0.171.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.171.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
 					"@pixiv/three-vrm-core": "../../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/examples/lookAt.html
+++ b/packages/three-vrm-core/examples/lookAt.html
@@ -28,8 +28,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.171.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.171.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
 					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/examples/meta.html
+++ b/packages/three-vrm-core/examples/meta.html
@@ -35,8 +35,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.171.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.171.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
 					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/package.json
+++ b/packages/three-vrm-core/package.json
@@ -54,8 +54,8 @@
     "@pixiv/types-vrmc-vrm-1.0": "3.4.0"
   },
   "devDependencies": {
-    "@types/three": "^0.170.0",
-    "three": "^0.171.0"
+    "@types/three": "^0.176.0",
+    "three": "^0.176.0"
   },
   "peerDependencies": {
     "three": ">=0.137"

--- a/packages/three-vrm-materials-hdr-emissive-multiplier/examples/loader-plugin.html
+++ b/packages/three-vrm-materials-hdr-emissive-multiplier/examples/loader-plugin.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.171.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.171.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
 					"@pixiv/three-vrm-materials-hdr-emissive-multiplier": "../lib/three-vrm-materials-hdr-emissive-multiplier.module.js"
 				}
 			}

--- a/packages/three-vrm-materials-hdr-emissive-multiplier/package.json
+++ b/packages/three-vrm-materials-hdr-emissive-multiplier/package.json
@@ -52,8 +52,8 @@
     "@pixiv/types-vrmc-materials-hdr-emissive-multiplier-1.0": "3.4.0"
   },
   "devDependencies": {
-    "@types/three": "^0.170.0",
-    "three": "^0.171.0"
+    "@types/three": "^0.176.0",
+    "three": "^0.176.0"
   },
   "peerDependencies": {
     "three": ">=0.137"

--- a/packages/three-vrm-materials-mtoon/examples/emissive-strength.html
+++ b/packages/three-vrm-materials-mtoon/examples/emissive-strength.html
@@ -24,8 +24,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.171.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.171.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
 					"@pixiv/three-vrm-materials-mtoon": "../lib/three-vrm-materials-mtoon.module.js"
 				}
 			}

--- a/packages/three-vrm-materials-mtoon/examples/feature-test.html
+++ b/packages/three-vrm-materials-mtoon/examples/feature-test.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.171.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.171.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
 					"@pixiv/three-vrm-materials-mtoon": "../lib/three-vrm-materials-mtoon.module.js"
 				}
 			}

--- a/packages/three-vrm-materials-mtoon/examples/loader-plugin.html
+++ b/packages/three-vrm-materials-mtoon/examples/loader-plugin.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.171.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.171.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
 					"@pixiv/three-vrm-materials-mtoon": "../lib/three-vrm-materials-mtoon.module.js"
 				}
 			}

--- a/packages/three-vrm-materials-mtoon/examples/webgpu-feature-test.html
+++ b/packages/three-vrm-materials-mtoon/examples/webgpu-feature-test.html
@@ -23,10 +23,10 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.171.0/build/three.webgpu.js",
-					"three/webgpu": "https://cdn.jsdelivr.net/npm/three@0.171.0/build/three.webgpu.js",
-					"three/tsl": "https://cdn.jsdelivr.net/npm/three@0.171.0/build/three.tsl.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.171.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.webgpu.js",
+					"three/webgpu": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.webgpu.js",
+					"three/tsl": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.tsl.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
 					"@pixiv/three-vrm-materials-mtoon": "../lib/three-vrm-materials-mtoon.module.js",
 					"@pixiv/three-vrm-materials-mtoon/nodes": "../lib/nodes/index.module.js"
 				}

--- a/packages/three-vrm-materials-mtoon/examples/webgpu-loader-plugin.html
+++ b/packages/three-vrm-materials-mtoon/examples/webgpu-loader-plugin.html
@@ -23,10 +23,10 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.171.0/build/three.webgpu.js",
-					"three/webgpu": "https://cdn.jsdelivr.net/npm/three@0.171.0/build/three.webgpu.js",
-					"three/tsl": "https://cdn.jsdelivr.net/npm/three@0.171.0/build/three.tsl.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.171.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.webgpu.js",
+					"three/webgpu": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.webgpu.js",
+					"three/tsl": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.tsl.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
 					"@pixiv/three-vrm-materials-mtoon": "../lib/three-vrm-materials-mtoon.module.js",
 					"@pixiv/three-vrm-materials-mtoon/nodes": "../lib/nodes/index.module.js"
 				}

--- a/packages/three-vrm-materials-mtoon/package.json
+++ b/packages/three-vrm-materials-mtoon/package.json
@@ -58,8 +58,8 @@
     "@pixiv/types-vrmc-materials-mtoon-1.0": "3.4.0"
   },
   "devDependencies": {
-    "@types/three": "^0.170.0",
-    "three": "^0.171.0"
+    "@types/three": "^0.176.0",
+    "three": "^0.176.0"
   },
   "peerDependencies": {
     "three": ">=0.137"

--- a/packages/three-vrm-materials-mtoon/src/nodes/MToonAnimatedUVNode.ts
+++ b/packages/three-vrm-materials-mtoon/src/nodes/MToonAnimatedUVNode.ts
@@ -1,5 +1,5 @@
 import * as THREE from 'three/webgpu';
-import { cos, mat2, sin, uv, vec2, vec4 } from 'three/tsl';
+import { cos, mat2, NodeRepresentation, ShaderNodeObject, sin, Swizzable, uv, vec2, vec4 } from 'three/tsl';
 import {
   refUVAnimationMaskTexture,
   refUVAnimationRotationPhase,
@@ -16,14 +16,14 @@ export class MToonAnimatedUVNode extends THREE.TempNode {
     this.hasMaskTexture = hasMaskTexture;
   }
 
-  public setup(): THREE.ShaderNodeObject<THREE.VarNode> {
-    let uvAnimationMask: THREE.NodeRepresentation = 1.0;
+  public setup(): ShaderNodeObject<THREE.VarNode> {
+    let uvAnimationMask: NodeRepresentation = 1.0;
 
     if (this.hasMaskTexture) {
       uvAnimationMask = vec4(refUVAnimationMaskTexture).context({ getUV: () => uv() }).r;
     }
 
-    let animatedUv: THREE.ShaderNodeObject<THREE.Swizzable> = uv();
+    let animatedUv: ShaderNodeObject<Swizzable> = uv();
 
     // rotate
     const phase = refUVAnimationRotationPhase.mul(uvAnimationMask);

--- a/packages/three-vrm-materials-mtoon/src/nodes/MToonLightingModel.ts
+++ b/packages/three-vrm-materials-mtoon/src/nodes/MToonLightingModel.ts
@@ -1,5 +1,5 @@
 import * as THREE from 'three/webgpu';
-import { BRDF_Lambert, diffuseColor, float, mix, transformedNormalView, vec3 } from 'three/tsl';
+import { BRDF_Lambert, diffuseColor, float, mix, ShaderNodeObject, transformedNormalView, vec3 } from 'three/tsl';
 import {
   matcap,
   parametricRim,
@@ -19,9 +19,9 @@ const linearstep = FnCompat(
     b,
     t,
   }: {
-    a: THREE.ShaderNodeObject<THREE.Node>;
-    b: THREE.ShaderNodeObject<THREE.Node>;
-    t: THREE.ShaderNodeObject<THREE.Node>;
+    a: ShaderNodeObject<THREE.Node>;
+    b: ShaderNodeObject<THREE.Node>;
+    t: ShaderNodeObject<THREE.Node>;
   }) => {
     const top = t.sub(a);
     const bottom = b.sub(a);
@@ -32,12 +32,12 @@ const linearstep = FnCompat(
 /**
  * Convert NdotL into toon shading factor using shadingShift and shadingToony
  */
-const getShading = FnCompat(({ dotNL }: { dotNL: THREE.ShaderNodeObject<THREE.Node> }) => {
+const getShading = FnCompat(({ dotNL }: { dotNL: ShaderNodeObject<THREE.Node> }) => {
   const shadow = 1.0; // TODO
 
   const feather = float(1.0).sub(shadingToony);
 
-  let shading: THREE.ShaderNodeObject<THREE.Node> = dotNL.add(shadingShift);
+  let shading: ShaderNodeObject<THREE.Node> = dotNL.add(shadingShift);
   shading = linearstep({
     a: feather.negate(),
     b: feather,
@@ -51,13 +51,7 @@ const getShading = FnCompat(({ dotNL }: { dotNL: THREE.ShaderNodeObject<THREE.No
  * Mix diffuseColor and shadeColor using shading factor and light color
  */
 const getDiffuse = FnCompat(
-  ({
-    shading,
-    lightColor,
-  }: {
-    shading: THREE.ShaderNodeObject<THREE.Node>;
-    lightColor: THREE.ShaderNodeObject<THREE.Node>;
-  }) => {
+  ({ shading, lightColor }: { shading: ShaderNodeObject<THREE.Node>; lightColor: ShaderNodeObject<THREE.Node> }) => {
     const feathered = mix(shadeColor, diffuseColor, shading);
     const col = lightColor.mul(BRDF_Lambert({ diffuseColor: feathered }));
 
@@ -86,18 +80,18 @@ export class MToonLightingModel extends THREE.LightingModel {
     // Unable to use `addAssign` in the current @types/three, we use `assign` and `add` instead
     // TODO: Fix the `addAssign` issue from the `@types/three` side
 
-    (reflectedLight.directDiffuse as THREE.ShaderNodeObject<THREE.Node>).assign(
-      (reflectedLight.directDiffuse as THREE.ShaderNodeObject<THREE.Node>).add(
+    (reflectedLight.directDiffuse as ShaderNodeObject<THREE.Node>).assign(
+      (reflectedLight.directDiffuse as ShaderNodeObject<THREE.Node>).add(
         getDiffuse({
           shading,
-          lightColor: lightColor as THREE.ShaderNodeObject<THREE.Node>,
+          lightColor: lightColor as ShaderNodeObject<THREE.Node>,
         }),
       ),
     );
 
     // rim
-    (reflectedLight.directSpecular as THREE.ShaderNodeObject<THREE.Node>).assign(
-      (reflectedLight.directSpecular as THREE.ShaderNodeObject<THREE.Node>).add(
+    (reflectedLight.directSpecular as ShaderNodeObject<THREE.Node>).assign(
+      (reflectedLight.directSpecular as ShaderNodeObject<THREE.Node>).add(
         parametricRim
           .add(matcap)
           .mul(rimMultiply)
@@ -122,9 +116,9 @@ export class MToonLightingModel extends THREE.LightingModel {
     const { irradiance, reflectedLight } = context;
 
     // indirect irradiance
-    (reflectedLight.indirectDiffuse as THREE.ShaderNodeObject<THREE.Node>).assign(
-      (reflectedLight.indirectDiffuse as THREE.ShaderNodeObject<THREE.Node>).add(
-        (irradiance as THREE.ShaderNodeObject<THREE.Node>).mul(BRDF_Lambert({ diffuseColor })),
+    (reflectedLight.indirectDiffuse as ShaderNodeObject<THREE.Node>).assign(
+      (reflectedLight.indirectDiffuse as ShaderNodeObject<THREE.Node>).add(
+        (irradiance as ShaderNodeObject<THREE.Node>).mul(BRDF_Lambert({ diffuseColor })),
       ),
     );
   }
@@ -134,8 +128,8 @@ export class MToonLightingModel extends THREE.LightingModel {
     const { reflectedLight } = context;
 
     // rim
-    (reflectedLight.indirectSpecular as THREE.ShaderNodeObject<THREE.Node>).assign(
-      (reflectedLight.indirectSpecular as THREE.ShaderNodeObject<THREE.Node>).add(
+    (reflectedLight.indirectSpecular as ShaderNodeObject<THREE.Node>).assign(
+      (reflectedLight.indirectSpecular as ShaderNodeObject<THREE.Node>).add(
         parametricRim
           .add(matcap)
           .mul(rimMultiply)

--- a/packages/three-vrm-materials-mtoon/src/nodes/MToonLightingModel.ts
+++ b/packages/three-vrm-materials-mtoon/src/nodes/MToonLightingModel.ts
@@ -70,7 +70,12 @@ export class MToonLightingModel extends THREE.LightingModel {
     super();
   }
 
-  direct({ lightDirection, lightColor, reflectedLight }: THREE.LightingModelDirectInput) {
+  // TODO: Add `lightDirection` and `lightColor` to `LightingModelDirectInput` in `@types/three`
+  direct({
+    lightDirection,
+    lightColor,
+    reflectedLight,
+  }: THREE.LightingModelDirectInput & { lightDirection: THREE.Node; lightColor: THREE.Node }) {
     const dotNL = transformedNormalView.dot(lightDirection).clamp(-1.0, 1.0);
 
     // toon diffuse
@@ -101,12 +106,21 @@ export class MToonLightingModel extends THREE.LightingModel {
     );
   }
 
-  indirect(context: THREE.LightingModelIndirectInput) {
+  // `builderOrContext`: `builder: THREE.NodeBuilder` in >= r174,
+  // `context: THREE.LightingModelIndirectInput` otherwise
+  //
+  // TODO: Add `context` to `NodeBuilder` in `@types/three`
+  indirect(builderOrContext: any) {
+    const context: THREE.LightingContext = builderOrContext.context || builderOrContext;
+
     this.indirectDiffuse(context);
     this.indirectSpecular(context);
   }
 
-  indirectDiffuse({ irradiance, reflectedLight }: THREE.LightingModelIndirectInput) {
+  // TODO: Add `context` to `NodeBuilder` in `@types/three`
+  indirectDiffuse(context: THREE.LightingContext) {
+    const { irradiance, reflectedLight } = context;
+
     // indirect irradiance
     (reflectedLight.indirectDiffuse as THREE.ShaderNodeObject<THREE.Node>).assign(
       (reflectedLight.indirectDiffuse as THREE.ShaderNodeObject<THREE.Node>).add(
@@ -115,7 +129,10 @@ export class MToonLightingModel extends THREE.LightingModel {
     );
   }
 
-  indirectSpecular({ reflectedLight }: THREE.LightingModelIndirectInput) {
+  // TODO: Add `context` to `NodeBuilder` in `@types/three`
+  indirectSpecular(context: THREE.LightingContext) {
+    const { reflectedLight } = context;
+
     // rim
     (reflectedLight.indirectSpecular as THREE.ShaderNodeObject<THREE.Node>).assign(
       (reflectedLight.indirectSpecular as THREE.ShaderNodeObject<THREE.Node>).add(

--- a/packages/three-vrm-materials-mtoon/src/nodes/MToonLightingModel.ts
+++ b/packages/three-vrm-materials-mtoon/src/nodes/MToonLightingModel.ts
@@ -64,7 +64,6 @@ export class MToonLightingModel extends THREE.LightingModel {
     super();
   }
 
-  // TODO: Add `lightDirection` and `lightColor` to `LightingModelDirectInput` in `@types/three`
   direct({
     lightDirection,
     lightColor,
@@ -100,18 +99,16 @@ export class MToonLightingModel extends THREE.LightingModel {
     );
   }
 
-  // `builderOrContext`: `builder: THREE.NodeBuilder` in >= r174,
-  // `context: THREE.LightingModelIndirectInput` otherwise
-  //
-  // TODO: Add `context` to `NodeBuilder` in `@types/three`
-  indirect(builderOrContext: any) {
-    const context: THREE.LightingContext = builderOrContext.context || builderOrContext;
+  // COMPAT: pre-r174
+  // `builderOrContext`: `THREE.NodeBuilder` in >= r174, `LightingModelIndirectInput` (`LightingContext`) otherwise
+  indirect(builderOrContext: THREE.NodeBuilder | THREE.LightingContext) {
+    const context: THREE.LightingContext =
+      'context' in builderOrContext ? (builderOrContext.context as unknown as THREE.LightingContext) : builderOrContext;
 
     this.indirectDiffuse(context);
     this.indirectSpecular(context);
   }
 
-  // TODO: Add `context` to `NodeBuilder` in `@types/three`
   indirectDiffuse(context: THREE.LightingContext) {
     const { irradiance, reflectedLight } = context;
 
@@ -123,7 +120,6 @@ export class MToonLightingModel extends THREE.LightingModel {
     );
   }
 
-  // TODO: Add `context` to `NodeBuilder` in `@types/three`
   indirectSpecular(context: THREE.LightingContext) {
     const { reflectedLight } = context;
 

--- a/packages/three-vrm-materials-mtoon/src/nodes/MToonLightingModel.ts
+++ b/packages/three-vrm-materials-mtoon/src/nodes/MToonLightingModel.ts
@@ -76,26 +76,19 @@ export class MToonLightingModel extends THREE.LightingModel {
       dotNL,
     });
 
-    // Unable to use `addAssign` in the current @types/three, we use `assign` and `add` instead
-    // TODO: Fix the `addAssign` issue from the `@types/three` side
-
-    (reflectedLight.directDiffuse as ShaderNodeObject<THREE.Node>).assign(
-      (reflectedLight.directDiffuse as ShaderNodeObject<THREE.Node>).add(
-        getDiffuse({
-          shading,
-          lightColor: lightColor as ShaderNodeObject<THREE.Node>,
-        }),
-      ),
+    (reflectedLight.directDiffuse as ShaderNodeObject<THREE.Node>).addAssign(
+      getDiffuse({
+        shading,
+        lightColor: lightColor as ShaderNodeObject<THREE.Node>,
+      }),
     );
 
     // rim
-    (reflectedLight.directSpecular as ShaderNodeObject<THREE.Node>).assign(
-      (reflectedLight.directSpecular as ShaderNodeObject<THREE.Node>).add(
-        parametricRim
-          .add(matcap)
-          .mul(rimMultiply)
-          .mul(mix(vec3(0.0), BRDF_Lambert({ diffuseColor: lightColor }), rimLightingMix)),
-      ),
+    (reflectedLight.directSpecular as ShaderNodeObject<THREE.Node>).addAssign(
+      parametricRim
+        .add(matcap)
+        .mul(rimMultiply)
+        .mul(mix(vec3(0.0), BRDF_Lambert({ diffuseColor: lightColor }), rimLightingMix)),
     );
   }
 
@@ -113,10 +106,8 @@ export class MToonLightingModel extends THREE.LightingModel {
     const { irradiance, reflectedLight } = context;
 
     // indirect irradiance
-    (reflectedLight.indirectDiffuse as ShaderNodeObject<THREE.Node>).assign(
-      (reflectedLight.indirectDiffuse as ShaderNodeObject<THREE.Node>).add(
-        (irradiance as ShaderNodeObject<THREE.Node>).mul(BRDF_Lambert({ diffuseColor })),
-      ),
+    (reflectedLight.indirectDiffuse as ShaderNodeObject<THREE.Node>).addAssign(
+      (irradiance as ShaderNodeObject<THREE.Node>).mul(BRDF_Lambert({ diffuseColor })),
     );
   }
 
@@ -124,13 +115,11 @@ export class MToonLightingModel extends THREE.LightingModel {
     const { reflectedLight } = context;
 
     // rim
-    (reflectedLight.indirectSpecular as ShaderNodeObject<THREE.Node>).assign(
-      (reflectedLight.indirectSpecular as ShaderNodeObject<THREE.Node>).add(
-        parametricRim
-          .add(matcap)
-          .mul(rimMultiply)
-          .mul(mix(vec3(1.0), vec3(0.0), rimLightingMix)),
-      ),
+    (reflectedLight.indirectSpecular as ShaderNodeObject<THREE.Node>).addAssign(
+      parametricRim
+        .add(matcap)
+        .mul(rimMultiply)
+        .mul(mix(vec3(1.0), vec3(0.0), rimLightingMix)),
     );
   }
 }

--- a/packages/three-vrm-materials-mtoon/src/nodes/MToonNodeMaterial.ts
+++ b/packages/three-vrm-materials-mtoon/src/nodes/MToonNodeMaterial.ts
@@ -7,6 +7,7 @@ import {
   materialNormal,
   mix,
   modelNormalMatrix,
+  modelViewMatrix,
   normalLocal,
   normalMap,
   positionLocal,
@@ -379,6 +380,11 @@ export class MToonNodeMaterial extends THREE.NodeMaterial {
         this.positionNode = (this.positionNode as THREE.ShaderNodeObject<THREE.Node>).add(outlineOffset);
       } else if (this.outlineWidthMode === MToonMaterialOutlineWidthMode.ScreenCoordinates) {
         const clipScale = cameraProjectionMatrix.element(1).element(1);
+
+        // We can't use `positionView` in `setupPosition`
+        // because using `positionView` here will make it calculate the `positionView` earlier
+        // and it won't be calculated again after setting the `positionNode`
+        const tempPositionView = modelViewMatrix.mul(positionLocal);
 
         // See about the type assertion: https://github.com/three-types/three-ts-types/pull/1123
         this.positionNode = (this.positionNode as THREE.ShaderNodeObject<THREE.Node>).add(

--- a/packages/three-vrm-materials-mtoon/src/nodes/MToonNodeMaterial.ts
+++ b/packages/three-vrm-materials-mtoon/src/nodes/MToonNodeMaterial.ts
@@ -391,7 +391,7 @@ export class MToonNodeMaterial extends THREE.NodeMaterial {
 
         // See about the type assertion: https://github.com/three-types/three-ts-types/pull/1123
         this.positionNode = (this.positionNode as ShaderNodeObject<THREE.Node>).add(
-          outlineOffset.div(clipScale).mul(positionView.z.negate()),
+          outlineOffset.div(clipScale).mul(tempPositionView.z.negate()),
         );
       }
 

--- a/packages/three-vrm-materials-mtoon/src/nodes/MToonNodeMaterial.ts
+++ b/packages/three-vrm-materials-mtoon/src/nodes/MToonNodeMaterial.ts
@@ -1,6 +1,7 @@
 import * as THREE from 'three/webgpu';
 import {
   cameraProjectionMatrix,
+  diffuseColor,
   float,
   length,
   matcapUV,
@@ -12,6 +13,8 @@ import {
   normalMap,
   positionLocal,
   positionView,
+  ShaderNodeObject,
+  Swizzable,
   vec3,
   vec4,
 } from 'three/tsl';
@@ -66,7 +69,7 @@ import { mtoonParametricRim } from './mtoonParametricRim';
  * See: https://github.com/Santarh/MToon
  */
 export class MToonNodeMaterial extends THREE.NodeMaterial {
-  public emissiveNode: THREE.ShaderNodeObject<THREE.Node> | null;
+  public emissiveNode: ShaderNodeObject<THREE.Node> | null;
 
   public color: THREE.Color;
   public map: THREE.Texture | null;
@@ -99,13 +102,13 @@ export class MToonNodeMaterial extends THREE.NodeMaterial {
   public uvAnimationRotationSpeedFactor: number;
   public uvAnimationMaskTexture: THREE.Texture | null;
 
-  public shadeColorNode: THREE.Swizzable | null;
+  public shadeColorNode: Swizzable | null;
   public shadingShiftNode: THREE.Node | null;
   public shadingToonyNode: THREE.Node | null;
   public rimLightingMixNode: THREE.Node | null;
   public rimMultiplyNode: THREE.Node | null;
   public matcapNode: THREE.Node | null;
-  public parametricRimColorNode: THREE.Swizzable | null;
+  public parametricRimColorNode: Swizzable | null;
   public parametricRimLiftNode: THREE.Node | null;
   public parametricRimFresnelPowerNode: THREE.Node | null;
 
@@ -217,7 +220,7 @@ export class MToonNodeMaterial extends THREE.NodeMaterial {
   public setupDiffuseColor(builder: THREE.NodeBuilder): void {
     // we must apply uv scroll to the map
     // this.colorNode will be used in super.setupDiffuseColor() so we temporarily replace it
-    let tempColorNode: THREE.ShaderNodeObject<THREE.Node> | null = null;
+    let tempColorNode: ShaderNodeObject<THREE.Node> | null = null;
 
     if (this.colorNode == null) {
       tempColorNode = refColor;
@@ -248,7 +251,7 @@ export class MToonNodeMaterial extends THREE.NodeMaterial {
     // See: https://github.com/mrdoob/three.js/pull/28646
     if (parseInt(THREE.REVISION, 10) < 166) {
       if (this.transparent === false && this.blending === THREE.NormalBlending && this.alphaToCoverage === false) {
-        THREE.diffuseColor.a.assign(1.0);
+        diffuseColor.a.assign(1.0);
       }
     }
 
@@ -268,7 +271,7 @@ export class MToonNodeMaterial extends THREE.NodeMaterial {
     parametricRim.assign(this._setupParametricRimNode());
   }
 
-  public setupNormal(builder: THREE.NodeBuilder): THREE.ShaderNodeObject<THREE.Node> {
+  public setupNormal(builder: THREE.NodeBuilder): ShaderNodeObject<THREE.Node> {
     // we must apply uv scroll to the normalMap
     // this.normalNode will be used in super.setupNormal() so we temporarily replace it
     const tempNormalNode = this.normalNode;
@@ -283,7 +286,7 @@ export class MToonNodeMaterial extends THREE.NodeMaterial {
 
       if (this.isOutline) {
         // See about the type assertion: https://github.com/three-types/three-ts-types/pull/1123
-        this.normalNode = (this.normalNode as THREE.ShaderNodeObject<THREE.Node>).negate();
+        this.normalNode = (this.normalNode as ShaderNodeObject<THREE.Node>).negate();
       }
     }
 
@@ -292,7 +295,7 @@ export class MToonNodeMaterial extends THREE.NodeMaterial {
     // See: https://github.com/mrdoob/three.js/pull/29137
     const threeRevision = parseInt(THREE.REVISION, 10);
     if (threeRevision >= 168) {
-      const ret = this.normalNode as THREE.ShaderNodeObject<THREE.Node>;
+      const ret = this.normalNode as ShaderNodeObject<THREE.Node>;
 
       // revert the normalNode
       this.normalNode = tempNormalNode;
@@ -315,7 +318,7 @@ export class MToonNodeMaterial extends THREE.NodeMaterial {
   public setupLighting(builder: THREE.NodeBuilder): THREE.Node {
     // we must apply uv scroll to the emissiveMap
     // this.emissiveNode will be used in super.setupLighting() so we temporarily replace it
-    let tempEmissiveNode: THREE.ShaderNodeObject<THREE.Node> | null = null;
+    let tempEmissiveNode: ShaderNodeObject<THREE.Node> | null = null;
 
     if (this.emissiveNode == null) {
       tempEmissiveNode = refEmissive.mul(refEmissiveIntensity);
@@ -341,8 +344,8 @@ export class MToonNodeMaterial extends THREE.NodeMaterial {
 
   public setupOutput(
     builder: THREE.NodeBuilder,
-    outputNode: THREE.ShaderNodeObject<THREE.Node>,
-  ): THREE.ShaderNodeObject<THREE.Node> {
+    outputNode: ShaderNodeObject<THREE.Node>,
+  ): ShaderNodeObject<THREE.Node> {
     // mix or set outline color
     if (this.isOutline && this.outlineWidthMode !== MToonMaterialOutlineWidthMode.None) {
       outputNode = vec4(
@@ -352,10 +355,10 @@ export class MToonNodeMaterial extends THREE.NodeMaterial {
     }
 
     // the ordinary output setup
-    return super.setupOutput(builder, outputNode) as THREE.ShaderNodeObject<THREE.Node>;
+    return super.setupOutput(builder, outputNode) as ShaderNodeObject<THREE.Node>;
   }
 
-  public setupPosition(builder: THREE.NodeBuilder): THREE.ShaderNodeObject<THREE.Node> {
+  public setupPosition(builder: THREE.NodeBuilder): ShaderNodeObject<THREE.Node> {
     // we must apply outline position offset
     // this.positionNode will be used in super.setupPosition() so we temporarily replace it
     const tempPositionNode = this.positionNode;
@@ -365,7 +368,7 @@ export class MToonNodeMaterial extends THREE.NodeMaterial {
 
       const normalLocalNormalized = normalLocal.normalize();
 
-      let width: THREE.ShaderNodeObject<THREE.Node> = refOutlineWidthFactor;
+      let width: ShaderNodeObject<THREE.Node> = refOutlineWidthFactor;
 
       if (this.outlineWidthMultiplyTexture && this.outlineWidthMultiplyTexture.isTexture === true) {
         const map = refOutlineWidthMultiplyTexture.context({ getUV: () => this._animatedUVNode });
@@ -377,7 +380,7 @@ export class MToonNodeMaterial extends THREE.NodeMaterial {
 
       if (this.outlineWidthMode === MToonMaterialOutlineWidthMode.WorldCoordinates) {
         // See about the type assertion: https://github.com/three-types/three-ts-types/pull/1123
-        this.positionNode = (this.positionNode as THREE.ShaderNodeObject<THREE.Node>).add(outlineOffset);
+        this.positionNode = (this.positionNode as ShaderNodeObject<THREE.Node>).add(outlineOffset);
       } else if (this.outlineWidthMode === MToonMaterialOutlineWidthMode.ScreenCoordinates) {
         const clipScale = cameraProjectionMatrix.element(1).element(1);
 
@@ -387,7 +390,7 @@ export class MToonNodeMaterial extends THREE.NodeMaterial {
         const tempPositionView = modelViewMatrix.mul(positionLocal);
 
         // See about the type assertion: https://github.com/three-types/three-ts-types/pull/1123
-        this.positionNode = (this.positionNode as THREE.ShaderNodeObject<THREE.Node>).add(
+        this.positionNode = (this.positionNode as ShaderNodeObject<THREE.Node>).add(
           outlineOffset.div(clipScale).mul(positionView.z.negate()),
         );
       }
@@ -396,7 +399,7 @@ export class MToonNodeMaterial extends THREE.NodeMaterial {
     }
 
     // the ordinary position setup
-    const ret = super.setupPosition(builder) as THREE.ShaderNodeObject<THREE.Node>;
+    const ret = super.setupPosition(builder) as ShaderNodeObject<THREE.Node>;
 
     // anti z-fighting
     // TODO: We might want to address this via glPolygonOffset instead?
@@ -461,12 +464,12 @@ export class MToonNodeMaterial extends THREE.NodeMaterial {
     this.uvAnimationRotationPhase += delta * this.uvAnimationRotationSpeedFactor;
   }
 
-  private _setupShadeColorNode(): THREE.Swizzable {
+  private _setupShadeColorNode(): Swizzable {
     if (this.shadeColorNode != null) {
       return vec3(this.shadeColorNode);
     }
 
-    let shadeColorNode: THREE.ShaderNodeObject<THREE.Node> = refShadeColorFactor;
+    let shadeColorNode: ShaderNodeObject<THREE.Node> = refShadeColorFactor;
 
     if (this.shadeMultiplyTexture && this.shadeMultiplyTexture.isTexture === true) {
       const map = refShadeMultiplyTexture.context({ getUV: () => this._animatedUVNode });
@@ -481,7 +484,7 @@ export class MToonNodeMaterial extends THREE.NodeMaterial {
       return float(this.shadingShiftNode);
     }
 
-    let shadingShiftNode: THREE.ShaderNodeObject<THREE.Node> = refShadingShiftFactor;
+    let shadingShiftNode: ShaderNodeObject<THREE.Node> = refShadingShiftFactor;
 
     if (this.shadingShiftTexture && this.shadingShiftTexture.isTexture === true) {
       const map = refShadeMultiplyTexture.context({ getUV: () => this._animatedUVNode });
@@ -507,7 +510,7 @@ export class MToonNodeMaterial extends THREE.NodeMaterial {
     return refRimLightingMixFactor;
   }
 
-  private _setupRimMultiplyNode(): THREE.Swizzable {
+  private _setupRimMultiplyNode(): Swizzable {
     if (this.rimMultiplyNode != null) {
       return vec3(this.rimMultiplyNode);
     }
@@ -520,7 +523,7 @@ export class MToonNodeMaterial extends THREE.NodeMaterial {
     return vec3(1.0);
   }
 
-  private _setupMatcapNode(): THREE.Swizzable {
+  private _setupMatcapNode(): Swizzable {
     if (this.matcapNode != null) {
       return vec3(this.matcapNode);
     }
@@ -533,7 +536,7 @@ export class MToonNodeMaterial extends THREE.NodeMaterial {
     return vec3(0.0);
   }
 
-  private _setupParametricRimNode(): THREE.Swizzable {
+  private _setupParametricRimNode(): Swizzable {
     const parametricRimColor =
       this.parametricRimColorNode != null ? vec3(this.parametricRimColorNode) : refParametricRimColorFactor;
 

--- a/packages/three-vrm-materials-mtoon/src/nodes/MToonNodeMaterialParameters.ts
+++ b/packages/three-vrm-materials-mtoon/src/nodes/MToonNodeMaterialParameters.ts
@@ -1,15 +1,16 @@
+import { Swizzable } from 'three/tsl';
 import * as THREE from 'three/webgpu';
 
 export interface MToonNodeMaterialParameters extends THREE.ShaderMaterialParameters {
   transparentWithZWrite?: boolean;
 
-  shadeColorNode?: THREE.Swizzable | null;
+  shadeColorNode?: Swizzable | null;
   shadingShiftNode?: THREE.Node | null;
   shadingToonyNode?: THREE.Node | null;
   rimLightingMixNode?: THREE.Node | null;
   rimMultiplyNode?: THREE.Node | null;
   matcapNode?: THREE.Node | null;
-  parametricRimColorNode?: THREE.Swizzable | null;
+  parametricRimColorNode?: Swizzable | null;
   parametricRimLiftNode?: THREE.Node | null;
   parametricRimFresnelPowerNode?: THREE.Node | null;
 }

--- a/packages/three-vrm-materials-mtoon/src/nodes/mtoonParametricRim.ts
+++ b/packages/three-vrm-materials-mtoon/src/nodes/mtoonParametricRim.ts
@@ -1,5 +1,5 @@
 import * as THREE from 'three/webgpu';
-import { float, modelViewPosition, transformedNormalView } from 'three/tsl';
+import { float, modelViewPosition, NodeRepresentation, transformedNormalView } from 'three/tsl';
 import { FnCompat } from './utils/FnCompat';
 
 export const mtoonParametricRim = FnCompat(
@@ -8,9 +8,9 @@ export const mtoonParametricRim = FnCompat(
     parametricRimFresnelPower,
     parametricRimColor,
   }: {
-    parametricRimLift: THREE.NodeRepresentation;
-    parametricRimFresnelPower: THREE.NodeRepresentation;
-    parametricRimColor: THREE.NodeRepresentation;
+    parametricRimLift: NodeRepresentation;
+    parametricRimFresnelPower: NodeRepresentation;
+    parametricRimColor: NodeRepresentation;
   }) => {
     const viewDir = modelViewPosition.normalize();
     const dotNV = transformedNormalView.dot(viewDir.negate());

--- a/packages/three-vrm-materials-v0compat/package.json
+++ b/packages/three-vrm-materials-v0compat/package.json
@@ -49,8 +49,8 @@
     "@pixiv/types-vrmc-materials-mtoon-1.0": "3.4.0"
   },
   "devDependencies": {
-    "@types/three": "^0.170.0",
-    "three": "^0.171.0"
+    "@types/three": "^0.176.0",
+    "three": "^0.176.0"
   },
   "peerDependencies": {
     "three": ">=0.137"

--- a/packages/three-vrm-node-constraint/examples/aim.html
+++ b/packages/three-vrm-node-constraint/examples/aim.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.171.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.171.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
 					"tweakpane": "https://cdn.jsdelivr.net/npm/tweakpane@3.0",
 					"tweakpane-plugin-rotation": "https://cdn.jsdelivr.net/npm/@0b5vr/tweakpane-plugin-rotation@0.1",
 					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"

--- a/packages/three-vrm-node-constraint/examples/importer.html
+++ b/packages/three-vrm-node-constraint/examples/importer.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.171.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.171.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
 					"tweakpane": "https://cdn.jsdelivr.net/npm/tweakpane@3.0",
 					"tweakpane-plugin-rotation": "https://cdn.jsdelivr.net/npm/@0b5vr/tweakpane-plugin-rotation@0.1",
 					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"

--- a/packages/three-vrm-node-constraint/examples/roll.html
+++ b/packages/three-vrm-node-constraint/examples/roll.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.171.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.171.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
 					"tweakpane": "https://cdn.jsdelivr.net/npm/tweakpane@3.0",
 					"tweakpane-plugin-rotation": "https://cdn.jsdelivr.net/npm/@0b5vr/tweakpane-plugin-rotation@0.1",
 					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"

--- a/packages/three-vrm-node-constraint/examples/rotation.html
+++ b/packages/three-vrm-node-constraint/examples/rotation.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.171.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.171.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
 					"tweakpane": "https://cdn.jsdelivr.net/npm/tweakpane@3.0",
 					"tweakpane-plugin-rotation": "https://cdn.jsdelivr.net/npm/@0b5vr/tweakpane-plugin-rotation@0.1",
 					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"

--- a/packages/three-vrm-node-constraint/examples/upper-arm.html
+++ b/packages/three-vrm-node-constraint/examples/upper-arm.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.171.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.171.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
 					"tweakpane": "https://cdn.jsdelivr.net/npm/tweakpane@3.0",
 					"tweakpane-plugin-rotation": "https://cdn.jsdelivr.net/npm/@0b5vr/tweakpane-plugin-rotation@0.1",
 					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"

--- a/packages/three-vrm-node-constraint/package.json
+++ b/packages/three-vrm-node-constraint/package.json
@@ -53,8 +53,8 @@
     "@pixiv/types-vrmc-node-constraint-1.0": "3.4.0"
   },
   "devDependencies": {
-    "@types/three": "^0.170.0",
-    "three": "^0.171.0"
+    "@types/three": "^0.176.0",
+    "three": "^0.176.0"
   },
   "peerDependencies": {
     "three": ">=0.137"

--- a/packages/three-vrm-springbone/examples/collider.html
+++ b/packages/three-vrm-springbone/examples/collider.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-				"three": "https://cdn.jsdelivr.net/npm/three@0.171.0/build/three.module.js",
-				"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.171.0/examples/jsm/",
+				"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
+				"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
 				"@pixiv/three-vrm-springbone": "../lib/three-vrm-springbone.module.js"
 			  }
 			}

--- a/packages/three-vrm-springbone/examples/loader-plugin.html
+++ b/packages/three-vrm-springbone/examples/loader-plugin.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-				"three": "https://cdn.jsdelivr.net/npm/three@0.171.0/build/three.module.js",
-				"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.171.0/examples/jsm/",
+				"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
+				"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
 				"@pixiv/three-vrm-springbone": "../lib/three-vrm-springbone.module.js"
 			  }
 			}

--- a/packages/three-vrm-springbone/examples/multiple.html
+++ b/packages/three-vrm-springbone/examples/multiple.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-				"three": "https://cdn.jsdelivr.net/npm/three@0.171.0/build/three.module.js",
-				"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.171.0/examples/jsm/",
+				"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
+				"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
 				"@pixiv/three-vrm-springbone": "../lib/three-vrm-springbone.module.js"
 			  }
 			}

--- a/packages/three-vrm-springbone/examples/single.html
+++ b/packages/three-vrm-springbone/examples/single.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-				"three": "https://cdn.jsdelivr.net/npm/three@0.171.0/build/three.module.js",
-				"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.171.0/examples/jsm/",
+				"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
+				"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
 				"@pixiv/three-vrm-springbone": "../lib/three-vrm-springbone.module.js"
 			  }
 			}

--- a/packages/three-vrm-springbone/package.json
+++ b/packages/three-vrm-springbone/package.json
@@ -55,8 +55,8 @@
     "@pixiv/types-vrmc-springbone-extended-collider-1.0": "3.4.0"
   },
   "devDependencies": {
-    "@types/three": "^0.170.0",
-    "three": "^0.171.0"
+    "@types/three": "^0.176.0",
+    "three": "^0.176.0"
   },
   "peerDependencies": {
     "three": ">=0.137"

--- a/packages/three-vrm/README.md
+++ b/packages/three-vrm/README.md
@@ -32,8 +32,8 @@ You can import all the dependencies via CDN like [jsDelivr](https://www.jsdelivr
 <script type="importmap">
   {
     "imports": {
-      "three": "https://cdn.jsdelivr.net/npm/three@0.171.0/build/three.module.js",
-      "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.171.0/examples/jsm/",
+      "three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
+      "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
       "@pixiv/three-vrm": "https://cdn.jsdelivr.net/npm/@pixiv/three-vrm@3/lib/three-vrm.module.min.js"
     }
   }

--- a/packages/three-vrm/examples/animations.html
+++ b/packages/three-vrm/examples/animations.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.171.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.171.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/basic.html
+++ b/packages/three-vrm/examples/basic.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.171.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.171.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/bones.html
+++ b/packages/three-vrm/examples/bones.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.171.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.171.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/debug.html
+++ b/packages/three-vrm/examples/debug.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.171.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.171.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/dnd.html
+++ b/packages/three-vrm/examples/dnd.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.171.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.171.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/expressions.html
+++ b/packages/three-vrm/examples/expressions.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.171.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.171.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/firstperson.html
+++ b/packages/three-vrm/examples/firstperson.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.171.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.171.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/humanoidAnimation/index.html
+++ b/packages/three-vrm/examples/humanoidAnimation/index.html
@@ -34,8 +34,8 @@
 			{
 				"imports": {
 					"fflate": "https://cdn.jsdelivr.net/npm/fflate@0.7.4/esm/browser.js",
-					"three": "https://cdn.jsdelivr.net/npm/three@0.171.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.171.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
 					"@pixiv/three-vrm": "../../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/lookat-advanced.html
+++ b/packages/three-vrm/examples/lookat-advanced.html
@@ -24,8 +24,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.171.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.171.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/lookat.html
+++ b/packages/three-vrm/examples/lookat.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.171.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.171.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/materials-debug.html
+++ b/packages/three-vrm/examples/materials-debug.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.171.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.171.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/meta.html
+++ b/packages/three-vrm/examples/meta.html
@@ -34,8 +34,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.171.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.171.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/mouse.html
+++ b/packages/three-vrm/examples/mouse.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.171.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.171.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/webgpu-dnd.html
+++ b/packages/three-vrm/examples/webgpu-dnd.html
@@ -23,10 +23,10 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.171.0/build/three.webgpu.js",
-					"three/webgpu": "https://cdn.jsdelivr.net/npm/three@0.171.0/build/three.webgpu.js",
-					"three/tsl": "https://cdn.jsdelivr.net/npm/three@0.171.0/build/three.tsl.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.171.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.webgpu.js",
+					"three/webgpu": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.webgpu.js",
+					"three/tsl": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.tsl.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js",
 					"@pixiv/three-vrm/nodes": "../lib/nodes/index.module.js"
 				}

--- a/packages/three-vrm/package.json
+++ b/packages/three-vrm/package.json
@@ -63,8 +63,8 @@
     "@pixiv/three-vrm-springbone": "3.4.0"
   },
   "devDependencies": {
-    "@types/three": "^0.170.0",
-    "three": "^0.171.0"
+    "@types/three": "^0.176.0",
+    "three": "^0.176.0"
   },
   "peerDependencies": {
     "three": ">=0.137"

--- a/packages/three-vrm/src/VRMUtils/combineMorphs.ts
+++ b/packages/three-vrm/src/VRMUtils/combineMorphs.ts
@@ -142,10 +142,10 @@ export function combineMorphs(vrm: VRMCore): void {
       let i = 0;
       for (const [name, bindSet] of nameBindSetMap) {
         if (hasPMorph) {
-          morphAttributes.position[i] = combineMorph(originalMorphAttributes.position, bindSet, morphTargetsRelative);
+          morphAttributes.position![i] = combineMorph(originalMorphAttributes.position!, bindSet, morphTargetsRelative);
         }
         if (hasNMorph) {
-          morphAttributes.normal[i] = combineMorph(originalMorphAttributes.normal, bindSet, morphTargetsRelative);
+          morphAttributes.normal![i] = combineMorph(originalMorphAttributes.normal!, bindSet, morphTargetsRelative);
         }
 
         expressionMap?.[name].addBind(

--- a/packages/three-vrm/src/VRMUtils/combineSkeletons.ts
+++ b/packages/three-vrm/src/VRMUtils/combineSkeletons.ts
@@ -319,8 +319,9 @@ function shallowCloneBufferGeometry(geometry: THREE.BufferGeometry): THREE.Buffe
     clone.setAttribute(name, attribute);
   }
 
-  for (const [name, morphAttribute] of Object.entries(geometry.morphAttributes)) {
-    clone.morphAttributes[name] = morphAttribute.concat();
+  for (const [key, morphAttributes] of Object.entries(geometry.morphAttributes)) {
+    const attributeName = key as keyof typeof geometry.morphAttributes;
+    clone.morphAttributes[attributeName] = morphAttributes.concat();
   }
   clone.morphTargetsRelative = geometry.morphTargetsRelative;
 

--- a/packages/three-vrm/src/VRMUtils/combineSkeletons.ts
+++ b/packages/three-vrm/src/VRMUtils/combineSkeletons.ts
@@ -1,4 +1,6 @@
 import * as THREE from 'three';
+import { attributeGetComponentCompat } from '../utils/attributeGetComponentCompat';
+import { attributeSetComponentCompat } from '../utils/attributeSetComponentCompat';
 
 /**
  * Traverses the given object and combines the skeletons of skinned meshes.
@@ -156,8 +158,8 @@ function listUsedIndices(
 
   for (let i = 0; i < skinIndexAttr.count; i++) {
     for (let j = 0; j < skinIndexAttr.itemSize; j++) {
-      const index = skinIndexAttr.getComponent(i, j);
-      const weight = skinWeightAttr.getComponent(i, j);
+      const index = attributeGetComponentCompat(skinIndexAttr, i, j);
+      const weight = attributeGetComponentCompat(skinWeightAttr, i, j);
 
       if (weight !== 0) {
         usedIndices.add(index);
@@ -255,9 +257,9 @@ function remapSkinIndexAttribute(
   // replace the skin index attribute with new indices
   for (let i = 0; i < attribute.count; i++) {
     for (let j = 0; j < attribute.itemSize; j++) {
-      const oldIndex = attribute.getComponent(i, j);
+      const oldIndex = attributeGetComponentCompat(attribute, i, j);
       const newIndex = oldToNew.get(oldIndex)!;
-      attribute.setComponent(i, j, newIndex);
+      attributeSetComponentCompat(attribute, i, j, newIndex);
     }
   }
 

--- a/packages/three-vrm/src/VRMUtils/removeUnnecessaryJoints.ts
+++ b/packages/three-vrm/src/VRMUtils/removeUnnecessaryJoints.ts
@@ -1,4 +1,6 @@
 import * as THREE from 'three';
+import { attributeGetComponentCompat } from '../utils/attributeGetComponentCompat';
+import { attributeSetComponentCompat } from '../utils/attributeSetComponentCompat';
 
 /**
  * Traverse the given object and remove unnecessarily bound joints from every `THREE.SkinnedMesh`.
@@ -71,7 +73,7 @@ export function removeUnnecessaryJoints(
     // create a new bone map
     for (let i = 0; i < attribute.count; i++) {
       for (let j = 0; j < attribute.itemSize; j++) {
-        const oldIndex = attribute.getComponent(i, j);
+        const oldIndex = attributeGetComponentCompat(attribute, i, j);
         let newIndex = oldToNew.get(oldIndex);
 
         // new skinIndex buffer
@@ -81,7 +83,7 @@ export function removeUnnecessaryJoints(
           newToOld.set(newIndex, oldIndex);
         }
 
-        attribute.setComponent(i, j, newIndex);
+        attributeSetComponentCompat(attribute, i, j, newIndex);
       }
     }
 

--- a/packages/three-vrm/src/VRMUtils/removeUnnecessaryVertices.ts
+++ b/packages/three-vrm/src/VRMUtils/removeUnnecessaryVertices.ts
@@ -136,12 +136,13 @@ export function removeUnnecessaryVertices(root: THREE.Object3D): void {
     /** True if all morphs are zero. */
     let isNullMorph = true;
 
-    Object.keys(geometry.morphAttributes).forEach((attributeName) => {
+    for (const [key, morphAttributes] of Object.entries(geometry.morphAttributes)) {
+      const attributeName = key as keyof typeof geometry.morphAttributes;
+
       newGeometry.morphAttributes[attributeName] = [];
 
-      const morphs = geometry.morphAttributes[attributeName];
-      for (let iMorph = 0; iMorph < morphs.length; iMorph++) {
-        const originalAttribute = morphs[iMorph] as THREE.BufferAttribute;
+      for (let iMorph = 0; iMorph < morphAttributes.length; iMorph++) {
+        const originalAttribute = morphAttributes[iMorph] as THREE.BufferAttribute;
 
         if ((originalAttribute as any).isInterleavedBufferAttribute) {
           throw new Error('removeUnnecessaryVertices: InterleavedBufferAttribute is not supported');
@@ -168,7 +169,7 @@ export function removeUnnecessaryVertices(root: THREE.Object3D): void {
           normalized,
         );
       }
-    });
+    }
 
     // If all morphs are zero, just discard the morph attributes we've just made
     if (isNullMorph) {

--- a/packages/three-vrm/src/utils/attributeGetComponentCompat.ts
+++ b/packages/three-vrm/src/utils/attributeGetComponentCompat.ts
@@ -1,0 +1,25 @@
+import * as THREE from 'three';
+
+// COMPAT: pre-r155
+/**
+ * A compat function for `BufferAttribute.getComponent()`.
+ * `BufferAttribute.getComponent()` is introduced in r155.
+ *
+ * See: https://github.com/mrdoob/three.js/pull/24515
+ */
+export function attributeGetComponentCompat(
+  attribute: THREE.BufferAttribute | THREE.InterleavedBufferAttribute,
+  index: number,
+  component: number,
+): number {
+  if ((attribute as any).getComponent) {
+    return (attribute as any).getComponent(index, component);
+  } else {
+    // Ref: https://github.com/mrdoob/three.js/pull/24515/files#diff-fd9bd9820242ad98f71b72535834e02a4500e4788ad62e618a172534b69af013
+    let value = attribute.array[index * attribute.itemSize + component];
+    if (attribute.normalized) {
+      value = THREE.MathUtils.denormalize(value, attribute.array as any);
+    }
+    return value;
+  }
+}

--- a/packages/three-vrm/src/utils/attributeSetComponentCompat.ts
+++ b/packages/three-vrm/src/utils/attributeSetComponentCompat.ts
@@ -1,0 +1,25 @@
+import * as THREE from 'three';
+
+// COMPAT: pre-r155
+/**
+ * A compat function for `BufferAttribute.setComponent()`.
+ * `BufferAttribute.setComponent()` is introduced in r155.
+ *
+ * See: https://github.com/mrdoob/three.js/pull/24515
+ */
+export function attributeSetComponentCompat(
+  attribute: THREE.BufferAttribute | THREE.InterleavedBufferAttribute,
+  index: number,
+  component: number,
+  value: number,
+): void {
+  if ((attribute as any).setComponent) {
+    (attribute as any).setComponent(index, component, value);
+  } else {
+    // Ref: https://github.com/mrdoob/three.js/pull/24515/files#diff-fd9bd9820242ad98f71b72535834e02a4500e4788ad62e618a172534b69af013
+    if (attribute.normalized) {
+      value = THREE.MathUtils.normalize(value, attribute.array as any);
+    }
+    attribute.array[index * attribute.itemSize + component] = value;
+  }
+}

--- a/patches/@types+three+0.176.0.patch
+++ b/patches/@types+three+0.176.0.patch
@@ -28,3 +28,29 @@ index 0f129f1..153a564 100644
  
      /**
       * Used to control the morph target behavior; when set to true, the morph target data is treated as relative offsets, rather than as absolute positions/normals.
+diff --git a/node_modules/@types/three/src/nodes/core/LightingModel.d.ts b/node_modules/@types/three/src/nodes/core/LightingModel.d.ts
+index cb894c0..fbbc46f 100644
+--- a/node_modules/@types/three/src/nodes/core/LightingModel.d.ts
++++ b/node_modules/@types/three/src/nodes/core/LightingModel.d.ts
+@@ -10,6 +10,8 @@ export interface LightingModelReflectedLight {
+ }
+ 
+ export interface LightingModelDirectInput extends DirectLightData {
++    lightColor: Node;
++    lightDirection: Node;
+     lightNode: Node;
+     reflectedLight: LightingModelReflectedLight;
+ }
+diff --git a/node_modules/@types/three/src/nodes/core/NodeBuilder.d.ts b/node_modules/@types/three/src/nodes/core/NodeBuilder.d.ts
+index eb477e3..0be5b27 100644
+--- a/node_modules/@types/three/src/nodes/core/NodeBuilder.d.ts
++++ b/node_modules/@types/three/src/nodes/core/NodeBuilder.d.ts
+@@ -49,6 +49,8 @@ export default abstract class NodeBuilder {
+     cache: NodeCache;
+     globalCache: NodeCache;
+ 
++    context: NodeBuilderContext;
++
+     /**
+      * @TODO used to be missing. check the actual type later
+      */

--- a/patches/@types+three+0.176.0.patch
+++ b/patches/@types+three+0.176.0.patch
@@ -1,0 +1,13 @@
+diff --git a/node_modules/@types/three/src/core/BufferGeometry.d.ts b/node_modules/@types/three/src/core/BufferGeometry.d.ts
+index 0f129f1..153a564 100644
+--- a/node_modules/@types/three/src/core/BufferGeometry.d.ts
++++ b/node_modules/@types/three/src/core/BufferGeometry.d.ts
+@@ -172,7 +172,7 @@ export class BufferGeometry<
+      * You will have to call {@link dispose | .dispose}(), and create a new instance of {@link THREE.BufferGeometry | BufferGeometry}.
+      * @defaultValue `{}`
+      */
+-    morphAttributes: Record<"position" | "normal" | "color", Array<BufferAttribute | InterleavedBufferAttribute>>;
++    morphAttributes: Partial<Record<"position" | "normal" | "color", Array<BufferAttribute | InterleavedBufferAttribute>>>;
+ 
+     /**
+      * Used to control the morph target behavior; when set to true, the morph target data is treated as relative offsets, rather than as absolute positions/normals.

--- a/patches/@types+three+0.176.0.patch
+++ b/patches/@types+three+0.176.0.patch
@@ -1,3 +1,20 @@
+diff --git a/node_modules/@types/three/src/animation/tracks/QuaternionKeyframeTrack.d.ts b/node_modules/@types/three/src/animation/tracks/QuaternionKeyframeTrack.d.ts
+index 1467ab3..f1b9eac 100644
+--- a/node_modules/@types/three/src/animation/tracks/QuaternionKeyframeTrack.d.ts
++++ b/node_modules/@types/three/src/animation/tracks/QuaternionKeyframeTrack.d.ts
+@@ -9,9 +9,9 @@ export class QuaternionKeyframeTrack extends KeyframeTrack {
+      * Constructs a new Quaternion keyframe track.
+      *
+      * @param {string} name - The keyframe track's name.
+-     * @param {Array<number>} times - A list of keyframe times.
+-     * @param {Array<number>} values - A list of keyframe values.
++     * @param {ArrayLike<number>} times - A list of keyframe times.
++     * @param {ArrayLike<number>} values - A list of keyframe values.
+      * @param {(InterpolateLinear|InterpolateDiscrete|InterpolateSmooth)} [interpolation] - The interpolation type.
+      */
+-    constructor(name: string, times: Array<number>, values: Array<number>, interpolation?: InterpolationModes);
++    constructor(name: string, times: ArrayLike<number>, values: ArrayLike<number>, interpolation?: InterpolationModes);
+ }
 diff --git a/node_modules/@types/three/src/core/BufferGeometry.d.ts b/node_modules/@types/three/src/core/BufferGeometry.d.ts
 index 0f129f1..153a564 100644
 --- a/node_modules/@types/three/src/core/BufferGeometry.d.ts

--- a/yarn.lock
+++ b/yarn.lock
@@ -1988,6 +1988,11 @@ asynckit@^0.4.0:
   resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
   integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
 
+at-least-node@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/at-least-node/-/at-least-node-1.0.0.tgz#602cd4b46e844ad4effc92a8011a3c46e0238dc2"
+  integrity sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
+
 axios@^1.7.4:
   version "1.8.4"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.8.4.tgz#78990bb4bc63d2cae072952d374835950a82f447"
@@ -2173,6 +2178,32 @@ cacache@^18.0.0, cacache@^18.0.3:
     tar "^6.1.11"
     unique-filename "^3.0.0"
 
+call-bind-apply-helpers@^1.0.0, call-bind-apply-helpers@^1.0.1, call-bind-apply-helpers@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz#4b5428c222be985d79c3d82657479dbe0b59b2d6"
+  integrity sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==
+  dependencies:
+    es-errors "^1.3.0"
+    function-bind "^1.1.2"
+
+call-bind@^1.0.8:
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.8.tgz#0736a9660f537e3388826f440d5ec45f744eaa4c"
+  integrity sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww==
+  dependencies:
+    call-bind-apply-helpers "^1.0.0"
+    es-define-property "^1.0.0"
+    get-intrinsic "^1.2.4"
+    set-function-length "^1.2.2"
+
+call-bound@^1.0.4:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/call-bound/-/call-bound-1.0.4.tgz#238de935d2a2a692928c538c7ccfa91067fd062a"
+  integrity sha512-+ys997U96po4Kx/ABpBCqhA9EuxJaQWDQg7295H4hBphv3IZg0boBKuwYpt4YXp6MZ5AmZQnU/tyMTlRpaSejg==
+  dependencies:
+    call-bind-apply-helpers "^1.0.2"
+    get-intrinsic "^1.3.0"
+
 callsites@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
@@ -2219,7 +2250,7 @@ chalk@^2.0.0, chalk@^2.4.2:
     escape-string-regexp "^1.0.5"
     supports-color "^5.3.0"
 
-chalk@^4.0.0, chalk@^4.0.2, chalk@^4.1.0, chalk@^4.1.1:
+chalk@^4.0.0, chalk@^4.0.2, chalk@^4.1.0, chalk@^4.1.1, chalk@^4.1.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -2252,7 +2283,7 @@ chownr@^2.0.0:
   resolved "https://registry.yarnpkg.com/chownr/-/chownr-2.0.0.tgz#15bfbe53d2eab4cf70f18a8cd68ebe5b3cb1dece"
   integrity sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
 
-ci-info@^3.2.0:
+ci-info@^3.2.0, ci-info@^3.7.0:
   version "3.9.0"
   resolved "https://registry.yarnpkg.com/ci-info/-/ci-info-3.9.0.tgz#4279a62028a7b1f262f3473fc9605f5e218c59b4"
   integrity sha512-NIxF55hv4nSqQswkAeiOi1r83xy8JldOFDTWiug55KBu9Jnblncd2U6ViHmYgHf01TPZS77NJBhBMKdWj9HQMQ==
@@ -2639,6 +2670,15 @@ defaults@^1.0.3:
   dependencies:
     clone "^1.0.2"
 
+define-data-property@^1.1.4:
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/define-data-property/-/define-data-property-1.1.4.tgz#894dc141bb7d3060ae4366f6a0107e68fbe48c5e"
+  integrity sha512-rBMvIzlpA8v6E+SJZoo++HAYqsLrkg7MSfIinMPFhmkorw7X+dOXVJQs+QT69zGkzMyfDnIMN2Wid1+NbL3T+A==
+  dependencies:
+    es-define-property "^1.0.0"
+    es-errors "^1.3.0"
+    gopd "^1.0.1"
+
 define-lazy-prop@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/define-lazy-prop/-/define-lazy-prop-2.0.0.tgz#3f7ae421129bcaaac9bc74905c98a0009ec9ee7f"
@@ -2729,6 +2769,15 @@ dotenv@^16.4.4, dotenv@~16.4.5:
   version "16.4.5"
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-16.4.5.tgz#cdd3b3b604cb327e286b4762e13502f717cb099f"
   integrity sha512-ZmdL2rui+eB2YwhsWzjInR8LldtZHGDoQ1ugH85ppHKwpUHL7j7rN0Ti9NCnGiQbhaZ11FpR+7ao1dNsmduNUg==
+
+dunder-proto@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/dunder-proto/-/dunder-proto-1.0.1.tgz#d7ae667e1dc83482f8b70fd0f6eefc50da30f58a"
+  integrity sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==
+  dependencies:
+    call-bind-apply-helpers "^1.0.1"
+    es-errors "^1.3.0"
+    gopd "^1.2.0"
 
 duplexer@^0.1.1:
   version "0.1.2"
@@ -2834,6 +2883,23 @@ error-ex@^1.3.1:
   integrity sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
   dependencies:
     is-arrayish "^0.2.1"
+
+es-define-property@^1.0.0, es-define-property@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/es-define-property/-/es-define-property-1.0.1.tgz#983eb2f9a6724e9303f61addf011c72e09e0b0fa"
+  integrity sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==
+
+es-errors@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/es-errors/-/es-errors-1.3.0.tgz#05f75a25dab98e4fb1dcd5e1472c0546d5057c8f"
+  integrity sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==
+
+es-object-atoms@^1.0.0, es-object-atoms@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/es-object-atoms/-/es-object-atoms-1.1.1.tgz#1c4f2c4837327597ce69d2ca190a7fdd172338c1"
+  integrity sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==
+  dependencies:
+    es-errors "^1.3.0"
 
 esbuild@^0.25.0:
   version "0.25.4"
@@ -3192,6 +3258,13 @@ find-up@^5.0.0:
     locate-path "^6.0.0"
     path-exists "^4.0.0"
 
+find-yarn-workspace-root@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/find-yarn-workspace-root/-/find-yarn-workspace-root-2.0.0.tgz#f47fb8d239c900eb78179aa81b66673eac88f7bd"
+  integrity sha512-1IMnbjt4KzsQfnhnzNd8wUEgXZ44IzZaZmnLYx7D5FZlaHt2gW20Cri8Q+E/t5tIj4+epTBub+2Zxu/vNILzqQ==
+  dependencies:
+    micromatch "^4.0.2"
+
 flat-cache@^4.0.0:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/flat-cache/-/flat-cache-4.0.1.tgz#0ece39fcb14ee012f4b0410bd33dd9c1f011127c"
@@ -3253,6 +3326,16 @@ fs-extra@^11.2.0:
     jsonfile "^6.0.1"
     universalify "^2.0.0"
 
+fs-extra@^9.0.0:
+  version "9.1.0"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-9.1.0.tgz#5954460c764a8da2094ba3554bf839e6b9a7c86d"
+  integrity sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
+  dependencies:
+    at-least-node "^1.0.0"
+    graceful-fs "^4.2.0"
+    jsonfile "^6.0.1"
+    universalify "^2.0.0"
+
 fs-minipass@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/fs-minipass/-/fs-minipass-2.1.0.tgz#7f5036fdbf12c63c169190cbe4199c852271f9fb"
@@ -3302,6 +3385,22 @@ get-east-asian-width@^1.0.0:
   resolved "https://registry.yarnpkg.com/get-east-asian-width/-/get-east-asian-width-1.2.0.tgz#5e6ebd9baee6fb8b7b6bd505221065f0cd91f64e"
   integrity sha512-2nk+7SIVb14QrgXFHcm84tD4bKQz0RxPuMT8Ag5KPOq7J5fEmAg0UbXdTOSHqNuHSU28k55qnceesxXRZGzKWA==
 
+get-intrinsic@^1.2.4, get-intrinsic@^1.3.0:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.3.0.tgz#743f0e3b6964a93a5491ed1bffaae054d7f98d01"
+  integrity sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==
+  dependencies:
+    call-bind-apply-helpers "^1.0.2"
+    es-define-property "^1.0.1"
+    es-errors "^1.3.0"
+    es-object-atoms "^1.1.1"
+    function-bind "^1.1.2"
+    get-proto "^1.0.1"
+    gopd "^1.2.0"
+    has-symbols "^1.1.0"
+    hasown "^2.0.2"
+    math-intrinsics "^1.1.0"
+
 get-package-type@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/get-package-type/-/get-package-type-0.1.0.tgz#8de2d803cff44df3bc6c456e6668b36c3926e11a"
@@ -3321,6 +3420,14 @@ get-port@5.1.1:
   version "5.1.1"
   resolved "https://registry.yarnpkg.com/get-port/-/get-port-5.1.1.tgz#0469ed07563479de6efb986baf053dcd7d4e3193"
   integrity sha512-g/Q1aTSDOxFpchXC4i8ZWvxA1lnPqx/JHqcpIw0/LX9T8x/GBbi6YnlN5nhaKIFkT8oFsscUKgDJYxfwfS6QsQ==
+
+get-proto@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/get-proto/-/get-proto-1.0.1.tgz#150b3f2743869ef3e851ec0c49d15b1d14d00ee1"
+  integrity sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==
+  dependencies:
+    dunder-proto "^1.0.1"
+    es-object-atoms "^1.0.0"
 
 get-stream@6.0.0:
   version "6.0.0"
@@ -3482,6 +3589,11 @@ globby@11.1.0:
     merge2 "^1.4.1"
     slash "^3.0.0"
 
+gopd@^1.0.1, gopd@^1.2.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/gopd/-/gopd-1.2.0.tgz#89f56b8217bdbc8802bd299df6d7f1081d7e51a1"
+  integrity sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==
+
 graceful-fs@4.2.11, graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.2.0, graceful-fs@^4.2.6, graceful-fs@^4.2.9:
   version "4.2.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.11.tgz#4183e4e8bf08bb6e05bbb2f7d2e0c8f712ca40e3"
@@ -3519,6 +3631,18 @@ has-flag@^4.0.0:
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-4.0.0.tgz#944771fd9c81c81265c4d6941860da06bb59479b"
   integrity sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
 
+has-property-descriptors@^1.0.2:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/has-property-descriptors/-/has-property-descriptors-1.0.2.tgz#963ed7d071dc7bf5f084c5bfbe0d1b6222586854"
+  integrity sha512-55JNKuIW+vq4Ke1BjOTjM2YctQIvCT7GFzHwmfZPGo5wnrgkid0YQtnAleFSqumZm4az3n2BS+erby5ipJdgrg==
+  dependencies:
+    es-define-property "^1.0.0"
+
+has-symbols@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.1.0.tgz#fc9c6a783a084951d0b971fe1018de813707a338"
+  integrity sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==
+
 has-unicode@2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
@@ -3531,7 +3655,7 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
-hasown@^2.0.0:
+hasown@^2.0.0, hasown@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/hasown/-/hasown-2.0.2.tgz#003eaf91be7adc372e84ec59dc37252cedb80003"
   integrity sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==
@@ -3861,12 +3985,17 @@ is-unicode-supported@^0.1.0:
   resolved "https://registry.yarnpkg.com/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz#3f26c76a809593b52bfa2ecb5710ed2779b522a7"
   integrity sha512-knxG2q4UC3u8stRGyAVJCOdxFmv5DZiRcdlIaAQXAbSfJya+OhopNotLQrstBhququ4ZpuKbDc/8S6mgXgPFPw==
 
-is-wsl@^2.2.0:
+is-wsl@^2.1.1, is-wsl@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
   integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
   dependencies:
     is-docker "^2.0.0"
+
+isarray@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-2.0.5.tgz#8af1e4c1221244cc62459faf38940d4e644a5723"
+  integrity sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==
 
 isarray@~1.0.0:
   version "1.0.0"
@@ -4406,6 +4535,17 @@ json-stable-stringify-without-jsonify@^1.0.1:
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
 
+json-stable-stringify@^1.0.2:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/json-stable-stringify/-/json-stable-stringify-1.3.0.tgz#8903cfac42ea1a0f97f35d63a4ce0518f0cc6a70"
+  integrity sha512-qtYiSSFlwot9XHtF9bD9c7rwKjr+RecWT//ZnPvSmEjpV5mmPOCN4j8UjY5hbjNkOwZ/jQv3J6R1/pL7RwgMsg==
+  dependencies:
+    call-bind "^1.0.8"
+    call-bound "^1.0.4"
+    isarray "^2.0.5"
+    jsonify "^0.0.1"
+    object-keys "^1.1.1"
+
 json-stringify-nice@^1.1.4:
   version "1.1.4"
   resolved "https://registry.yarnpkg.com/json-stringify-nice/-/json-stringify-nice-1.1.4.tgz#2c937962b80181d3f317dd39aa323e14f5a60a67"
@@ -4435,6 +4575,11 @@ jsonfile@^6.0.1:
   optionalDependencies:
     graceful-fs "^4.1.6"
 
+jsonify@^0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/jsonify/-/jsonify-0.0.1.tgz#2aa3111dae3d34a0f151c63f3a45d995d9420978"
+  integrity sha512-2/Ki0GcmuqSrgFyelQq9M05y7PS0mEwuIzrf3f1fPqkVDVRvZrPZtVSMHxdgo8Aq0sxAOb/cr2aqqA3LeWHVPg==
+
 jsonparse@^1.2.0, jsonparse@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/jsonparse/-/jsonparse-1.3.1.tgz#3f4dae4a91fac315f71062f8521cc239f1366280"
@@ -4461,6 +4606,13 @@ kind-of@^6.0.2, kind-of@^6.0.3:
   version "6.0.3"
   resolved "https://registry.yarnpkg.com/kind-of/-/kind-of-6.0.3.tgz#07c05034a6c349fa06e24fa35aa76db4580ce4dd"
   integrity sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
+
+klaw-sync@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/klaw-sync/-/klaw-sync-6.0.0.tgz#1fd2cfd56ebb6250181114f0a581167099c2b28c"
+  integrity sha512-nIeuVSzdCCs6TDPTqI8w1Yre34sSq7AkZ4B3sfOBbI2CgVSB4Du4aLQijFU2+lhAFCwt9+42Hel6lQNIv6AntQ==
+  dependencies:
+    graceful-fs "^4.1.11"
 
 kleur@^3.0.3:
   version "3.0.3"
@@ -4843,6 +4995,11 @@ markdown-it@^14.1.0:
     punycode.js "^2.3.1"
     uc.micro "^2.1.0"
 
+math-intrinsics@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/math-intrinsics/-/math-intrinsics-1.1.0.tgz#a0dd74be81e2aa5c2f27e65ce283605ee4e2b7f9"
+  integrity sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==
+
 mdurl@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/mdurl/-/mdurl-2.0.0.tgz#80676ec0433025dd3e17ee983d0fe8de5a2237e0"
@@ -4880,7 +5037,7 @@ meshoptimizer@~0.18.1:
   resolved "https://registry.yarnpkg.com/meshoptimizer/-/meshoptimizer-0.18.1.tgz#cdb90907f30a7b5b1190facd3b7ee6b7087797d8"
   integrity sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw==
 
-micromatch@^4.0.4, micromatch@^4.0.8, micromatch@~4.0.8:
+micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.8, micromatch@~4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.8.tgz#d66fa18f3a47076789320b9b1af32bd86d9fa202"
   integrity sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==
@@ -5334,6 +5491,11 @@ npm-run-path@^5.1.0:
     "@nx/nx-win32-arm64-msvc" "20.1.0"
     "@nx/nx-win32-x64-msvc" "20.1.0"
 
+object-keys@^1.1.1:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
+  integrity sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
+
 once@^1.3.0, once@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/once/-/once-1.4.0.tgz#583b1aa775961d4b113ac17d9c50baef9dd76bd1"
@@ -5361,6 +5523,14 @@ onetime@^7.0.0:
   integrity sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==
   dependencies:
     mimic-function "^5.0.0"
+
+open@^7.4.2:
+  version "7.4.2"
+  resolved "https://registry.yarnpkg.com/open/-/open-7.4.2.tgz#b8147e26dcf3e426316c730089fd71edd29c2321"
+  integrity sha512-MVHddDVweXZF3awtlAS+6pgKLlm/JgxZ90+/NBurBoQctVOOB/zDdVjcyPzQ+0laDGbsWgrRkflI65sQeOgT9Q==
+  dependencies:
+    is-docker "^2.0.0"
+    is-wsl "^2.1.1"
 
 open@^8.4.0:
   version "8.4.0"
@@ -5593,6 +5763,27 @@ parse-url@^8.1.0:
   integrity sha512-xDvOoLU5XRrcOZvnI6b8zA6n9O9ejNk/GExuz1yBuWUGn9KA97GI6HTs6u02wKara1CeVmZhH+0TZFdWScR89w==
   dependencies:
     parse-path "^7.0.0"
+
+patch-package@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/patch-package/-/patch-package-8.0.0.tgz#d191e2f1b6e06a4624a0116bcb88edd6714ede61"
+  integrity sha512-da8BVIhzjtgScwDJ2TtKsfT5JFWz1hYoBl9rUQ1f38MC2HwnEIkK8VN3dKMKcP7P7bvvgzNDbfNHtx3MsQb5vA==
+  dependencies:
+    "@yarnpkg/lockfile" "^1.1.0"
+    chalk "^4.1.2"
+    ci-info "^3.7.0"
+    cross-spawn "^7.0.3"
+    find-yarn-workspace-root "^2.0.0"
+    fs-extra "^9.0.0"
+    json-stable-stringify "^1.0.2"
+    klaw-sync "^6.0.0"
+    minimist "^1.2.6"
+    open "^7.4.2"
+    rimraf "^2.6.3"
+    semver "^7.5.3"
+    slash "^2.0.0"
+    tmp "^0.0.33"
+    yaml "^2.2.2"
 
 path-exists@^3.0.0:
   version "3.0.0"
@@ -5994,6 +6185,13 @@ rfdc@^1.4.1:
   resolved "https://registry.yarnpkg.com/rfdc/-/rfdc-1.4.1.tgz#778f76c4fb731d93414e8f925fbecf64cce7f6ca"
   integrity sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==
 
+rimraf@^2.6.3:
+  version "2.7.1"
+  resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.7.1.tgz#35797f13a7fdadc566142c29d4f07ccad483e3ec"
+  integrity sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
+  dependencies:
+    glob "^7.1.3"
+
 rimraf@^3.0.0:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-3.0.2.tgz#f1a5402ba6220ad52cc1282bac1ae3aa49fd061a"
@@ -6068,6 +6266,18 @@ set-blocking@^2.0.0:
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
   integrity sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==
 
+set-function-length@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/set-function-length/-/set-function-length-1.2.2.tgz#aac72314198eaed975cf77b2c3b6b880695e5449"
+  integrity sha512-pgRc4hJ4/sNjWCSS9AmnS40x3bNMDTknHgL5UaMBTMyJnU90EgWh1Rz+MC9eFu4BuN/UwZjKQuY/1v3rM7HMfg==
+  dependencies:
+    define-data-property "^1.1.4"
+    es-errors "^1.3.0"
+    function-bind "^1.1.2"
+    get-intrinsic "^1.2.4"
+    gopd "^1.0.1"
+    has-property-descriptors "^1.0.2"
+
 shallow-clone@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/shallow-clone/-/shallow-clone-3.0.1.tgz#8f2981ad92531f55035b01fb230769a40e02efa3"
@@ -6118,6 +6328,11 @@ slash@3.0.0, slash@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-3.0.0.tgz#6539be870c165adbd5240220dbe361f1bc4d4634"
   integrity sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
+
+slash@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
+  integrity sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
 
 slice-ansi@^5.0.0:
   version "5.0.0"
@@ -6898,6 +7113,11 @@ yallist@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
   integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
+
+yaml@^2.2.2:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.8.0.tgz#15f8c9866211bdc2d3781a0890e44d4fa1a5fff6"
+  integrity sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==
 
 yaml@^2.7.0, "yaml@^2.7.0 ":
   version "2.7.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -408,6 +408,11 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
+"@dimforge/rapier3d-compat@^0.12.0":
+  version "0.12.0"
+  resolved "https://registry.yarnpkg.com/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz#7b3365e1dfdc5cd957b45afe920b4ac06c7cd389"
+  integrity sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==
+
 "@emnapi/core@^1.1.0":
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/@emnapi/core/-/core-1.2.0.tgz#7b738e5033738132bf6af0b8fae7b05249bdcbd7"
@@ -1656,11 +1661,12 @@
   resolved "https://registry.yarnpkg.com/@types/stats.js/-/stats.js-0.17.0.tgz#0ed81d48e03b590c24da85540c1d952077a9fe20"
   integrity sha512-9w+a7bR8PeB0dCT/HBULU2fMqf6BAzvKbxFboYhmDtDkKPiyXYbjoe2auwsXlEFI7CFNMF1dCv3dFH5Poy9R1w==
 
-"@types/three@^0.170.0":
-  version "0.170.0"
-  resolved "https://registry.yarnpkg.com/@types/three/-/three-0.170.0.tgz#1fe17693e4e08dd6fd8662542af4c9cba9671620"
-  integrity sha512-CUm2uckq+zkCY7ZbFpviRttY+6f9fvwm6YqSqPfA5K22s9w7R4VnA3rzJse8kHVvuzLcTx+CjNCs2NYe0QFAyg==
+"@types/three@^0.176.0":
+  version "0.176.0"
+  resolved "https://registry.yarnpkg.com/@types/three/-/three-0.176.0.tgz#b6eced2b05e839395a6171e066c4631bc5b0a1e0"
+  integrity sha512-FwfPXxCqOtP7EdYMagCFePNKoG1AGBDUEVKtluv2BTVRpSt7b+X27xNsirPCTCqY1pGYsPUzaM3jgWP7dXSxlw==
   dependencies:
+    "@dimforge/rapier3d-compat" "^0.12.0"
     "@tweenjs/tween.js" "~23.1.3"
     "@types/stats.js" "*"
     "@types/webxr" "*"
@@ -6428,10 +6434,10 @@ text-extensions@^1.0.0:
   resolved "https://registry.yarnpkg.com/text-extensions/-/text-extensions-1.9.0.tgz#1853e45fee39c945ce6f6c36b2d659b5aabc2a26"
   integrity sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==
 
-three@^0.171.0:
-  version "0.171.0"
-  resolved "https://registry.yarnpkg.com/three/-/three-0.171.0.tgz#3c0dd3f8fa14e78a7f8db6e416b98f264f1185c0"
-  integrity sha512-Y/lAXPaKZPcEdkKjh0JOAHVv8OOnv/NDJqm0wjfCzyQmfKxV7zvkwsnBgPBKTzJHToSOhRGQAGbPJObT59B/PQ==
+three@^0.176.0:
+  version "0.176.0"
+  resolved "https://registry.yarnpkg.com/three/-/three-0.176.0.tgz#a30c1974e46db5745e4f96dd9ee2028d71e16ecf"
+  integrity sha512-PWRKYWQo23ojf9oZSlRGH8K09q7nRSWx6LY/HF/UUrMdYgN9i1e2OwJYHoQjwc6HF/4lvvYLC5YC1X8UJL2ZpA==
 
 through2@^2.0.0:
   version "2.0.5"


### PR DESCRIPTION
This bumps Three.js to r176.

I believe there are no actions needed on the user side.

See: https://github.com/mrdoob/three.js/releases

