### PR TITLE
fix: three-vrm-core, humanoid, Handle negative node indices (-1) in VRM0.0 humanoid bones

### DIFF
--- a/packages/three-vrm-core/src/humanoid/VRMHumanoidLoaderPlugin.ts
+++ b/packages/three-vrm-core/src/humanoid/VRMHumanoidLoaderPlugin.ts
@@ -175,6 +175,15 @@ export class VRMHumanoidLoaderPlugin implements GLTFLoaderPlugin {
             return;
           }
 
+          // VRM0.0 can contain -1 as a node index, which is invalid
+          // Found at least in UniVRM-0.61.1
+          if (index < 0) {
+            console.warn(
+              `A glTF node index for the humanoid bone ${boneName} is negative (${index}), ignoring this bone.`,
+            );
+            return;
+          }
+
           const node = await this.parser.getDependency('node', index);
 
           // if the specified node does not exist, emit a warning


### PR DESCRIPTION
VRM0.0 can contain -1 as a node index, which is invalid. Found at least in UniVRM-0.61.1.