### PR TITLE
Bump three r180

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,8 @@ You can import all the dependencies via CDN like [jsDelivr](https://www.jsdelivr
 <script type="importmap">
   {
     "imports": {
-      "three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
-      "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
+      "three": "https://cdn.jsdelivr.net/npm/three@0.180.0/build/three.module.js",
+      "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/",
       "@pixiv/three-vrm": "https://cdn.jsdelivr.net/npm/@pixiv/three-vrm@3/lib/three-vrm.module.min.js"
     }
   }

--- a/packages/three-vrm-animation/examples/dnd.html
+++ b/packages/three-vrm-animation/examples/dnd.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.180.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/",
 					"@pixiv/three-vrm": "https://cdn.jsdelivr.net/npm/@pixiv/three-vrm@3/lib/three-vrm.module.js",
 					"@pixiv/three-vrm-animation": "../lib/three-vrm-animation.module.js"
 				}

--- a/packages/three-vrm-animation/examples/loader-plugin.html
+++ b/packages/three-vrm-animation/examples/loader-plugin.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.180.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/",
 					"@pixiv/three-vrm": "https://cdn.jsdelivr.net/npm/@pixiv/three-vrm@3/lib/three-vrm.module.js",
 					"@pixiv/three-vrm-animation": "../lib/three-vrm-animation.module.js"
 				}

--- a/packages/three-vrm-animation/package.json
+++ b/packages/three-vrm-animation/package.json
@@ -51,9 +51,9 @@
     "@pixiv/types-vrmc-vrm-animation-1.0": "3.4.3"
   },
   "devDependencies": {
-    "@types/three": "^0.177.0",
+    "@types/three": "^0.180.0",
     "lint-staged": "16.1.2",
-    "three": "^0.177.0"
+    "three": "^0.180.0"
   },
   "peerDependencies": {
     "three": ">=0.137"

--- a/packages/three-vrm-core/examples/expressions.html
+++ b/packages/three-vrm-core/examples/expressions.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.180.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/",
 					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/examples/firstPerson.html
+++ b/packages/three-vrm-core/examples/firstPerson.html
@@ -28,8 +28,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.180.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/",
 					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/examples/humanoid.html
+++ b/packages/three-vrm-core/examples/humanoid.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.180.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/",
 					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/examples/humanoidAnimation/index.html
+++ b/packages/three-vrm-core/examples/humanoidAnimation/index.html
@@ -34,8 +34,8 @@
 			{
 				"imports": {
 					"fflate": "https://cdn.jsdelivr.net/npm/fflate@0.7.4/esm/browser.js",
-					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.180.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/",
 					"@pixiv/three-vrm-core": "../../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/examples/lookAt.html
+++ b/packages/three-vrm-core/examples/lookAt.html
@@ -28,8 +28,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.180.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/",
 					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/examples/meta.html
+++ b/packages/three-vrm-core/examples/meta.html
@@ -35,8 +35,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.180.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/",
 					"@pixiv/three-vrm-core": "../lib/three-vrm-core.module.js"
 				}
 			}

--- a/packages/three-vrm-core/package.json
+++ b/packages/three-vrm-core/package.json
@@ -54,8 +54,8 @@
     "@pixiv/types-vrmc-vrm-1.0": "3.4.3"
   },
   "devDependencies": {
-    "@types/three": "^0.177.0",
-    "three": "^0.177.0"
+    "@types/three": "^0.180.0",
+    "three": "^0.180.0"
   },
   "peerDependencies": {
     "three": ">=0.137"

--- a/packages/three-vrm-materials-hdr-emissive-multiplier/examples/loader-plugin.html
+++ b/packages/three-vrm-materials-hdr-emissive-multiplier/examples/loader-plugin.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.180.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/",
 					"@pixiv/three-vrm-materials-hdr-emissive-multiplier": "../lib/three-vrm-materials-hdr-emissive-multiplier.module.js"
 				}
 			}

--- a/packages/three-vrm-materials-hdr-emissive-multiplier/package.json
+++ b/packages/three-vrm-materials-hdr-emissive-multiplier/package.json
@@ -52,8 +52,8 @@
     "@pixiv/types-vrmc-materials-hdr-emissive-multiplier-1.0": "3.4.3"
   },
   "devDependencies": {
-    "@types/three": "^0.177.0",
-    "three": "^0.177.0"
+    "@types/three": "^0.180.0",
+    "three": "^0.180.0"
   },
   "peerDependencies": {
     "three": ">=0.137"

--- a/packages/three-vrm-materials-mtoon/examples/emissive-strength.html
+++ b/packages/three-vrm-materials-mtoon/examples/emissive-strength.html
@@ -24,8 +24,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.180.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/",
 					"@pixiv/three-vrm-materials-mtoon": "../lib/three-vrm-materials-mtoon.module.js"
 				}
 			}

--- a/packages/three-vrm-materials-mtoon/examples/feature-test.html
+++ b/packages/three-vrm-materials-mtoon/examples/feature-test.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.180.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/",
 					"@pixiv/three-vrm-materials-mtoon": "../lib/three-vrm-materials-mtoon.module.js"
 				}
 			}

--- a/packages/three-vrm-materials-mtoon/examples/loader-plugin.html
+++ b/packages/three-vrm-materials-mtoon/examples/loader-plugin.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.180.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/",
 					"@pixiv/three-vrm-materials-mtoon": "../lib/three-vrm-materials-mtoon.module.js"
 				}
 			}

--- a/packages/three-vrm-materials-mtoon/examples/webgpu-feature-test.html
+++ b/packages/three-vrm-materials-mtoon/examples/webgpu-feature-test.html
@@ -23,10 +23,10 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.webgpu.js",
-					"three/webgpu": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.webgpu.js",
-					"three/tsl": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.tsl.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.180.0/build/three.webgpu.js",
+					"three/webgpu": "https://cdn.jsdelivr.net/npm/three@0.180.0/build/three.webgpu.js",
+					"three/tsl": "https://cdn.jsdelivr.net/npm/three@0.180.0/build/three.tsl.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/",
 					"@pixiv/three-vrm-materials-mtoon": "../lib/three-vrm-materials-mtoon.module.js",
 					"@pixiv/three-vrm-materials-mtoon/nodes": "../lib/nodes/index.module.js"
 				}

--- a/packages/three-vrm-materials-mtoon/examples/webgpu-loader-plugin.html
+++ b/packages/three-vrm-materials-mtoon/examples/webgpu-loader-plugin.html
@@ -23,10 +23,10 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.webgpu.js",
-					"three/webgpu": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.webgpu.js",
-					"three/tsl": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.tsl.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.180.0/build/three.webgpu.js",
+					"three/webgpu": "https://cdn.jsdelivr.net/npm/three@0.180.0/build/three.webgpu.js",
+					"three/tsl": "https://cdn.jsdelivr.net/npm/three@0.180.0/build/three.tsl.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/",
 					"@pixiv/three-vrm-materials-mtoon": "../lib/three-vrm-materials-mtoon.module.js",
 					"@pixiv/three-vrm-materials-mtoon/nodes": "../lib/nodes/index.module.js"
 				}

--- a/packages/three-vrm-materials-mtoon/package.json
+++ b/packages/three-vrm-materials-mtoon/package.json
@@ -58,8 +58,8 @@
     "@pixiv/types-vrmc-materials-mtoon-1.0": "3.4.3"
   },
   "devDependencies": {
-    "@types/three": "^0.177.0",
-    "three": "^0.177.0"
+    "@types/three": "^0.180.0",
+    "three": "^0.180.0"
   },
   "peerDependencies": {
     "three": ">=0.137"

--- a/packages/three-vrm-materials-mtoon/src/GLTFMToonMaterialParamsAssignHelper.ts
+++ b/packages/three-vrm-materials-mtoon/src/GLTFMToonMaterialParamsAssignHelper.ts
@@ -35,11 +35,12 @@ export class GLTFMToonMaterialParamsAssignHelper {
     convertSRGBToLinear?: boolean,
   ): void {
     if (value != null) {
-      this._materialParams[key] = new THREE.Color().fromArray(value);
+      const color = new THREE.Color().fromArray(value);
 
       if (convertSRGBToLinear) {
-        this._materialParams[key].convertSRGBToLinear();
+        color.convertSRGBToLinear();
       }
+      (this._materialParams as any)[key] = color;
     }
   }
 
@@ -53,7 +54,7 @@ export class GLTFMToonMaterialParamsAssignHelper {
         await this._parser.assignTexture(this._materialParams, key, texture);
 
         if (isColorTexture) {
-          setTextureColorSpace(this._materialParams[key], 'srgb');
+          setTextureColorSpace(this._materialParams[key] as THREE.Texture, 'srgb');
         }
       }
     })();

--- a/packages/three-vrm-materials-mtoon/src/nodes/MToonAnimatedUVNode.ts
+++ b/packages/three-vrm-materials-mtoon/src/nodes/MToonAnimatedUVNode.ts
@@ -1,5 +1,5 @@
 import * as THREE from 'three/webgpu';
-import { cos, mat2, NodeRepresentation, ShaderNodeObject, sin, Swizzable, uv, vec2, vec4 } from 'three/tsl';
+import { cos, mat2, ShaderNodeObject, sin, Swizzable, uv, vec2, vec4 } from 'three/tsl';
 import {
   refUVAnimationMaskTexture,
   refUVAnimationRotationPhase,
@@ -17,7 +17,7 @@ export class MToonAnimatedUVNode extends THREE.TempNode {
   }
 
   public setup(): ShaderNodeObject<THREE.VarNode> {
-    let uvAnimationMask: NodeRepresentation = 1.0;
+    let uvAnimationMask: THREE.TSL.OperatorNodeParameter = 1.0;
 
     if (this.hasMaskTexture) {
       uvAnimationMask = vec4(refUVAnimationMaskTexture).context({ getUV: () => uv() }).r;

--- a/packages/three-vrm-materials-mtoon/src/nodes/MToonNodeMaterial.ts
+++ b/packages/three-vrm-materials-mtoon/src/nodes/MToonNodeMaterial.ts
@@ -387,7 +387,7 @@ export class MToonNodeMaterial extends THREE.NodeMaterial {
         // See about the type assertion: https://github.com/three-types/three-ts-types/pull/1123
         this.positionNode = (this.positionNode as ShaderNodeObject<THREE.Node>).add(outlineOffset);
       } else if (this.outlineWidthMode === MToonMaterialOutlineWidthMode.ScreenCoordinates) {
-        const clipScale = cameraProjectionMatrix.element(uniform(1)).element(uniform(1));
+        const clipScale = cameraProjectionMatrix.element(1).element(1);
 
         // We can't use `positionView` in `setupPosition`
         // because using `positionView` here will make it calculate the `positionView` earlier

--- a/packages/three-vrm-materials-mtoon/src/nodes/MToonNodeMaterial.ts
+++ b/packages/three-vrm-materials-mtoon/src/nodes/MToonNodeMaterial.ts
@@ -15,6 +15,7 @@ import {
   positionView,
   ShaderNodeObject,
   Swizzable,
+  uniform,
   vec3,
   vec4,
 } from 'three/tsl';
@@ -271,7 +272,9 @@ export class MToonNodeMaterial extends THREE.NodeMaterial {
     parametricRim.assign(this._setupParametricRimNode());
   }
 
-  public setupNormal(builder: THREE.NodeBuilder): ShaderNodeObject<THREE.Node> {
+  public setupNormal(): ShaderNodeObject<THREE.Node>;
+  public setupNormal(builder?: THREE.NodeBuilder): ShaderNodeObject<THREE.Node>;
+  public setupNormal(builder?: THREE.NodeBuilder): ShaderNodeObject<THREE.Node> {
     // we must apply uv scroll to the normalMap
     // this.normalNode will be used in super.setupNormal() so we temporarily replace it
     const tempNormalNode = this.normalNode;
@@ -304,6 +307,8 @@ export class MToonNodeMaterial extends THREE.NodeMaterial {
     } else {
       // pre-r168
       // the ordinary normal setup
+
+      // @ts-expect-error type workaround for pre-r168
       super.setupNormal(builder);
 
       // revert the normalNode
@@ -382,7 +387,7 @@ export class MToonNodeMaterial extends THREE.NodeMaterial {
         // See about the type assertion: https://github.com/three-types/three-ts-types/pull/1123
         this.positionNode = (this.positionNode as ShaderNodeObject<THREE.Node>).add(outlineOffset);
       } else if (this.outlineWidthMode === MToonMaterialOutlineWidthMode.ScreenCoordinates) {
-        const clipScale = cameraProjectionMatrix.element(1).element(1);
+        const clipScale = cameraProjectionMatrix.element(uniform(1)).element(uniform(1));
 
         // We can't use `positionView` in `setupPosition`
         // because using `positionView` here will make it calculate the `positionView` earlier

--- a/packages/three-vrm-materials-mtoon/src/nodes/mtoonParametricRim.ts
+++ b/packages/three-vrm-materials-mtoon/src/nodes/mtoonParametricRim.ts
@@ -1,5 +1,5 @@
 import * as THREE from 'three/webgpu';
-import { float, modelViewPosition, NodeRepresentation, transformedNormalView } from 'three/tsl';
+import { float, modelViewPosition, transformedNormalView } from 'three/tsl';
 import { FnCompat } from './utils/FnCompat';
 
 export const mtoonParametricRim = FnCompat(
@@ -8,9 +8,9 @@ export const mtoonParametricRim = FnCompat(
     parametricRimFresnelPower,
     parametricRimColor,
   }: {
-    parametricRimLift: NodeRepresentation;
-    parametricRimFresnelPower: NodeRepresentation;
-    parametricRimColor: NodeRepresentation;
+    parametricRimLift: THREE.TSL.OperatorNodeParameter;
+    parametricRimFresnelPower: THREE.TSL.OperatorNodeParameter;
+    parametricRimColor: THREE.TSL.OperatorNodeParameter;
   }) => {
     const viewDir = modelViewPosition.normalize();
     const dotNV = transformedNormalView.dot(viewDir.negate());

--- a/packages/three-vrm-materials-v0compat/package.json
+++ b/packages/three-vrm-materials-v0compat/package.json
@@ -49,8 +49,8 @@
     "@pixiv/types-vrmc-materials-mtoon-1.0": "3.4.3"
   },
   "devDependencies": {
-    "@types/three": "^0.177.0",
-    "three": "^0.177.0"
+    "@types/three": "^0.180.0",
+    "three": "^0.180.0"
   },
   "peerDependencies": {
     "three": ">=0.137"

--- a/packages/three-vrm-node-constraint/examples/aim.html
+++ b/packages/three-vrm-node-constraint/examples/aim.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.180.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/",
 					"tweakpane": "https://cdn.jsdelivr.net/npm/tweakpane@3.0",
 					"tweakpane-plugin-rotation": "https://cdn.jsdelivr.net/npm/@0b5vr/tweakpane-plugin-rotation@0.1",
 					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"

--- a/packages/three-vrm-node-constraint/examples/importer.html
+++ b/packages/three-vrm-node-constraint/examples/importer.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.180.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/",
 					"tweakpane": "https://cdn.jsdelivr.net/npm/tweakpane@3.0",
 					"tweakpane-plugin-rotation": "https://cdn.jsdelivr.net/npm/@0b5vr/tweakpane-plugin-rotation@0.1",
 					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"

--- a/packages/three-vrm-node-constraint/examples/roll.html
+++ b/packages/three-vrm-node-constraint/examples/roll.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.180.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/",
 					"tweakpane": "https://cdn.jsdelivr.net/npm/tweakpane@3.0",
 					"tweakpane-plugin-rotation": "https://cdn.jsdelivr.net/npm/@0b5vr/tweakpane-plugin-rotation@0.1",
 					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"

--- a/packages/three-vrm-node-constraint/examples/rotation.html
+++ b/packages/three-vrm-node-constraint/examples/rotation.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.180.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/",
 					"tweakpane": "https://cdn.jsdelivr.net/npm/tweakpane@3.0",
 					"tweakpane-plugin-rotation": "https://cdn.jsdelivr.net/npm/@0b5vr/tweakpane-plugin-rotation@0.1",
 					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"

--- a/packages/three-vrm-node-constraint/examples/upper-arm.html
+++ b/packages/three-vrm-node-constraint/examples/upper-arm.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.180.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/",
 					"tweakpane": "https://cdn.jsdelivr.net/npm/tweakpane@3.0",
 					"tweakpane-plugin-rotation": "https://cdn.jsdelivr.net/npm/@0b5vr/tweakpane-plugin-rotation@0.1",
 					"@pixiv/three-vrm-node-constraint": "../lib/three-vrm-node-constraint.module.js"

--- a/packages/three-vrm-node-constraint/package.json
+++ b/packages/three-vrm-node-constraint/package.json
@@ -53,8 +53,8 @@
     "@pixiv/types-vrmc-node-constraint-1.0": "3.4.3"
   },
   "devDependencies": {
-    "@types/three": "^0.177.0",
-    "three": "^0.177.0"
+    "@types/three": "^0.180.0",
+    "three": "^0.180.0"
   },
   "peerDependencies": {
     "three": ">=0.137"

--- a/packages/three-vrm-springbone/examples/collider.html
+++ b/packages/three-vrm-springbone/examples/collider.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-				"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
-				"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
+				"three": "https://cdn.jsdelivr.net/npm/three@0.180.0/build/three.module.js",
+				"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/",
 				"@pixiv/three-vrm-springbone": "../lib/three-vrm-springbone.module.js"
 			  }
 			}

--- a/packages/three-vrm-springbone/examples/loader-plugin.html
+++ b/packages/three-vrm-springbone/examples/loader-plugin.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-				"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
-				"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
+				"three": "https://cdn.jsdelivr.net/npm/three@0.180.0/build/three.module.js",
+				"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/",
 				"@pixiv/three-vrm-springbone": "../lib/three-vrm-springbone.module.js"
 			  }
 			}

--- a/packages/three-vrm-springbone/examples/multiple.html
+++ b/packages/three-vrm-springbone/examples/multiple.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-				"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
-				"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
+				"three": "https://cdn.jsdelivr.net/npm/three@0.180.0/build/three.module.js",
+				"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/",
 				"@pixiv/three-vrm-springbone": "../lib/three-vrm-springbone.module.js"
 			  }
 			}

--- a/packages/three-vrm-springbone/examples/single.html
+++ b/packages/three-vrm-springbone/examples/single.html
@@ -23,8 +23,8 @@
 		<script type="importmap">
 			{
 			  "imports": {
-				"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
-				"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
+				"three": "https://cdn.jsdelivr.net/npm/three@0.180.0/build/three.module.js",
+				"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/",
 				"@pixiv/three-vrm-springbone": "../lib/three-vrm-springbone.module.js"
 			  }
 			}

--- a/packages/three-vrm-springbone/package.json
+++ b/packages/three-vrm-springbone/package.json
@@ -55,8 +55,8 @@
     "@pixiv/types-vrmc-springbone-extended-collider-1.0": "3.4.3"
   },
   "devDependencies": {
-    "@types/three": "^0.177.0",
-    "three": "^0.177.0"
+    "@types/three": "^0.180.0",
+    "three": "^0.180.0"
   },
   "peerDependencies": {
     "three": ">=0.137"

--- a/packages/three-vrm/README.md
+++ b/packages/three-vrm/README.md
@@ -32,8 +32,8 @@ You can import all the dependencies via CDN like [jsDelivr](https://www.jsdelivr
 <script type="importmap">
   {
     "imports": {
-      "three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
-      "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
+      "three": "https://cdn.jsdelivr.net/npm/three@0.180.0/build/three.module.js",
+      "three/addons/": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/",
       "@pixiv/three-vrm": "https://cdn.jsdelivr.net/npm/@pixiv/three-vrm@3/lib/three-vrm.module.min.js"
     }
   }

--- a/packages/three-vrm/examples/animations.html
+++ b/packages/three-vrm/examples/animations.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.180.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/basic.html
+++ b/packages/three-vrm/examples/basic.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.180.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/bones.html
+++ b/packages/three-vrm/examples/bones.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.180.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/debug.html
+++ b/packages/three-vrm/examples/debug.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.180.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/dnd.html
+++ b/packages/three-vrm/examples/dnd.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.180.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/expressions.html
+++ b/packages/three-vrm/examples/expressions.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.180.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/firstperson.html
+++ b/packages/three-vrm/examples/firstperson.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.180.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/humanoidAnimation/index.html
+++ b/packages/three-vrm/examples/humanoidAnimation/index.html
@@ -34,8 +34,8 @@
 			{
 				"imports": {
 					"fflate": "https://cdn.jsdelivr.net/npm/fflate@0.7.4/esm/browser.js",
-					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.180.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/",
 					"@pixiv/three-vrm": "../../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/lookat-advanced.html
+++ b/packages/three-vrm/examples/lookat-advanced.html
@@ -24,8 +24,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.180.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/lookat.html
+++ b/packages/three-vrm/examples/lookat.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.180.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/materials-debug.html
+++ b/packages/three-vrm/examples/materials-debug.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.180.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/meta.html
+++ b/packages/three-vrm/examples/meta.html
@@ -34,8 +34,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.180.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/mouse.html
+++ b/packages/three-vrm/examples/mouse.html
@@ -22,8 +22,8 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.module.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.180.0/build/three.module.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js"
 				}
 			}

--- a/packages/three-vrm/examples/webgpu-dnd.html
+++ b/packages/three-vrm/examples/webgpu-dnd.html
@@ -23,10 +23,10 @@
 		<script type="importmap">
 			{
 				"imports": {
-					"three": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.webgpu.js",
-					"three/webgpu": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.webgpu.js",
-					"three/tsl": "https://cdn.jsdelivr.net/npm/three@0.177.0/build/three.tsl.js",
-					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.177.0/examples/jsm/",
+					"three": "https://cdn.jsdelivr.net/npm/three@0.180.0/build/three.webgpu.js",
+					"three/webgpu": "https://cdn.jsdelivr.net/npm/three@0.180.0/build/three.webgpu.js",
+					"three/tsl": "https://cdn.jsdelivr.net/npm/three@0.180.0/build/three.tsl.js",
+					"three/addons/": "https://cdn.jsdelivr.net/npm/three@0.180.0/examples/jsm/",
 					"@pixiv/three-vrm": "../lib/three-vrm.module.js",
 					"@pixiv/three-vrm/nodes": "../lib/nodes/index.module.js"
 				}

--- a/packages/three-vrm/package.json
+++ b/packages/three-vrm/package.json
@@ -63,8 +63,8 @@
     "@pixiv/three-vrm-springbone": "3.4.3"
   },
   "devDependencies": {
-    "@types/three": "^0.177.0",
-    "three": "^0.177.0"
+    "@types/three": "^0.180.0",
+    "three": "^0.180.0"
   },
   "peerDependencies": {
     "three": ">=0.137"

--- a/patches/@types+three+0.180.0.patch
+++ b/patches/@types+three+0.180.0.patch
@@ -39,3 +39,15 @@ index eb477e3..0be5b27 100644
      /**
       * @TODO used to be missing. check the actual type later
       */
+diff --git a/node_modules/@types/three/src/nodes/tsl/TSLCore.d.ts b/node_modules/@types/three/src/nodes/tsl/TSLCore.d.ts
+index 0e3c220..ceabbbb 100644
+--- a/node_modules/@types/three/src/nodes/tsl/TSLCore.d.ts
++++ b/node_modules/@types/three/src/nodes/tsl/TSLCore.d.ts
+@@ -391,6 +391,7 @@ export const bvec4: (node: Node) => ShaderNodeObject<Node>;
+ interface Matrix2Function {
+     (value: Matrix2): ShaderNodeObject<ConstNode<Matrix2>>;
+     (node: Node): ShaderNodeObject<Node>;
++    (n11: Node | number, n12: Node | number, n21?: Node | number, n22?: Node | number): ShaderNodeObject<ConstNode<Matrix2>>;
+ }
+ 
+ export const mat2: Matrix2Function;

--- a/patches/@types+three+0.180.0.patch
+++ b/patches/@types+three+0.180.0.patch
@@ -51,3 +51,13 @@ index 0e3c220..ceabbbb 100644
  }
  
  export const mat2: Matrix2Function;
+diff --git a/node_modules/@types/three/src/textures/ExternalTexture.d.ts b/node_modules/@types/three/src/textures/ExternalTexture.d.ts
+index 8f62cac..0e0d807 100644
+--- a/node_modules/@types/three/src/textures/ExternalTexture.d.ts
++++ b/node_modules/@types/three/src/textures/ExternalTexture.d.ts
+@@ -1,3 +1,5 @@
++/// <reference types="@webgpu/types" />
++
+ import { Texture } from "./Texture.js";
+ 
+ declare class ExternalTexture extends Texture {

--- a/patches/@types+three+0.180.0.patch
+++ b/patches/@types+three+0.180.0.patch
@@ -40,7 +40,7 @@ index eb477e3..0be5b27 100644
       * @TODO used to be missing. check the actual type later
       */
 diff --git a/node_modules/@types/three/src/nodes/tsl/TSLCore.d.ts b/node_modules/@types/three/src/nodes/tsl/TSLCore.d.ts
-index 0e3c220..ceabbbb 100644
+index 0e3c220..30f3901 100644
 --- a/node_modules/@types/three/src/nodes/tsl/TSLCore.d.ts
 +++ b/node_modules/@types/three/src/nodes/tsl/TSLCore.d.ts
 @@ -391,6 +391,7 @@ export const bvec4: (node: Node) => ShaderNodeObject<Node>;
@@ -51,6 +51,15 @@ index 0e3c220..ceabbbb 100644
  }
  
  export const mat2: Matrix2Function;
+@@ -443,7 +444,7 @@ export const mat4: Matrix4Function;
+ export const string: (value?: string) => ShaderNodeObject<ConstNode<string>>;
+ export const arrayBuffer: (value: ArrayBuffer) => ShaderNodeObject<ConstNode<ArrayBuffer>>;
+ 
+-export const element: (node: Node, indexNode: Node) => ShaderNodeObject<Node>;
++export const element: (node: Node | number, indexNode: Node | number) => ShaderNodeObject<Node>;
+ export const convert: (node: Node, types: string) => ShaderNodeObject<Node>;
+ export const split: (node: Node, channels?: string) => ShaderNodeObject<Node>;
+ 
 diff --git a/node_modules/@types/three/src/textures/ExternalTexture.d.ts b/node_modules/@types/three/src/textures/ExternalTexture.d.ts
 index 8f62cac..0e0d807 100644
 --- a/node_modules/@types/three/src/textures/ExternalTexture.d.ts

--- a/yarn.lock
+++ b/yarn.lock
@@ -2186,10 +2186,10 @@
   resolved "https://registry.yarnpkg.com/@types/stats.js/-/stats.js-0.17.0.tgz#0ed81d48e03b590c24da85540c1d952077a9fe20"
   integrity sha512-9w+a7bR8PeB0dCT/HBULU2fMqf6BAzvKbxFboYhmDtDkKPiyXYbjoe2auwsXlEFI7CFNMF1dCv3dFH5Poy9R1w==
 
-"@types/three@^0.177.0":
-  version "0.177.0"
-  resolved "https://registry.yarnpkg.com/@types/three/-/three-0.177.0.tgz#8427014f19d2eed20b9a13ee0a16eabb61b1904b"
-  integrity sha512-/ZAkn4OLUijKQySNci47lFO+4JLE1TihEjsGWPUT+4jWqxtwOPPEwJV1C3k5MEx0mcBPCdkFjzRzDOnHEI1R+A==
+"@types/three@^0.180.0":
+  version "0.180.0"
+  resolved "https://registry.yarnpkg.com/@types/three/-/three-0.180.0.tgz#c9525a744e55c43f720185710c5dc33e6ff67b53"
+  integrity sha512-ykFtgCqNnY0IPvDro7h+9ZeLY+qjgUWv+qEvUt84grhenO60Hqd4hScHE7VTB9nOQ/3QM8lkbNE+4vKjEpUxKg==
   dependencies:
     "@dimforge/rapier3d-compat" "~0.12.0"
     "@tweenjs/tween.js" "~23.1.3"
@@ -2197,7 +2197,7 @@
     "@types/webxr" "*"
     "@webgpu/types" "*"
     fflate "~0.8.2"
-    meshoptimizer "~0.18.1"
+    meshoptimizer "~0.22.0"
 
 "@types/unist@*":
   version "3.0.3"
@@ -5654,10 +5654,10 @@ merge2@^1.3.0:
   resolved "https://registry.yarnpkg.com/merge2/-/merge2-1.4.1.tgz#4368892f885e907455a6fd7dc55c0c9d404990ae"
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
-meshoptimizer@~0.18.1:
-  version "0.18.1"
-  resolved "https://registry.yarnpkg.com/meshoptimizer/-/meshoptimizer-0.18.1.tgz#cdb90907f30a7b5b1190facd3b7ee6b7087797d8"
-  integrity sha512-ZhoIoL7TNV4s5B6+rx5mC//fw8/POGyNxS/DZyCJeiZ12ScLfVwRE/GfsxwiTkMYYD5DmK2/JXnEVXqL4rF+Sw==
+meshoptimizer@~0.22.0:
+  version "0.22.0"
+  resolved "https://registry.yarnpkg.com/meshoptimizer/-/meshoptimizer-0.22.0.tgz#1ec36b075543e7d661f5ebc21339ae3dab4bc18c"
+  integrity sha512-IebiK79sqIy+E4EgOr+CAw+Ke8hAspXKzBd0JdgEmPHiAwmvEj2S4h1rfvo+o/BnfEYd/jAOg5IeeIjzlzSnDg==
 
 micromatch@^4.0.2, micromatch@^4.0.4, micromatch@^4.0.8:
   version "4.0.8"
@@ -7274,10 +7274,10 @@ text-extensions@^1.0.0:
   resolved "https://registry.yarnpkg.com/text-extensions/-/text-extensions-1.9.0.tgz#1853e45fee39c945ce6f6c36b2d659b5aabc2a26"
   integrity sha512-wiBrwC1EhBelW12Zy26JeOUkQ5mRu+5o8rpsJk5+2t+Y5vE7e842qtZDQ2g1NpX/29HdyFeJ4nSIhI47ENSxlQ==
 
-three@^0.177.0:
-  version "0.177.0"
-  resolved "https://registry.yarnpkg.com/three/-/three-0.177.0.tgz#e51f2eb2b921fbab535bdfa81c403f9993b9dd83"
-  integrity sha512-EiXv5/qWAaGI+Vz2A+JfavwYCMdGjxVsrn3oBwllUoqYeaBO75J63ZfyaQKoiLrqNHoTlUc6PFgMXnS0kI45zg==
+three@^0.180.0:
+  version "0.180.0"
+  resolved "https://registry.yarnpkg.com/three/-/three-0.180.0.tgz#b930cabfb524f6d36bf63e874b4d866888b50487"
+  integrity sha512-o+qycAMZrh+TsE01GqWUxUIKR1AL0S8pq7zDkYOQw8GqfX8b8VoCKYUoHbhiX5j+7hr8XsuHDVU6+gkQJQKg9w==
 
 through2@^2.0.0:
   version "2.0.5"


### PR DESCRIPTION
This bumps Three.js to r180.

See:
- https://github.com/mrdoob/three.js/releases
- https://github.com/mrdoob/three.js/wiki/Migration-Guide#179--180