### PR TITLE
chore: pnpm-workspace.yaml, add allowBuilds config for esbuild and nx

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,6 +1,10 @@
 packages:
   - packages/*
 
+allowBuilds:
+  esbuild: true
+  nx: true
+
 minimumReleaseAge: 10080
 
 patchedDependencies:


### PR DESCRIPTION
pnpm 11 requires the allowBuilds config to be set for esbuild and nx