### PR TITLE
bump three.js to 0.177.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ You can import all the dependencies via CDN like [jsDelivr](https://www.jsdelivr
 <script type="importmap">
   {
     "imports": {
-      "three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
-      "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
+      "three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
+      "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
       "@pixiv/three-vrm": "https://cdn.jsdelivr.net/npm/@pixiv/three-vrm@3/lib/three-vrm.module.min.js"
     }
   }

--- a/packages/three-vrm-animation/examples/dnd.html
+++ b/packages/three-vrm-animation/examples/dnd.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
 					"@pixiv/three-vrm": "https://cdn.jsdelivr.net/npm/@pixiv/three-vrm@3/lib/three-vrm.module.js",
 					"@pixiv/three-vrm-animation": "../lib/three-vrm-animation.module.js"
 				}

--- a/packages/three-vrm-animation/examples/loader-plugin.html
+++ b/packages/three-vrm-animation/examples/loader-plugin.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
 					"@pixiv/three-vrm": "https://cdn.jsdelivr.net/npm/@pixiv/three-vrm@3/lib/three-vrm.module.js",
 					"@pixiv/three-vrm-animation": "../lib/three-vrm-animation.module.js"
 				}

--- a/packages/three-vrm-animation/package.json
+++ b/packages/three-vrm-animation/package.json
@@ -51,9 +51,9 @@
     "@pixiv/types-vrmc-vrm-animation-1.0": "3.4.1"
   },
   "devDependencies": {
-    "@types/three": "^0.176.0",
+    "@types/three": "^0.177.0",
     "lint-staged": "16.1.2",
-    "three": "^0.176.0"
+    "three": "^0.177.0"
   },
   "peerDependencies": {
     "three": ">=0.137"

--- a/packages/three-vrm-core/examples/expressions.html
+++ b/packages/three-vrm-core/examples/expressions.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
 					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/examples/firstPerson.html
+++ b/packages/three-vrm-core/examples/firstPerson.html
@@ -28,8 +28,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
 					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/examples/humanoid.html
+++ b/packages/three-vrm-core/examples/humanoid.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
 					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/examples/humanoidAnimation/index.html
+++ b/packages/three-vrm-core/examples/humanoidAnimation/index.html
@@ -34,8 +34,8 @@
 			{
 				"imports": {
 					"fflate": "https://cdn.jsdelivr.net/npm/fflate@0.7.4/esm/browser.js",
-					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
 					"@pixiv/three-vrm-core": "../../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/examples/lookAt.html
+++ b/packages/three-vrm-core/examples/lookAt.html
@@ -28,8 +28,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
 					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/examples/meta.html
+++ b/packages/three-vrm-core/examples/meta.html
@@ -35,8 +35,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
 					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/package.json
+++ b/packages/three-vrm-core/package.json
@@ -54,8 +54,8 @@
     "@pixiv/types-vrmc-vrm-1.0": "3.4.1"
   },
   "devDependencies": {
-    "@types/three": "^0.176.0",
-    "three": "^0.176.0"
+    "@types/three": "^0.177.0",
+    "three": "^0.177.0"
   },
   "peerDependencies": {
     "three": ">=0.137"

--- a/packages/three-vrm-materials-hdr-emissive-multiplier/examples/loader-plugin.html
+++ b/packages/three-vrm-materials-hdr-emissive-multiplier/examples/loader-plugin.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
 					"@pixiv/three-vrm-materials-hdr-emissive-multiplier": "../lib/three-vrm-materials-hdr-emissive-multiplier.module.js"
 				}
 			}

--- a/packages/three-vrm-materials-hdr-emissive-multiplier/package.json
+++ b/packages/three-vrm-materials-hdr-emissive-multiplier/package.json
@@ -52,8 +52,8 @@
     "@pixiv/types-vrmc-materials-hdr-emissive-multiplier-1.0": "3.4.1"
   },
   "devDependencies": {
-    "@types/three": "^0.176.0",
-    "three": "^0.176.0"
+    "@types/three": "^0.177.0",
+    "three": "^0.177.0"
   },
   "peerDependencies": {
     "three": ">=0.137"

--- a/packages/three-vrm-materials-mtoon/examples/emissive-strength.html
+++ b/packages/three-vrm-materials-mtoon/examples/emissive-strength.html
@@ -24,8 +24,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
 					"@pixiv/three-vrm-materials-mtoon": "../lib/three-vrm-materials-mtoon.module.js"
 				}
 			}

--- a/packages/three-vrm-materials-mtoon/examples/feature-test.html
+++ b/packages/three-vrm-materials-mtoon/examples/feature-test.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
 					"@pixiv/three-vrm-materials-mtoon": "../lib/three-vrm-materials-mtoon.module.js"
 				}
 			}

--- a/packages/three-vrm-materials-mtoon/examples/loader-plugin.html
+++ b/packages/three-vrm-materials-mtoon/examples/loader-plugin.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
 					"@pixiv/three-vrm-materials-mtoon": "../lib/three-vrm-materials-mtoon.module.js"
 				}
 			}

--- a/packages/three-vrm-materials-mtoon/examples/webgpu-feature-test.html
+++ b/packages/three-vrm-materials-mtoon/examples/webgpu-feature-test.html
@@ -23,10 +23,10 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.webgpu.js",
-					"three/webgpu": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.webgpu.js",
-					"three/tsl": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.tsl.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.webgpu.js",
+					"three/webgpu": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.webgpu.js",
+					"three/tsl": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.tsl.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
 					"@pixiv/three-vrm-materials-mtoon": "../lib/three-vrm-materials-mtoon.module.js",
 					"@pixiv/three-vrm-materials-mtoon/nodes": "../lib/nodes/index.module.js"
 				}

--- a/packages/three-vrm-materials-mtoon/examples/webgpu-loader-plugin.html
+++ b/packages/three-vrm-materials-mtoon/examples/webgpu-loader-plugin.html
@@ -23,10 +23,10 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.webgpu.js",
-					"three/webgpu": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.webgpu.js",
-					"three/tsl": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.tsl.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.webgpu.js",
+					"three/webgpu": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.webgpu.js",
+					"three/tsl": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.tsl.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
 					"@pixiv/three-vrm-materials-mtoon": "../lib/three-vrm-materials-mtoon.module.js",
 					"@pixiv/three-vrm-materials-mtoon/nodes": "../lib/nodes/index.module.js"
 				}

--- a/packages/three-vrm-materials-mtoon/package.json
+++ b/packages/three-vrm-materials-mtoon/package.json
@@ -58,8 +58,8 @@
     "@pixiv/types-vrmc-materials-mtoon-1.0": "3.4.1"
   },
   "devDependencies": {
-    "@types/three": "^0.176.0",
-    "three": "^0.176.0"
+    "@types/three": "^0.177.0",
+    "three": "^0.177.0"
   },
   "peerDependencies": {
     "three": ">=0.137"

--- a/packages/three-vrm-materials-v0compat/package.json
+++ b/packages/three-vrm-materials-v0compat/package.json
@@ -49,8 +49,8 @@
     "@pixiv/types-vrmc-materials-mtoon-1.0": "3.4.1"
   },
   "devDependencies": {
-    "@types/three": "^0.176.0",
-    "three": "^0.176.0"
+    "@types/three": "^0.177.0",
+    "three": "^0.177.0"
   },
   "peerDependencies": {
     "three": ">=0.137"

--- a/packages/three-vrm-node-constraint/examples/aim.html
+++ b/packages/three-vrm-node-constraint/examples/aim.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
 					"tweakpane": "https://cdn.jsdelivr.net/npm/tweakpane@3.0",
 					"tweakpane-plugin-rotation": "https://cdn.jsdelivr.net/npm/@0b5vr/tweakpane-plugin-rotation@0.1",
 					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"

--- a/packages/three-vrm-node-constraint/examples/importer.html
+++ b/packages/three-vrm-node-constraint/examples/importer.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
 					"tweakpane": "https://cdn.jsdelivr.net/npm/tweakpane@3.0",
 					"tweakpane-plugin-rotation": "https://cdn.jsdelivr.net/npm/@0b5vr/tweakpane-plugin-rotation@0.1",
 					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"

--- a/packages/three-vrm-node-constraint/examples/roll.html
+++ b/packages/three-vrm-node-constraint/examples/roll.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
 					"tweakpane": "https://cdn.jsdelivr.net/npm/tweakpane@3.0",
 					"tweakpane-plugin-rotation": "https://cdn.jsdelivr.net/npm/@0b5vr/tweakpane-plugin-rotation@0.1",
 					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"

--- a/packages/three-vrm-node-constraint/examples/rotation.html
+++ b/packages/three-vrm-node-constraint/examples/rotation.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
 					"tweakpane": "https://cdn.jsdelivr.net/npm/tweakpane@3.0",
 					"tweakpane-plugin-rotation": "https://cdn.jsdelivr.net/npm/@0b5vr/tweakpane-plugin-rotation@0.1",
 					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"

--- a/packages/three-vrm-node-constraint/examples/upper-arm.html
+++ b/packages/three-vrm-node-constraint/examples/upper-arm.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
 					"tweakpane": "https://cdn.jsdelivr.net/npm/tweakpane@3.0",
 					"tweakpane-plugin-rotation": "https://cdn.jsdelivr.net/npm/@0b5vr/tweakpane-plugin-rotation@0.1",
 					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"

--- a/packages/three-vrm-node-constraint/package.json
+++ b/packages/three-vrm-node-constraint/package.json
@@ -53,8 +53,8 @@
     "@pixiv/types-vrmc-node-constraint-1.0": "3.4.1"
   },
   "devDependencies": {
-    "@types/three": "^0.176.0",
-    "three": "^0.176.0"
+    "@types/three": "^0.177.0",
+    "three": "^0.177.0"
   },
   "peerDependencies": {
     "three": ">=0.137"

--- a/packages/three-vrm-springbone/examples/collider.html
+++ b/packages/three-vrm-springbone/examples/collider.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-				"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
-				"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
+				"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
+				"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
 				"@pixiv/three-vrm-springbone": "../lib/three-vrm-springbone.module.js"
 			  }
 			}

--- a/packages/three-vrm-springbone/examples/loader-plugin.html
+++ b/packages/three-vrm-springbone/examples/loader-plugin.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-				"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
-				"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
+				"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
+				"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
 				"@pixiv/three-vrm-springbone": "../lib/three-vrm-springbone.module.js"
 			  }
 			}

--- a/packages/three-vrm-springbone/examples/multiple.html
+++ b/packages/three-vrm-springbone/examples/multiple.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-				"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
-				"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
+				"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
+				"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
 				"@pixiv/three-vrm-springbone": "../lib/three-vrm-springbone.module.js"
 			  }
 			}

--- a/packages/three-vrm-springbone/examples/single.html
+++ b/packages/three-vrm-springbone/examples/single.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-				"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
-				"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
+				"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
+				"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
 				"@pixiv/three-vrm-springbone": "../lib/three-vrm-springbone.module.js"
 			  }
 			}

--- a/packages/three-vrm-springbone/package.json
+++ b/packages/three-vrm-springbone/package.json
@@ -55,8 +55,8 @@
     "@pixiv/types-vrmc-springbone-extended-collider-1.0": "3.4.1"
   },
   "devDependencies": {
-    "@types/three": "^0.176.0",
-    "three": "^0.176.0"
+    "@types/three": "^0.177.0",
+    "three": "^0.177.0"
   },
   "peerDependencies": {
     "three": ">=0.137"

--- a/packages/three-vrm/README.md
+++ b/packages/three-vrm/README.md
@@ -32,8 +32,8 @@ You can import all the dependencies via CDN like [jsDelivr](https://www.jsdelivr
 <script type="importmap">
   {
     "imports": {
-      "three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
-      "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
+      "three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
+      "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
       "@pixiv/three-vrm": "https://cdn.jsdelivr.net/npm/@pixiv/three-vrm@3/lib/three-vrm.module.min.js"
     }
   }

--- a/packages/three-vrm/examples/animations.html
+++ b/packages/three-vrm/examples/animations.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/basic.html
+++ b/packages/three-vrm/examples/basic.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/bones.html
+++ b/packages/three-vrm/examples/bones.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/debug.html
+++ b/packages/three-vrm/examples/debug.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/dnd.html
+++ b/packages/three-vrm/examples/dnd.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/expressions.html
+++ b/packages/three-vrm/examples/expressions.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/firstperson.html
+++ b/packages/three-vrm/examples/firstperson.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/humanoidAnimation/index.html
+++ b/packages/three-vrm/examples/humanoidAnimation/index.html
@@ -34,8 +34,8 @@
 			{
 				"imports": {
 					"fflate": "https://cdn.jsdelivr.net/npm/fflate@0.7.4/esm/browser.js",
-					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
 					"@pixiv/three-vrm": "../../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/lookat-advanced.html
+++ b/packages/three-vrm/examples/lookat-advanced.html
@@ -24,8 +24,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/lookat.html
+++ b/packages/three-vrm/examples/lookat.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/materials-debug.html
+++ b/packages/three-vrm/examples/materials-debug.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/meta.html
+++ b/packages/three-vrm/examples/meta.html
@@ -34,8 +34,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/mouse.html
+++ b/packages/three-vrm/examples/mouse.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/webgpu-dnd.html
+++ b/packages/three-vrm/examples/webgpu-dnd.html
@@ -23,10 +23,10 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.webgpu.js",
-					"three/webgpu": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.webgpu.js",
-					"three/tsl": "https://cdn.jsdelivr.net/npm/three@0.176.0/build/three.tsl.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.176.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.webgpu.js",
+					"three/webgpu": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.webgpu.js",
+					"three/tsl": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.tsl.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js",
 					"@pixiv/three-vrm/nodes": "../lib/nodes/index.module.js"
 				}

--- a/packages/three-vrm/package.json
+++ b/packages/three-vrm/package.json
@@ -63,8 +63,8 @@
     "@pixiv/three-vrm-springbone": "3.4.1"
   },
   "devDependencies": {
-    "@types/three": "^0.176.0",
-    "three": "^0.176.0"
+    "@types/three": "^0.177.0",
+    "three": "^0.177.0"
   },
   "peerDependencies": {
     "three": ">=0.137"

--- a/patches/@types+three+0.177.0.patch
+++ b/patches/@types+three+0.177.0.patch
@@ -1,8 +1,8 @@
 diff --git a/node_modules/@types/three/src/animation/tracks/QuaternionKeyframeTrack.d.ts b/node_modules/@types/three/src/animation/tracks/QuaternionKeyframeTrack.d.ts
-index 1467ab3..f1b9eac 100644
+index 4bcaa98..f1b9eac 100644
 --- a/node_modules/@types/three/src/animation/tracks/QuaternionKeyframeTrack.d.ts
 +++ b/node_modules/@types/three/src/animation/tracks/QuaternionKeyframeTrack.d.ts
-@@ -9,9 +9,9 @@ export class QuaternionKeyframeTrack extends KeyframeTrack {
+@@ -9,8 +9,8 @@ export class QuaternionKeyframeTrack extends KeyframeTrack {
       * Constructs a new Quaternion keyframe track.
       *
       * @param {string} name - The keyframe track's name.
@@ -12,22 +12,7 @@ index 1467ab3..f1b9eac 100644
 +     * @param {ArrayLike<number>} values - A list of keyframe values.
       * @param {(InterpolateLinear|InterpolateDiscrete|InterpolateSmooth)} [interpolation] - The interpolation type.
       */
--    constructor(name: string, times: Array<number>, values: Array<number>, interpolation?: InterpolationModes);
-+    constructor(name: string, times: ArrayLike<number>, values: ArrayLike<number>, interpolation?: InterpolationModes);
- }
-diff --git a/node_modules/@types/three/src/core/BufferGeometry.d.ts b/node_modules/@types/three/src/core/BufferGeometry.d.ts
-index 0f129f1..153a564 100644
---- a/node_modules/@types/three/src/core/BufferGeometry.d.ts
-+++ b/node_modules/@types/three/src/core/BufferGeometry.d.ts
-@@ -172,7 +172,7 @@ export class BufferGeometry<
-      * You will have to call {@link dispose | .dispose}(), and create a new instance of {@link THREE.BufferGeometry | BufferGeometry}.
-      * @defaultValue `{}`
-      */
--    morphAttributes: Record<"position" | "normal" | "color", Array<BufferAttribute | InterleavedBufferAttribute>>;
-+    morphAttributes: Partial<Record<"position" | "normal" | "color", Array<BufferAttribute | InterleavedBufferAttribute>>>;
- 
-     /**
-      * Used to control the morph target behavior; when set to true, the morph target data is treated as relative offsets, rather than as absolute positions/normals.
+     constructor(name: string, times: ArrayLike<number>, values: ArrayLike<number>, interpolation?: InterpolationModes);
 diff --git a/node_modules/@types/three/src/nodes/core/LightingModel.d.ts b/node_modules/@types/three/src/nodes/core/LightingModel.d.ts
 index cb894c0..fbbc46f 100644
 --- a/node_modules/@types/three/src/nodes/core/LightingModel.d.ts

--- a/yarn.lock
+++ b/yarn.lock
@@ -408,7 +408,7 @@
   dependencies:
     "@jridgewell/trace-mapping" "0.3.9"
 
-"@dimforge/rapier3d-compat@^0.12.0":
+"@dimforge/rapier3d-compat@~0.12.0":
   version "0.12.0"
   resolved "https://registry.yarnpkg.com/@dimforge/rapier3d-compat/-/rapier3d-compat-0.12.0.tgz#7b3365e1dfdc5cd957b45afe920b4ac06c7cd389"
   integrity sha512-uekIGetywIgopfD97oDL5PfeezkFpNhwlzlaEYNOA0N6ghdsOvh/HYjSMek5Q2O1PYvRSDFcqFVJl4r4ZBwOow==
@@ -1665,12 +1665,12 @@
   resolved "https://registry.yarnpkg.com/@types/stats.js/-/stats.js-0.17.0.tgz#0ed81d48e03b590c24da85540c1d952077a9fe20"
   integrity sha512-9w+a7bR8PeB0dCT/HBULU2fMqf6BAzvKbxFboYhmDtDkKPiyXYbjoe2auwsXlEFI7CFNMF1dCv3dFH5Poy9R1w==
 
-"@types/three@^0.176.0":
-  version "0.176.0"
-  resolved "https://registry.yarnpkg.com/@types/three/-/three-0.176.0.tgz#b6eced2b05e839395a6171e066c4631bc5b0a1e0"
-  integrity sha512-FwfPXxCqOtP7EdYMagCFePNKoG1AGBDUEVKtluv2BTVRpSt7b+X27xNsirPCTCqY1pGYsPUzaM3jgWP7dXSxlw==
+"@types/three@^0.177.0":
+  version "0.177.0"
+  resolved "https://registry.yarnpkg.com/@types/three/-/three-0.177.0.tgz#8427014f19d2eed20b9a13ee0a16eabb61b1904b"
+  integrity sha512-/ZAkn4OLUijKQySNci47lFO+4JLE1TihEjsGWPUT+4jWqxtwOPPEwJV1C3k5MEx0mcBPCdkFjzRzDOnHEI1R+A==
   dependencies:
-    "@dimforge/rapier3d-compat" "^0.12.0"
+    "@dimforge/rapier3d-compat" "~0.12.0"
     "@tweenjs/tween.js" "~23.1.3"
     "@types/stats.js" "*"
     "@types/webxr" "*"
@@ -6582,10 +6582,10 @@ text-extensions@^1.0.0:
   resolved "https://registry.yarnpkg.com/text-extensions/-/text-extensions-1.9.0.tgz#1853e45fee39c945ce6f6c36b2d659b5aabc2a26"
   integrity sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==
 
-three@^0.176.0:
-  version "0.176.0"
-  resolved "https://registry.yarnpkg.com/three/-/three-0.176.0.tgz#a30c1974e46db5745e4f96dd9ee2028d71e16ecf"
-  integrity sha512-PWRKYWQo23ojf9oZSlRGH8K09q7nRSWx6LY/HF/UUrMdYgN9i1e2OwJYHoQjwc6HF/4lvvYLC5YC1X8UJL2ZpA==
+three@^0.177.0:
+  version "0.177.0"
+  resolved "https://registry.yarnpkg.com/three/-/three-0.177.0.tgz#e51f2eb2b921fbab535bdfa81c403f9993b9dd83"
+  integrity sha512-EiXv5/qWAaGI+Vz2A+JfavwYCMdGjxVsrn3oBwllUoqYeaBO75J63ZfyaQKoiLrqNHoTlUc6PFgMXnS0kI45zg==
 
 through2@^2.0.0:
   version "2.0.5"


### PR DESCRIPTION
This bumps Three.js to r177.

See:
- https://github.com/mrdoob/three.js/releases/tag/r177
- https://github.com/mrdoob/three.js/wiki/Migration-Guide#r176--r177