### PR TITLE
fix: VRMSpringBoneLoaderPlugin, skip springs without joints

### DIFF
--- a/packages/three-vrm-springbone/src/VRMSpringBoneJoint.ts
+++ b/packages/three-vrm-springbone/src/VRMSpringBoneJoint.ts
@@ -2,6 +2,7 @@ import * as THREE from 'three';
 import { Matrix4InverseCache } from './utils/Matrix4InverseCache';
 import type { VRMSpringBoneColliderGroup } from './VRMSpringBoneColliderGroup';
 import type { VRMSpringBoneJointSettings } from './VRMSpringBoneJointSettings';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import type { VRMSpringBoneManager } from './VRMSpringBoneManager';
 
 // based on

--- a/packages/three-vrm-springbone/src/VRMSpringBoneLoaderPlugin.ts
+++ b/packages/three-vrm-springbone/src/VRMSpringBoneLoaderPlugin.ts
@@ -103,8 +103,7 @@ export class VRMSpringBoneLoaderPlugin implements GLTFLoaderPlugin {
     const threeNodes: THREE.Object3D[] = await gltf.parser.getDependencies('node');
 
     const extension = json.extensions?.[VRMSpringBoneLoaderPlugin.EXTENSION_NAME] as
-      | V1SpringBoneSchema.VRMCSpringBone
-      | undefined;
+      V1SpringBoneSchema.VRMCSpringBone | undefined;
     if (!extension) {
       return null;
     }

--- a/packages/three-vrm-springbone/src/VRMSpringBoneLoaderPlugin.ts
+++ b/packages/three-vrm-springbone/src/VRMSpringBoneLoaderPlugin.ts
@@ -103,7 +103,8 @@ export class VRMSpringBoneLoaderPlugin implements GLTFLoaderPlugin {
     const threeNodes: THREE.Object3D[] = await gltf.parser.getDependencies('node');
 
     const extension = json.extensions?.[VRMSpringBoneLoaderPlugin.EXTENSION_NAME] as
-      V1SpringBoneSchema.VRMCSpringBone | undefined;
+      | V1SpringBoneSchema.VRMCSpringBone
+      | undefined;
     if (!extension) {
       return null;
     }
@@ -208,6 +209,10 @@ export class VRMSpringBoneLoaderPlugin implements GLTFLoaderPlugin {
 
     extension.springs?.forEach((schemaSpring, iSpring) => {
       const schemaJoints = schemaSpring.joints;
+      if (schemaJoints == null) {
+        console.warn(`VRMSpringBoneLoaderPlugin: The spring #${iSpring} has no joints. Skipping the spring`);
+        return;
+      }
 
       // prepare colliders
       const colliderGroupsForSpring = schemaSpring.colliderGroups


### PR DESCRIPTION
Some VRMC_springBone assets can contain a spring entry without `joints`. Such a spring is invalid but we should go permissive. Show a warning and skip that spring instead of bailing out the entire loader.

Related: 806d70d4