### PR TITLE
fix: warn when VRM0 morph bind target mesh is not found

### DIFF
--- a/packages/three-vrm-core/src/expressions/VRMExpressionLoaderPlugin.ts
+++ b/packages/three-vrm-core/src/expressions/VRMExpressionLoaderPlugin.ts
@@ -301,6 +301,13 @@ export class VRMExpressionLoaderPlugin implements GLTFLoaderPlugin {
               }
             });
 
+            if (nodesUsingMesh.length === 0) {
+              console.warn(
+                `VRMExpressionLoaderPlugin: ${schemaGroup.name} attempts to bind a morph target to the mesh #${bind.mesh} but the mesh is not found.`,
+              );
+              return;
+            }
+
             const morphTargetIndex = bind.index;
 
             await Promise.all(

--- a/packages/three-vrm-core/src/expressions/VRMExpressionLoaderPlugin.ts
+++ b/packages/three-vrm-core/src/expressions/VRMExpressionLoaderPlugin.ts
@@ -303,7 +303,7 @@ export class VRMExpressionLoaderPlugin implements GLTFLoaderPlugin {
 
             if (nodesUsingMesh.length === 0) {
               console.warn(
-                `VRMExpressionLoaderPlugin: ${schemaGroup.name} attempts to bind a morph target to the mesh #${bind.mesh} but the mesh is not found.`,
+                `VRMExpressionLoaderPlugin: ${schemaGroup.name} attempts to bind a morph target to the mesh #${bind.mesh} but the mesh is not found or not used in the scene. Ignoring the bind.`,
               );
               return;
             }


### PR DESCRIPTION
Fixes #1326.

In VRMExpressionLoaderPlugin._v0Import, when a VRM0 blendShape morph target bind specifies a mesh that no node in the glTF references, the bind was silently ignored. This made it impossible to diagnose malformed model data.

This PR adds a console.warn in that case, consistent with the existing warning emitted when a morph index is out of range.

Changes

packages/three-vrm-core/src/expressions/VRMExpressionLoaderPlugin.ts:

```ts
if (nodesUsingMesh.length === 0) {
  console.warn(
    `VRMExpressionLoaderPlugin: ${schemaGroup.name} attempts to bind a morph target to the mesh #${bind.mesh} but the mesh is not found.`,
  );
  return;
}
```

The warning message format is consistent with the existing morph-index-not-found warning in the same function.

Verification

- pnpm build (incl. build-types) — passes, no type errors
- pnpm test — 96 passed
- pnpm lint — 0 errors (pre-existing unused-import warnings unrelated to this change)